### PR TITLE
Integrate Hephaestus elementwise routing and group_norm API

### DIFF
--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -61,8 +61,8 @@ pub use loss::{
 };
 pub use module::Module;
 pub use normalization::{
-    BatchNorm1d, BatchNorm2d, BatchNorm3d, GroupNorm, InstanceNorm1d, InstanceNorm2d, LayerNorm,
-    RMSNorm,
+    group_norm, BatchNorm1d, BatchNorm2d, BatchNorm3d, GroupNorm, InstanceNorm1d, InstanceNorm2d,
+    LayerNorm, RMSNorm,
 };
 pub use parameter::Parameter;
 pub use pool::{

--- a/coeus-nn/src/normalization/groupnorm.rs
+++ b/coeus-nn/src/normalization/groupnorm.rs
@@ -9,7 +9,7 @@
 
 use crate::module::Module;
 use coeus_autograd::Var;
-use coeus_core::{Float, MoiraiBackend};
+use coeus_core::{CpuAddressableStorage, CpuAddressableStorageMut, Float, MoiraiBackend};
 use coeus_tensor::Tensor;
 use std::cell::RefCell;
 
@@ -201,4 +201,107 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const G: usize> Module<T, 
         let scaled = coeus_autograd::mul(&normed, &w_reshaped);
         coeus_autograd::add(&scaled, &b_reshaped)
     }
+}
+
+/// Functional (stateless) group normalization — tensor-level, no autograd tracking.
+///
+/// Equivalent to `torch.nn.functional.group_norm(input, num_groups, weight, bias, eps)`.
+///
+/// # Shape
+/// Input: `[N, C, *]` where `C % num_groups == 0`.
+/// Output: same shape as input.
+///
+/// # Panics
+/// Panics if:
+/// - `input` has fewer than two dimensions.
+/// - `num_groups == 0`.
+/// - `C % num_groups != 0`.
+/// - `weight` or `bias` is present and not shaped `[C]`.
+/// - `eps` is not finite or is negative.
+pub fn group_norm<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Tensor<T, B>,
+    num_groups: usize,
+    weight: Option<&Tensor<T, B>>,
+    bias: Option<&Tensor<T, B>>,
+    eps: f64,
+) -> Tensor<T, B>
+where
+    B::DeviceBuffer<T>: CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
+{
+    use coeus_ops::{add_assign, div_assign, mean_axis, mul, sqrt_assign, sub};
+    let backend = B::default();
+    let shape = input.shape_cloned();
+    assert!(
+        shape.len() >= 2,
+        "group_norm: input must have at least 2 dimensions"
+    );
+    assert!(num_groups > 0, "group_norm: num_groups must be greater than 0");
+    assert!(
+        eps.is_finite() && eps >= 0.0,
+        "group_norm: eps must be finite and non-negative"
+    );
+    let n = shape[0];
+    let c = shape[1];
+    assert_eq!(
+        c % num_groups,
+        0,
+        "group_norm: channels ({c}) not divisible by num_groups ({num_groups})"
+    );
+    if let Some(w) = weight {
+        assert_eq!(w.shape(), &[c], "group_norm: weight must have shape [C]");
+    }
+    if let Some(b) = bias {
+        assert_eq!(b.shape(), &[c], "group_norm: bias must have shape [C]");
+    }
+    let c_per_g = c / num_groups;
+    let spatial: usize = if shape.len() > 2 {
+        shape[2..].iter().product()
+    } else {
+        1
+    };
+    let group_size = c_per_g * spatial;
+
+    // Reshape to [N*G, group_size] for per-group normalization
+    let flat = input.reshape([n * num_groups, group_size]);
+
+    // Mean over last dim: [N*G, 1]
+    let mean = mean_axis(&flat, 1, &backend);
+
+    // Centre: x − μ  (broadcasts [N*G, 1] → [N*G, group_size])
+    let xmu = sub(&flat, &mean, &backend);
+
+    // Variance = mean(xmu²) over last dim: [N*G, 1]
+    let xmu_sq = mul(&xmu, &xmu, &backend);
+    let mut var = mean_axis(&xmu_sq, 1, &backend);
+
+    // stdev = sqrt(var + eps): reuse var buffer
+    let eps_t = Tensor::full_on([1], T::from_f64(eps), &backend);
+    add_assign(&mut var, &eps_t, &backend);
+    sqrt_assign(&mut var, &backend); // now holds stdev
+
+    // istdev = 1 / stdev
+    let ones = Tensor::ones_on([n * num_groups, 1], &backend);
+    let mut istdev = ones;
+    div_assign(&mut istdev, &var, &backend);
+
+    // x_hat = xmu * istdev (broadcasts [N*G, 1] → [N*G, group_size])
+    let x_hat = mul(&xmu, &istdev, &backend);
+
+    // Reshape back to original layout
+    let mut out = x_hat.reshape(shape.clone());
+
+    // Per-channel affine transform (both weight and bias are [C])
+    let mut broadcast_shape = vec![1usize; shape.len()];
+    broadcast_shape[1] = c;
+
+    if let Some(w) = weight {
+        let w_bc = w.reshape(broadcast_shape.clone());
+        out = mul(&out, &w_bc, &backend);
+    }
+    if let Some(b) = bias {
+        let b_bc = b.reshape(broadcast_shape.clone());
+        add_assign(&mut out, &b_bc, &backend);
+    }
+
+    out
 }

--- a/coeus-nn/src/normalization/mod.rs
+++ b/coeus-nn/src/normalization/mod.rs
@@ -9,7 +9,7 @@ pub mod rmsnorm;
 pub use batchnorm1d::BatchNorm1d;
 pub use batchnorm2d::BatchNorm2d;
 pub use batchnorm3d::BatchNorm3d;
-pub use groupnorm::GroupNorm;
+pub use groupnorm::{group_norm, GroupNorm};
 pub use instancenorm::{InstanceNorm1d, InstanceNorm2d};
 pub use layernorm::LayerNorm;
 pub use rmsnorm::RMSNorm;

--- a/coeus-wgpu/src/backend/ops/mod.rs
+++ b/coeus-wgpu/src/backend/ops/mod.rs
@@ -1,10 +1,139 @@
 use crate::backend::{WgpuBackend, WgpuScalar};
 use crate::kernels;
 use coeus_core::{Layout, Storage};
+use std::sync::Arc;
 
 mod attention;
 
-impl<T: WgpuScalar + leto_ops::Scalar> coeus_ops::BackendOps<T> for WgpuBackend {
+fn try_hephaestus_contiguous_binary<T: WgpuScalar + hephaestus_wgpu::WgslScalar>(
+    op: coeus_ops::BinaryOp,
+    a: &crate::storage::WgpuStorage<T>,
+    b: &crate::storage::WgpuStorage<T>,
+    c: &mut crate::storage::WgpuStorage<T>,
+) -> bool {
+    if Arc::ptr_eq(&a.buffer, &c.buffer) || Arc::ptr_eq(&b.buffer, &c.buffer) {
+        return false;
+    }
+    let ctx = crate::backend::get_wgpu_context();
+    let run = |result: hephaestus_wgpu::Result<hephaestus_wgpu::WgpuBuffer<T>>,
+               c: &mut crate::storage::WgpuStorage<T>| {
+        c.buffer = Arc::new(result.expect("hephaestus-wgpu contiguous binary dispatch failed"));
+        true
+    };
+    match op {
+        coeus_ops::BinaryOp::Add => run(
+            hephaestus_wgpu::binary_elementwise::<hephaestus_wgpu::AddOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::BinaryOp::Sub => run(
+            hephaestus_wgpu::binary_elementwise::<hephaestus_wgpu::SubOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::BinaryOp::Mul => run(
+            hephaestus_wgpu::binary_elementwise::<hephaestus_wgpu::MulOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::BinaryOp::Div => run(
+            hephaestus_wgpu::binary_elementwise::<hephaestus_wgpu::DivOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+    }
+}
+
+fn try_hephaestus_contiguous_unary<T: WgpuScalar + hephaestus_wgpu::WgslScalar>(
+    op: coeus_ops::UnaryOp,
+    a: &crate::storage::WgpuStorage<T>,
+    c: &mut crate::storage::WgpuStorage<T>,
+) -> bool {
+    if Arc::ptr_eq(&a.buffer, &c.buffer) {
+        return false;
+    }
+    let ctx = crate::backend::get_wgpu_context();
+    let run = |result: hephaestus_wgpu::Result<hephaestus_wgpu::WgpuBuffer<T>>,
+               c: &mut crate::storage::WgpuStorage<T>| {
+        c.buffer = Arc::new(result.expect("hephaestus-wgpu contiguous unary dispatch failed"));
+        true
+    };
+    match op {
+        coeus_ops::UnaryOp::Sin => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::SinOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Cos => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::CosOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Exp => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::ExpOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Log => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::LnOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Neg => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::NegOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Abs => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::AbsOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Sqrt => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::SqrtOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Recip => run(
+            hephaestus_wgpu::unary_elementwise::<hephaestus_wgpu::RecipOp, T>(
+                &ctx.hephaestus_device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        _ => false,
+    }
+}
+
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::BackendOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn elementwise_binary(
         &self,
@@ -25,7 +154,15 @@ impl<T: WgpuScalar + leto_ops::Scalar> coeus_ops::BackendOps<T> for WgpuBackend 
             && c_layout.is_contiguous()
             && c_layout.offset() == 0
         {
-            kernels::dispatch_contiguous_binary::<T>(op, &a.buffer, &b.buffer, &c.buffer, c.len());
+            if !try_hephaestus_contiguous_binary(op, a, b, c) {
+                kernels::dispatch_contiguous_binary::<T>(
+                    op,
+                    &a.buffer,
+                    &b.buffer,
+                    &c.buffer,
+                    c.len(),
+                );
+            }
         } else {
             kernels::dispatch_binary::<T>(
                 op,
@@ -55,7 +192,9 @@ impl<T: WgpuScalar + leto_ops::Scalar> coeus_ops::BackendOps<T> for WgpuBackend 
             && c_layout.is_contiguous()
             && c_layout.offset() == 0
         {
-            kernels::dispatch_contiguous_unary::<T>(op, &a.buffer, &c.buffer, c.len());
+            if !try_hephaestus_contiguous_unary(op, a, c) {
+                kernels::dispatch_contiguous_unary::<T>(op, &a.buffer, &c.buffer, c.len());
+            }
         } else {
             kernels::dispatch_unary::<T>(op, &a.buffer, a_layout, &c.buffer, c_layout, c.len());
         }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,6 +8,9 @@
 - [x] [patch] Reduced cache lock contention by switching from
   `Mutex<HashMap<...>>` to `RwLock<HashMap<...>>` and using a compile-outside-
   lock, double-check insert pattern.
+- [x] [patch] Routed contiguous non-aliased elementwise binary and a supported
+  unary subset through `hephaestus-wgpu` public kernels to reduce Coeus-local
+  WGSL duplication and rely on Hephaestus pipeline caching where possible.
 - [x] Evidence: `cargo fmt`; `cargo test -p coeus-wgpu`;
   `cargo clippy -p coeus-wgpu --all-targets -- -D warnings`.
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -14,6 +14,10 @@ contention in `coeus-wgpu` while preserving kernel parity behavior.
 - [x] [patch] Replaced global `Mutex<HashMap<...>>` with
   `RwLock<HashMap<...>>` and double-checked insertion to avoid holding the
   write lock while compiling pipelines.
+- [x] [patch] Reduced GPU kernel redundancy against `hephaestus-wgpu` by routing
+  contiguous non-aliased `Add/Sub/Mul/Div` and unary
+  `Sin/Cos/Exp/Log/Neg/Abs/Sqrt/Recip` through Hephaestus elementwise dispatch,
+  while retaining Coeus-local kernels for aliasing and unsupported unary ops.
 - [x] Evidence: `cargo fmt`; `cargo test -p coeus-wgpu`; `cargo clippy -p
   coeus-wgpu --all-targets -- -D warnings`.
 


### PR DESCRIPTION
## Summary
- route contiguous non-aliased binary/unary GPU elementwise ops through hephaestus-wgpu where supported
- keep coeus-local kernels for aliasing/unsupported ops
- add functional group_norm export and module re-exports
- document the SSOT/anti-redundancy GPU milestone

## Validation
- cargo test -p coeus-wgpu
- cargo clippy -p coeus-wgpu --all-targets -- -D warnings
- attempted cargo test -p coeus-nn --test nn_normalization_tests (blocked by upstream moirai-executor compile mismatch)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR routes GPU elementwise operations through the `hephaestus-wgpu` library for contiguous, non-aliased tensors to eliminate kernel duplication, while keeping local kernels as a fallback for aliasing and unsupported operations. Additionally, it exports a functional `group_norm` API alongside the existing `GroupNorm` module, and updates documentation to track the GPU kernel consolidation milestone.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `docs/backlog.md` |
| 3 | `coeus-wgpu/src/backend/ops/mod.rs` |
| 4 | `coeus-nn/src/normalization/mod.rs` |
| 5 | `coeus-nn/src/lib.rs` |
| 6 | `coeus-nn/src/normalization/groupnorm.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct group normalization operation for tensor inputs, including optional scale and bias support.
  * Expanded public normalization exports so the new group normalization API is available from the main package surface.

* **Bug Fixes**
  * Improved GPU execution for contiguous elementwise operations, with smarter handling when tensors share storage.
  * Reduced unnecessary kernel duplication for supported unary and binary operations, helping improve consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->