### PR TITLE
perf(cuda): Hephaestus dynamic-strided elementwise routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,12 @@
 
 ### Changed
 
-- **CUDA Hephaestus primitive routing** — contiguous non-aliased
-  `coeus-cuda` primitive elementwise operations now route through
-  `hephaestus-cuda`, matching the existing WGPU provider-first boundary while
-  retaining Coeus-local CUDA kernels for aliasing, dynamic-layout strided paths,
-  and NN-specific formulas.
+- **CUDA Hephaestus primitive routing (contiguous + strided)** — contiguous
+  non-aliased `coeus-cuda` primitive elementwise operations route through
+  `hephaestus-cuda` first; strided paths with rank ≤ `MAX_STRIDED_RANK` and no
+  broadcast output dimension now also route through Hephaestus's dynamic-strided
+  kernel, with Coeus-local CUDA kernels retained for aliasing, out-of-range rank,
+  broadcast output, and NN-specific formulas.
 - **WGPU Hephaestus zero-allocation dispatch** — contiguous non-aliased
   elementwise unary/binary routes in `coeus-wgpu` now use Hephaestus `*_into`
   APIs to write into caller-owned output buffers instead of allocating and

--- a/coeus-cuda/src/backend/ops/math.rs
+++ b/coeus-cuda/src/backend/ops/math.rs
@@ -138,6 +138,194 @@ where
     }
 }
 
+#[inline]
+fn hephaestus_operand<'a, T>(
+    storage: &'a CudaStorage<T>,
+    layout: &'a Layout,
+) -> hephaestus_cuda::StridedOperandDyn<'a, T> {
+    hephaestus_cuda::StridedOperandDyn {
+        buffer: storage.buffer.as_ref(),
+        layout: hephaestus_cuda::StridedLayout {
+            shape: layout.shape(),
+            strides: layout.strides(),
+            offset: layout.offset(),
+        },
+    }
+}
+
+#[inline]
+fn can_route_dynamic_strided(layouts: &[&Layout], out: &Layout) -> bool {
+    layouts
+        .iter()
+        .chain(std::iter::once(&out))
+        .all(|layout| layout.ndim() <= hephaestus_cuda::MAX_STRIDED_RANK)
+        && !out
+            .shape()
+            .iter()
+            .zip(out.strides())
+            .any(|(&dim, &stride)| dim > 1 && stride == 0)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn try_hephaestus_strided_binary<T>(
+    op: coeus_ops::BinaryOp,
+    a: &CudaStorage<T>,
+    a_layout: &Layout,
+    b: &CudaStorage<T>,
+    b_layout: &Layout,
+    c: &mut CudaStorage<T>,
+    c_layout: &Layout,
+) -> bool
+where
+    T: CudaScalar + hephaestus_cuda::CudaScalar,
+{
+    if !can_route_dynamic_strided(&[a_layout, b_layout], c_layout) {
+        return false;
+    }
+    let device = crate::backend::get_cuda_device();
+    let run = |result: hephaestus_cuda::Result<()>| {
+        result.expect("hephaestus-cuda dynamic strided binary dispatch failed");
+        true
+    };
+    match op {
+        coeus_ops::BinaryOp::Add => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::AddOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::BinaryOp::Sub => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::SubOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::BinaryOp::Mul => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::MulOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::BinaryOp::Div => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::DivOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+    }
+}
+
+fn try_hephaestus_strided_unary<T>(
+    op: coeus_ops::UnaryOp,
+    a: &CudaStorage<T>,
+    a_layout: &Layout,
+    c: &mut CudaStorage<T>,
+    c_layout: &Layout,
+) -> bool
+where
+    T: CudaScalar + hephaestus_cuda::CudaScalar,
+{
+    if !can_route_dynamic_strided(&[a_layout], c_layout) {
+        return false;
+    }
+    let device = crate::backend::get_cuda_device();
+    let run = |result: hephaestus_cuda::Result<()>| {
+        result.expect("hephaestus-cuda dynamic strided unary dispatch failed");
+        true
+    };
+    match op {
+        coeus_ops::UnaryOp::Sin => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::SinOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Cos => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::CosOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Exp => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::ExpOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Log => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::LnOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Neg => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::NegOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Abs => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::AbsOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Sqrt => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::SqrtOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Recip => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::RecipOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        _ => false,
+    }
+}
+
 impl CudaBackend {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn cuda_elementwise_binary<T>(
@@ -172,7 +360,9 @@ impl CudaBackend {
                 if kernels::launch_contiguous_binary(op, a, b, c, n) {
                     return;
                 }
-            } else if kernels::launch_strided_binary(op, a, a_layout, b, b_layout, c, c_layout, n) {
+            } else if try_hephaestus_strided_binary(op, a, a_layout, b, b_layout, c, c_layout)
+                || kernels::launch_strided_binary(op, a, a_layout, b, b_layout, c, c_layout, n)
+            {
                 return;
             }
         }
@@ -199,7 +389,9 @@ impl CudaBackend {
                     return;
                 }
             } else {
-                if kernels::launch_strided_unary(op, a, a_layout, c, c_layout, n) {
+                if try_hephaestus_strided_unary(op, a, a_layout, c, c_layout)
+                    || kernels::launch_strided_unary(op, a, a_layout, c, c_layout, n)
+                {
                     return;
                 }
             }

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-110 - Conv3d backward parity vs Burn autodiff [COMPLETE]
+### Current Sprint: MS-111 - CUDA strided Hephaestus routing [COMPLETE]
+**Objective**: Extend CUDA Hephaestus routing to the dynamic-strided path so
+non-contiguous CUDA elementwise ops also prefer the Hephaestus kernel (with
+rank ≤ MAX_STRIDED_RANK and no broadcast dimensions in output) before the
+Coeus-local strided fallback.
+**Target version**: 0.5.1 (patch-class; performance).
+
+- [x] [patch] Added `try_hephaestus_strided_binary` routing Add/Sub/Mul/Div
+  through `hephaestus_cuda::binary_elementwise_strided_dyn_into` with guard for
+  rank and broadcast exclusion.
+- [x] [patch] Added `try_hephaestus_strided_unary` routing Sin/Cos/Exp/Log/Neg/
+  Abs/Sqrt/Recip through `hephaestus_cuda::unary_elementwise_strided_dyn_into`.
+- [x] [patch] Added `hephaestus_operand` helper to convert Coeus layout
+  (shape/strides/offset) to `hephaestus_cuda::StridedOperandDyn`.
+- [x] Evidence: `cargo check -p coeus-cuda --all-targets` clean;
+  `cargo check -p coeus-cuda --features cuda` clean.
+
+### Previous Sprint: MS-110 - Conv3d backward parity vs Burn autodiff [COMPLETE]
 **Objective**: Add differential Burn autodiff parity for Conv3d backward
 pass (dx, dw), completing backward parity coverage for all three conv dims.
 **Target version**: 0.5.1 (patch-class; test coverage).


### PR DESCRIPTION
## Summary

- Adds `try_hephaestus_strided_binary` and `try_hephaestus_strided_unary` in `coeus-cuda` routing the strided elementwise path through `hephaestus_cuda::*_elementwise_strided_dyn_into` when the layout rank is within `MAX_STRIDED_RANK` and the output has no broadcast dimensions.
- Complements the existing contiguous Hephaestus routing (MS-107) by covering the non-contiguous case.
- Coeus-local strided kernels remain the fallback for out-of-range rank, broadcast output, and NN-specific ops.

## Test plan

- [x] `cargo check -p coeus-cuda --all-targets` clean
- [x] `cargo check -p coeus-cuda --features cuda` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extends CUDA elementwise operation routing to use Hephaestus dynamic-strided kernels for non-contiguous layouts. When tensors have rank within `MAX_STRIDED_RANK` and the output has no broadcast dimensions, both unary and binary elementwise operations now route through `hephaestus_cuda::*_elementwise_strided_dyn_into` before falling back to Coeus-local strided kernels. This complements the existing contiguous Hephaestus routing (MS-107) and improves performance for strided tensor operations.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `docs/checklist.md` |
| 3 | `coeus-cuda/src/backend/ops/math.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->