### PR TITLE
dist: harden local communicator reduction path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- **LocalCommunicator all-reduce contention fix** — refactored
+  `coeus-dist/src/local.rs::all_reduce` to compute the reduction once on rank 0
+  and publish the reduced payload for all ranks, removing redundant per-rank
+  reduction loops under shared lock.
+- **Collective payload safety guards** — added local staged-payload helpers in
+  `coeus-dist/src/local.rs` (`slot_vec_ref`, `assert_numel`) to provide explicit
+  type and numel validation across local collectives.
+- **Local collective temporary allocation cleanup** — removed zero-filled temp
+  vectors in `broadcast`, `reduce`, and `scatter` by cloning validated staging
+  payloads directly.
 - **Fusion op-tag hierarchy cleanup** — moved binary fused-expression ZST tags
   (`BinaryOpTag`, `Add`, `Sub`, `Mul`, `Div`) into
   `coeus-ops/src/fuse/op_tags/binary.rs` and re-exported them through

--- a/coeus-dist/src/local.rs
+++ b/coeus-dist/src/local.rs
@@ -3,6 +3,7 @@ use crate::helpers::{copy_host_slice_to_tensor, get_tensor_host_data};
 use crate::ops::ReduceOpTag;
 use coeus_core::{ComputeBackend, Scalar};
 use coeus_tensor::Tensor;
+use std::any::type_name;
 use std::sync::{Arc, Barrier, Mutex};
 
 /// Shared state for thread-based rank cluster simulation.
@@ -85,6 +86,36 @@ impl LocalCommunicator {
             })
             .collect()
     }
+
+    #[inline]
+    fn slot_vec_ref<'a, T: Scalar>(
+        slot: &'a Option<Box<dyn std::any::Any + Send>>,
+        rank: usize,
+        collective: &'static str,
+    ) -> &'a Vec<T> {
+        let payload = slot.as_ref().unwrap_or_else(|| {
+            panic!("{collective}: missing staging payload for rank {rank}");
+        });
+        payload.downcast_ref::<Vec<T>>().unwrap_or_else(|| {
+            panic!(
+                "{collective}: staging payload type mismatch on rank {rank}; expected {}",
+                type_name::<Vec<T>>()
+            )
+        })
+    }
+
+    #[inline]
+    fn assert_numel(
+        data_len: usize,
+        expected_numel: usize,
+        rank: usize,
+        collective: &'static str,
+    ) {
+        assert_eq!(
+            data_len, expected_numel,
+            "{collective}: payload numel mismatch for rank {rank}; expected {expected_numel}, got {data_len}",
+        );
+    }
 }
 
 impl Communicator for LocalCommunicator {
@@ -124,25 +155,39 @@ impl Communicator for LocalCommunicator {
         // 2. Barrier sync
         self.barrier();
 
-        // 3. Perform reduction on host
-        let mut reduced = vec![T::zero(); numel];
-        {
-            let bufs = self.shared.buffers.lock().unwrap();
-            let r0_data = bufs[0].as_ref().unwrap().downcast_ref::<Vec<T>>().unwrap();
-            reduced.copy_from_slice(r0_data);
-
+        // 3. Perform reduction once on rank 0 and publish it to slot 0.
+        if self.rank == 0 {
+            let mut bufs = self.shared.buffers.lock().unwrap();
+            let mut reduced = {
+                let r0_data = Self::slot_vec_ref::<T>(&bufs[0], 0, "all_reduce");
+                Self::assert_numel(r0_data.len(), numel, 0, "all_reduce");
+                r0_data.clone()
+            };
             for r in 1..self.size {
-                let r_data = bufs[r].as_ref().unwrap().downcast_ref::<Vec<T>>().unwrap();
+                let r_data = Self::slot_vec_ref::<T>(&bufs[r], r, "all_reduce");
+                Self::assert_numel(r_data.len(), numel, r, "all_reduce");
                 for i in 0..numel {
                     reduced[i] = Op::apply(reduced[i], r_data[i]);
                 }
             }
+            bufs[0] = Some(Box::new(reduced));
         }
 
-        // 4. Barrier sync before clear
+        // 4. Barrier sync to ensure reduced payload is published.
         self.barrier();
 
-        // 5. Clear staging board
+        // 5. All ranks read reduced payload.
+        let reduced = {
+            let bufs = self.shared.buffers.lock().unwrap();
+            let reduced = Self::slot_vec_ref::<T>(&bufs[0], 0, "all_reduce");
+            Self::assert_numel(reduced.len(), numel, 0, "all_reduce");
+            reduced.clone()
+        };
+
+        // 6. Barrier sync before clear.
+        self.barrier();
+
+        // 7. Clear staging board
         if self.rank == 0 {
             let mut bufs = self.shared.buffers.lock().unwrap();
             for item in bufs.iter_mut() {
@@ -150,10 +195,10 @@ impl Communicator for LocalCommunicator {
             }
         }
 
-        // 6. Barrier sync post clear
+        // 8. Barrier sync post clear
         self.barrier();
 
-        // 7. Transfer to device
+        // 9. Transfer to device
         copy_host_slice_to_tensor(&reduced, tensor, backend);
     }
 
@@ -180,15 +225,12 @@ impl Communicator for LocalCommunicator {
 
         self.barrier();
 
-        let mut broadcasted = vec![T::zero(); numel];
+        let mut broadcasted = Vec::new();
         if self.rank != root {
             let bufs = self.shared.buffers.lock().unwrap();
-            let root_data = bufs[root]
-                .as_ref()
-                .unwrap()
-                .downcast_ref::<Vec<T>>()
-                .unwrap();
-            broadcasted.copy_from_slice(root_data);
+            let root_data = Self::slot_vec_ref::<T>(&bufs[root], root, "broadcast");
+            Self::assert_numel(root_data.len(), numel, root, "broadcast");
+            broadcasted = root_data.clone();
         }
 
         self.barrier();
@@ -277,14 +319,16 @@ impl Communicator for LocalCommunicator {
         self.barrier();
 
         // 3. Perform reduction on root process
-        let mut reduced = vec![T::zero(); numel];
+        let mut reduced = Vec::new();
         if self.rank == root {
             let bufs = self.shared.buffers.lock().unwrap();
-            let r0_data = bufs[0].as_ref().unwrap().downcast_ref::<Vec<T>>().unwrap();
-            reduced.copy_from_slice(r0_data);
+            let r0_data = Self::slot_vec_ref::<T>(&bufs[0], 0, "reduce");
+            Self::assert_numel(r0_data.len(), numel, 0, "reduce");
+            reduced = r0_data.clone();
 
             for r in 1..self.size {
-                let r_data = bufs[r].as_ref().unwrap().downcast_ref::<Vec<T>>().unwrap();
+                let r_data = Self::slot_vec_ref::<T>(&bufs[r], r, "reduce");
+                Self::assert_numel(r_data.len(), numel, r, "reduce");
                 for i in 0..numel {
                     reduced[i] = Op::apply(reduced[i], r_data[i]);
                 }
@@ -396,15 +440,12 @@ impl Communicator for LocalCommunicator {
 
         self.barrier();
 
-        let mut scattered = vec![T::zero(); numel];
+        let scattered;
         {
             let bufs = self.shared.buffers.lock().unwrap();
-            let rank_data = bufs[self.rank]
-                .as_ref()
-                .unwrap()
-                .downcast_ref::<Vec<T>>()
-                .unwrap();
-            scattered.copy_from_slice(rank_data);
+            let rank_data = Self::slot_vec_ref::<T>(&bufs[self.rank], self.rank, "scatter");
+            Self::assert_numel(rank_data.len(), numel, self.rank, "scatter");
+            scattered = rank_data.clone();
         }
 
         self.barrier();

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,17 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-144: LocalCommunicator contention and safety hardening [COMPLETE]
+
+- [x] [patch] Refactored `coeus-dist/src/local.rs::all_reduce` so reduction is
+  computed once on rank 0 and published for all ranks, removing per-rank
+  redundant O(world_size*numel) reduction work under shared lock.
+- [x] [patch] Added staged payload guards via `slot_vec_ref` and
+  `assert_numel` for explicit type/shape validation during collectives.
+- [x] [patch] Removed unnecessary zero-initialized temporary buffers in
+  `broadcast`, `reduce`, and `scatter` by cloning validated payloads.
+- [x] Evidence: `cargo test -p coeus-dist --tests` (20/20 pass);
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-143: Fusion op-tag binary ZST split [COMPLETE]
 
 - [x] [patch] Promoted binary fused-expression tags from the monolithic

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,21 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-143 - Fusion op-tag binary ZST split [COMPLETE]
+### Current Sprint: MS-144 - LocalCommunicator contention and safety hardening [COMPLETE]
+**Objective**: Resolve a distributed-runtime hotspot by eliminating redundant
+`all_reduce` work across ranks, hardening staged payload validation, and
+cutting avoidable temporary allocations in local collectives.
+
+- [x] [patch] Refactored `coeus-dist/src/local.rs::all_reduce` to compute the
+  reduction once on rank 0 and publish the reduced payload for all ranks.
+- [x] [patch] Added explicit staged-payload validation helpers
+  (`slot_vec_ref`, `assert_numel`) for type/shape guardrails.
+- [x] [patch] Removed unnecessary zero-fill temp allocations in `broadcast`,
+  `reduce`, and `scatter`.
+- [x] Evidence: `cargo test -p coeus-dist --tests` passes 20/20; `cargo clippy
+  -p coeus-dist --all-targets -- -D warnings` passes.
+
+### Previous Sprint: MS-143 - Fusion op-tag binary ZST split [COMPLETE]
 **Objective**: Remove the partial duplicate `op_tags/binary.rs` split by making
 binary fused-expression tags a real vertical module under `coeus-ops` while
 preserving the existing public re-export surface.


### PR DESCRIPTION
## Summary
- compute LocalCommunicator all_reduce once on rank 0 and share result
- add payload type/numel guards for staged local collectives
- remove redundant zero-init temporary vectors in broadcast/reduce/scatter

## Validation
- cargo test -p coeus-dist --tests
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the local communicator's distributed reduction operations by eliminating redundant computation. Previously, `all_reduce` performed O(world_size × numel) reduction work on every rank under a shared lock. The refactored implementation computes the reduction once on rank 0 and broadcasts the result, significantly reducing contention. Additionally, the PR introduces type and shape validation helpers (`slot_vec_ref`, `assert_numel`) to guard staged payload access across collective operations, and removes unnecessary zero-initialized temporary buffers in `broadcast`, `reduce`, and `scatter` operations by directly cloning validated payloads instead.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/local.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local collective operations to reduce contention and make distributed reductions more reliable.
  * Added stronger validation for staged payloads, helping catch invalid shapes or sizes earlier.
  * Removed unnecessary temporary allocations to improve efficiency during collective communication.

* **Documentation**
  * Updated release tracking and sprint notes to reflect the latest collective-operation improvements and completed verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->