### PR TITLE
test(nn): Conv3d backward parity vs Burn autodiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - **BatchNorm2d training-mode backward parity** — differential Burn autodiff
   test verifying `dx`, `dw`, `db` for training-mode BatchNorm2d using Coeus's
   NHWC-layout, population-variance formula (97th parity test; ε ≤ 1e-4).
+- **Conv3d backward parity** — differential Burn autodiff test verifying `dx`
+  and `dw` for valid 3D convolution, completing backward coverage for Conv1d/2d/3d
+  (98th parity test).
 
 ### Fixed
 

--- a/coeus-nn/tests/burn_live_parity.rs
+++ b/coeus-nn/tests/burn_live_parity.rs
@@ -3415,6 +3415,61 @@ fn conv3d_stride_padding_matches_burn() {
     );
 }
 
+// ── Conv3d backward (dx, dw) matches Burn autodiff ────────────────────────────
+//
+// Valid (no-padding) convolution so the backward formula is exact with stride=1.
+// Weight shape [oc, ic, kd, kh, kw]; no bias.
+// Uses `burn::tensor::module::conv3d` free function with tracked input/weight
+// tensors (no std-gated GradientsParams needed).
+
+#[test]
+fn conv3d_backward_matches_burn() {
+    use burn::backend::autodiff::Autodiff;
+    use burn::tensor::module::conv3d as burn_conv3d;
+    use burn::tensor::ops::ConvOptions;
+    use coeus_nn::Conv3d;
+
+    type AB = Autodiff<NdArray<f32>>;
+    let device: NdArrayDevice = Default::default();
+
+    let (n, ic, oc, d, h, w, k) = (1usize, 2, 1, 5, 5, 5, 3);
+    let data: Vec<f32> = (0..n * ic * d * h * w)
+        .map(|x| x as f32 * 0.03 - 2.0)
+        .collect();
+    let w_vec: Vec<f32> = (0..oc * ic * k * k * k)
+        .map(|x| (x as f32 + 1.0) * 0.1 - 0.5)
+        .collect();
+
+    // Coeus: forward + backward (valid conv, stride=1, pad=0).
+    let xv = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![n, ic, d, h, w], &data),
+        true,
+    );
+    let mut conv_c = Conv3d::<f32, SequentialBackend>::new(ic, oc, k, false);
+    conv_c.weight = Var::new(CoeusTensor::from_slice(vec![oc, ic, k, k, k], &w_vec), true);
+    coeus_autograd::sum(&conv_c.forward(&xv)).backward();
+    let dx_c = xv.grad().unwrap();
+    let dw_c = conv_c.weight.grad().unwrap();
+
+    // Burn: free-function conv3d with tracked input and weight.
+    let xb: BurnTensor<AB, 5> =
+        BurnTensor::from_data(TensorData::new(data.clone(), [n, ic, d, h, w]), &device)
+            .require_grad();
+    let wb: BurnTensor<AB, 5> =
+        BurnTensor::from_data(TensorData::new(w_vec.clone(), [oc, ic, k, k, k]), &device)
+            .require_grad();
+    let opts = ConvOptions::new([1, 1, 1], [0, 0, 0], [1, 1, 1], 1);
+    let grads = burn_conv3d(xb.clone(), wb.clone(), None, opts)
+        .sum()
+        .backward();
+
+    let dx_b: Vec<f32> = xb.grad(&grads).unwrap().into_data().to_vec().unwrap();
+    let dw_b: Vec<f32> = wb.grad(&grads).unwrap().into_data().to_vec().unwrap();
+
+    assert_close("conv3d_bwd_dx", dx_c.as_slice(), &dx_b);
+    assert_close("conv3d_bwd_dw", dw_c.as_slice(), &dw_b);
+}
+
 // ── Transpose backward (gradient routing) matches Burn autodiff ──────────────
 
 #[test]

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,18 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-109 - WGPU Hephaestus zero-allocation elementwise routing [COMPLETE]
+### Current Sprint: MS-110 - Conv3d backward parity vs Burn autodiff [COMPLETE]
+**Objective**: Add differential Burn autodiff parity for Conv3d backward
+pass (dx, dw), completing backward parity coverage for all three conv dims.
+**Target version**: 0.5.1 (patch-class; test coverage).
+
+- [x] [patch] Added `conv3d_backward_matches_burn` — free-function Burn conv3d
+  with tracked input/weight, valid convolution (stride=1, pad=0, dil=1),
+  comparing dx and dw within epsilon tolerance.
+- [x] Evidence: `cargo nextest run -p coeus-nn --test burn_live_parity`:
+  98/98 pass.
+
+### Previous Sprint: MS-109 - WGPU Hephaestus zero-allocation elementwise routing [COMPLETE]
 **Objective**: Reduce WGPU elementwise allocation churn by keeping delegated
 Hephaestus contiguous routes in caller-owned output buffers.
 **Target version**: 0.5.1 (patch-class; behavior-preserving backend optimization).


### PR DESCRIPTION
## Summary

- Adds `conv3d_backward_matches_burn` — differential Burn autodiff parity for Conv3d backward (dx, dw).
- Uses `burn::tensor::module::conv3d` free function with tracked input and weight tensors (no std-gated `GradientsParams` needed), valid convolution (stride=1, pad=0, dil=1).
- Completes backward parity coverage for all three convolution dimensions: Conv1d ✓, Conv2d ✓, Conv3d ✓ (98th parity test).

## Test plan

- [x] `cargo nextest run -p coeus-nn --test burn_live_parity`: 98/98 pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds backward pass parity testing for `Conv3d` by implementing `conv3d_backward_matches_burn`, which compares gradient computations (`dx`, `dw`) against Burn's autodiff implementation. The test uses a valid convolution configuration (stride=1, pad=0, dil=1) with tracked tensors, completing backward parity coverage across all three convolution dimensions (Conv1d, Conv2d, Conv3d) and bringing the total parity test count to 98.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/burn_live_parity.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->