### PR TITLE
test(nn): InstanceNorm1d/2d backward parity vs Burn autodiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - **Conv3d backward parity** — differential Burn autodiff test verifying `dx`
   and `dw` for valid 3D convolution, completing backward coverage for Conv1d/2d/3d
   (98th parity test).
+- **InstanceNorm1d/2d backward parity** — differential Burn autodiff tests
+  verifying `dx`, `dw`, `db` for InstanceNorm1d [N,C,L] and InstanceNorm2d
+  [N,C,H,W] backward passes (99th and 100th parity tests; ε ≤ 1e-4).
 
 ### Fixed
 

--- a/coeus-nn/tests/burn_live_parity.rs
+++ b/coeus-nn/tests/burn_live_parity.rs
@@ -3682,3 +3682,151 @@ fn batchnorm2d_training_backward_matches_burn() {
     let dx_c_flat = xv.grad().unwrap();
     assert_close_rel("batchnorm2d_bwd_dx", dx_c_flat.as_slice(), &dx_b_flat, 1e-4);
 }
+
+// ── InstanceNorm1d backward (dx) matches Burn autodiff ────────────────────────
+//
+// InstanceNorm normalizes each (sample, channel) slice over the spatial dim L.
+// Formula: reshape [N,C,L] → [N*C, L], population variance (÷L), then
+//   y[nc, l] = gamma[nc%C] * x_hat[nc, l] + beta[nc%C].
+// gamma/beta are tiled [C] → [N*C, 1] via repeat_dim(0, N).
+
+#[test]
+fn instancenorm1d_backward_matches_burn() {
+    use burn::backend::autodiff::Autodiff;
+    use coeus_nn::InstanceNorm1d;
+
+    type AB = Autodiff<NdArray<f32>>;
+    let device: NdArrayDevice = Default::default();
+
+    let (n, c, l) = (2usize, 2, 4);
+    let nc = n * c;
+    let eps = 1e-5_f32;
+    let data: Vec<f32> = (0..n * c * l).map(|x| x as f32 * 0.1 - 1.0).collect();
+    let gamma = vec![1.2f32, 0.8];
+    let beta = vec![0.1f32, -0.1];
+
+    // Coeus forward + backward.
+    let xv = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![n, c, l], &data),
+        true,
+    );
+    let mut in1 = InstanceNorm1d::<f32, SequentialBackend>::new(c, eps as f64);
+    in1.weight = Var::new(CoeusTensor::from_slice(vec![c], &gamma), true);
+    in1.bias = Var::new(CoeusTensor::from_slice(vec![c], &beta), true);
+    coeus_autograd::sum(&in1.forward(&xv)).backward();
+
+    // Burn autodiff: manual InstanceNorm1d formula.
+    // gamma/beta: [C] → repeat N times dim-0 → [N*C] → [N*C, 1] for broadcast.
+    let xb: BurnTensor<AB, 3> =
+        BurnTensor::from_data(TensorData::new(data.clone(), [n, c, l]), &device).require_grad();
+    let wb: BurnTensor<AB, 1> =
+        BurnTensor::from_data(TensorData::new(gamma.clone(), [c]), &device).require_grad();
+    let bk: BurnTensor<AB, 1> =
+        BurnTensor::from_data(TensorData::new(beta.clone(), [c]), &device).require_grad();
+
+    let flat: BurnTensor<AB, 2> = xb.clone().reshape([nc, l]);
+    let mean = flat.clone().sum_dim(1) / (l as f32); // [N*C, 1]
+    let xmu = flat.sub(mean);
+    let var = xmu.clone().powf_scalar(2.0).sum_dim(1) / (l as f32);
+    let xhat = xmu / (var.add_scalar(eps)).sqrt(); // [N*C, L]
+    let g2 = wb.clone().reshape([1, c]).repeat_dim(0, n).reshape([nc, 1]);
+    let b2 = bk.clone().reshape([1, c]).repeat_dim(0, n).reshape([nc, 1]);
+    let grads = (xhat.mul(g2) + b2).sum().backward();
+
+    let dx_b: Vec<f32> = xb.grad(&grads).unwrap().into_data().to_vec().unwrap();
+    let to_vec = |t: BurnTensor<NdArray<f32>, 1>| t.into_data().to_vec::<f32>().unwrap();
+
+    assert_close_rel(
+        "instancenorm1d_bwd_dx",
+        xv.grad().unwrap().as_slice(),
+        &dx_b,
+        1e-4,
+    );
+    assert_close_rel(
+        "instancenorm1d_bwd_dw",
+        in1.weight.grad().unwrap().as_slice(),
+        &to_vec(wb.grad(&grads).unwrap()),
+        1e-4,
+    );
+    assert_close_rel(
+        "instancenorm1d_bwd_db",
+        in1.bias.grad().unwrap().as_slice(),
+        &to_vec(bk.grad(&grads).unwrap()),
+        1e-4,
+    );
+}
+
+// ── InstanceNorm2d backward (dx) matches Burn autodiff ────────────────────────
+//
+// Same as InstanceNorm1d but spatial = H*W (normalized over each HxW slice).
+// Reshape [N,C,H,W] → [N*C, H*W], same population-variance normalize, then
+//   y[nc, hw] = gamma[nc%C] * x_hat[nc, hw] + beta[nc%C].
+
+#[test]
+fn instancenorm2d_backward_matches_burn() {
+    use burn::backend::autodiff::Autodiff;
+    use coeus_nn::InstanceNorm2d;
+
+    type AB = Autodiff<NdArray<f32>>;
+    let device: NdArrayDevice = Default::default();
+
+    let (n, c, h, w) = (2usize, 2, 3, 3);
+    let nc = n * c;
+    let hw = h * w;
+    let eps = 1e-5_f32;
+    let data: Vec<f32> = (0..n * c * h * w)
+        .map(|x| x as f32 * 0.05 - 1.0)
+        .collect();
+    let gamma = vec![1.2f32, 0.8];
+    let beta = vec![0.1f32, -0.1];
+
+    // Coeus forward + backward.
+    let xv = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![n, c, h, w], &data),
+        true,
+    );
+    let mut in2 = InstanceNorm2d::<f32, SequentialBackend>::new(c, eps as f64);
+    in2.weight = Var::new(CoeusTensor::from_slice(vec![c], &gamma), true);
+    in2.bias = Var::new(CoeusTensor::from_slice(vec![c], &beta), true);
+    coeus_autograd::sum(&in2.forward(&xv)).backward();
+
+    // Burn autodiff: manual InstanceNorm2d formula.
+    // Reshape [N,C,H,W] → [N*C, H*W] for spatial normalization.
+    let xb: BurnTensor<AB, 4> =
+        BurnTensor::from_data(TensorData::new(data.clone(), [n, c, h, w]), &device).require_grad();
+    let wb: BurnTensor<AB, 1> =
+        BurnTensor::from_data(TensorData::new(gamma.clone(), [c]), &device).require_grad();
+    let bk: BurnTensor<AB, 1> =
+        BurnTensor::from_data(TensorData::new(beta.clone(), [c]), &device).require_grad();
+
+    let flat: BurnTensor<AB, 2> = xb.clone().reshape([nc, hw]);
+    let mean = flat.clone().sum_dim(1) / (hw as f32); // [N*C, 1]
+    let xmu = flat.sub(mean);
+    let var = xmu.clone().powf_scalar(2.0).sum_dim(1) / (hw as f32);
+    let xhat = xmu / (var.add_scalar(eps)).sqrt(); // [N*C, H*W]
+    let g2 = wb.clone().reshape([1, c]).repeat_dim(0, n).reshape([nc, 1]);
+    let b2 = bk.clone().reshape([1, c]).repeat_dim(0, n).reshape([nc, 1]);
+    let grads = (xhat.mul(g2) + b2).sum().backward();
+
+    let dx_b: Vec<f32> = xb.grad(&grads).unwrap().into_data().to_vec().unwrap();
+    let to_vec = |t: BurnTensor<NdArray<f32>, 1>| t.into_data().to_vec::<f32>().unwrap();
+
+    assert_close_rel(
+        "instancenorm2d_bwd_dx",
+        xv.grad().unwrap().as_slice(),
+        &dx_b,
+        1e-4,
+    );
+    assert_close_rel(
+        "instancenorm2d_bwd_dw",
+        in2.weight.grad().unwrap().as_slice(),
+        &to_vec(wb.grad(&grads).unwrap()),
+        1e-4,
+    );
+    assert_close_rel(
+        "instancenorm2d_bwd_db",
+        in2.bias.grad().unwrap().as_slice(),
+        &to_vec(bk.grad(&grads).unwrap()),
+        1e-4,
+    );
+}

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,20 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-111 - CUDA strided Hephaestus routing [COMPLETE]
+### Current Sprint: MS-112 - InstanceNorm1d/2d backward parity [COMPLETE]
+**Objective**: Add differential Burn autodiff parity for InstanceNorm1d and
+InstanceNorm2d backward passes (dx, dw, db), closing the norm backward gap.
+**Target version**: 0.5.1 (patch-class; test coverage).
+
+- [x] [patch] Added `instancenorm1d_backward_matches_burn` — [N,C,L] input,
+  per-(sample,channel) spatial normalization formula in Burn autodiff,
+  verifies dx/dw/db within 1e-4 relative tolerance (99th parity test).
+- [x] [patch] Added `instancenorm2d_backward_matches_burn` — [N,C,H,W] input,
+  reshape to [N*C, H*W] for spatial normalization (100th parity test).
+- [x] Evidence: `cargo nextest run -p coeus-nn --test burn_live_parity`:
+  100/100 pass.
+
+### Previous Sprint: MS-111 - CUDA strided Hephaestus routing [COMPLETE]
 **Objective**: Extend CUDA Hephaestus routing to the dynamic-strided path so
 non-contiguous CUDA elementwise ops also prefer the Hephaestus kernel (with
 rank ≤ MAX_STRIDED_RANK and no broadcast dimensions in output) before the
@@ -50,7 +63,7 @@ identity assertions, plus aliasing fallback parity.
   coeus-wgpu test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer`;
   `cargo test -p coeus-wgpu test_wgpu_aliasing_unary_neg_matches_cpu`.
 
-### Current Sprint: MS-108 - BatchNorm2d training-mode backward parity [COMPLETE]
+### Previous Sprint: MS-108 - BatchNorm2d training-mode backward parity [COMPLETE]
 **Objective**: Add differential Burn autodiff parity for BatchNorm2d training-mode
 backward pass (dx, dw, db), matching Coeus's NHWC-based population-variance formula
 against the same formula manually expressed in Burn autodiff tensors.
@@ -62,7 +75,7 @@ against the same formula manually expressed in Burn autodiff tensors.
   (÷M not ÷(M-1)), verifies dx/dw/db within 1e-4 relative tolerance.
 - [x] Evidence: `cargo nextest run -p coeus-nn --test burn_live_parity`: 97/97 pass.
 
-### Current Sprint: MS-107 - CUDA Hephaestus primitive routing [COMPLETE]
+### Previous Sprint: MS-107 - CUDA Hephaestus primitive routing [COMPLETE]
 **Objective**: Keep CUDA and WGPU shared primitive GPU dispatch centralized in
 Hephaestus while preserving Coeus-local kernels only for aliasing, strided
 coverage not yet mapped through the static-rank Hephaestus API, and


### PR DESCRIPTION
## Summary

- Adds `instancenorm1d_backward_matches_burn` and `instancenorm2d_backward_matches_burn`.
- InstanceNorm normalizes each `(sample, channel)` slice over its spatial dimension. Both tests implement the same per-channel spatial normalization formula in Burn autodiff tensors (reshape to `[N*C, spatial]`, population variance, then `gamma`/`beta` tiled via `repeat_dim(0, N)`).
- Reaches **100 parity tests** passing (up from 98 before this PR).

## Test plan

- [x] `cargo nextest run -p coeus-nn --test burn_live_parity`: 100/100 pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds backward pass parity tests for `InstanceNorm1d` and `InstanceNorm2d` neural network layers, verifying that gradients (`dx`, `dw`, `db`) computed by the Coeus implementation match those from Burn's autodiff engine. Both tests implement the per-channel spatial normalization formula by reshaping inputs to `[N*C, spatial]`, computing population variance, and applying tiled `gamma`/`beta` parameters via `repeat_dim`. This brings the total parity test count to 100 (up from 98), with all tests passing at 1e-4 relative tolerance.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `CHANGELOG.md` |
| 3 | `coeus-nn/tests/burn_live_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->