### PR TITLE
dist: harden local collective staging contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@
 
 ### Fixed
 
+- **Local gather/all-gather staged payload safety** — `LocalCommunicator`
+  now validates staged payload type and `numel` in both `all_gather` and
+  `gather` via shared helpers, removing unchecked downcasts.
+- **Local collective staging cleanup DRY** — added `clear_staging` in
+  `coeus-dist/src/local.rs` and reused it across local collectives to remove
+  duplicated staging-reset loops.
+- **Scatter shape contract enforcement** — `LocalCommunicator::scatter`
+  now validates root-side input tensor `numel` for each rank and includes
+  dedicated panic-contract coverage in
+  `coeus-dist/tests/dist_tests.rs::test_local_scatter_mismatched_input_numel_panics`.
 - **InstanceNorm parity oracle** — the PyTorch reference affine `weight`/`bias`
   tensors now set `requires_grad=True`, so their gradients are populated for the
   differential comparison (previously `None`, which would have masked any

--- a/coeus-dist/src/local.rs
+++ b/coeus-dist/src/local.rs
@@ -105,16 +105,19 @@ impl LocalCommunicator {
     }
 
     #[inline]
-    fn assert_numel(
-        data_len: usize,
-        expected_numel: usize,
-        rank: usize,
-        collective: &'static str,
-    ) {
+    fn assert_numel(data_len: usize, expected_numel: usize, rank: usize, collective: &'static str) {
         assert_eq!(
             data_len, expected_numel,
             "{collective}: payload numel mismatch for rank {rank}; expected {expected_numel}, got {data_len}",
         );
+    }
+
+    #[inline]
+    fn clear_staging(&self) {
+        let mut bufs = self.shared.buffers.lock().unwrap();
+        for item in bufs.iter_mut() {
+            *item = None;
+        }
     }
 }
 
@@ -189,10 +192,7 @@ impl Communicator for LocalCommunicator {
 
         // 7. Clear staging board
         if self.rank == 0 {
-            let mut bufs = self.shared.buffers.lock().unwrap();
-            for item in bufs.iter_mut() {
-                *item = None;
-            }
+            self.clear_staging();
         }
 
         // 8. Barrier sync post clear
@@ -236,8 +236,7 @@ impl Communicator for LocalCommunicator {
         self.barrier();
 
         if self.rank == root {
-            let mut bufs = self.shared.buffers.lock().unwrap();
-            bufs[root] = None;
+            self.clear_staging();
         }
 
         self.barrier();
@@ -275,7 +274,8 @@ impl Communicator for LocalCommunicator {
         {
             let bufs = self.shared.buffers.lock().unwrap();
             for r in 0..self.size {
-                let r_data = bufs[r].as_ref().unwrap().downcast_ref::<Vec<T>>().unwrap();
+                let r_data = Self::slot_vec_ref::<T>(&bufs[r], r, "all_gather");
+                Self::assert_numel(r_data.len(), numel, r, "all_gather");
                 copy_host_slice_to_tensor(r_data, &mut output[r], backend);
             }
         }
@@ -283,10 +283,7 @@ impl Communicator for LocalCommunicator {
         self.barrier();
 
         if self.rank == 0 {
-            let mut bufs = self.shared.buffers.lock().unwrap();
-            for item in bufs.iter_mut() {
-                *item = None;
-            }
+            self.clear_staging();
         }
 
         self.barrier();
@@ -340,10 +337,7 @@ impl Communicator for LocalCommunicator {
 
         // 5. Clear staging board
         if self.rank == root {
-            let mut bufs = self.shared.buffers.lock().unwrap();
-            for item in bufs.iter_mut() {
-                *item = None;
-            }
+            self.clear_staging();
         }
 
         // 6. Barrier sync post clear
@@ -390,7 +384,8 @@ impl Communicator for LocalCommunicator {
         if self.rank == root {
             let bufs = self.shared.buffers.lock().unwrap();
             for r in 0..self.size {
-                let r_data = bufs[r].as_ref().unwrap().downcast_ref::<Vec<T>>().unwrap();
+                let r_data = Self::slot_vec_ref::<T>(&bufs[r], r, "gather");
+                Self::assert_numel(r_data.len(), numel, r, "gather");
                 copy_host_slice_to_tensor(r_data, &mut output[r], backend);
             }
         }
@@ -398,10 +393,7 @@ impl Communicator for LocalCommunicator {
         self.barrier();
 
         if self.rank == root {
-            let mut bufs = self.shared.buffers.lock().unwrap();
-            for item in bufs.iter_mut() {
-                *item = None;
-            }
+            self.clear_staging();
         }
 
         self.barrier();
@@ -433,6 +425,12 @@ impl Communicator for LocalCommunicator {
         if self.rank == root {
             let mut bufs = self.shared.buffers.lock().unwrap();
             for r in 0..self.size {
+                assert_eq!(
+                    input[r].numel(),
+                    numel,
+                    "LocalCommunicator scatter input numel mismatch on root at rank {}",
+                    r
+                );
                 let host_data = get_tensor_host_data(&input[r], backend).into_owned();
                 bufs[r] = Some(Box::new(host_data));
             }
@@ -451,10 +449,7 @@ impl Communicator for LocalCommunicator {
         self.barrier();
 
         if self.rank == root {
-            let mut bufs = self.shared.buffers.lock().unwrap();
-            for item in bufs.iter_mut() {
-                *item = None;
-            }
+            self.clear_staging();
         }
 
         self.barrier();

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -225,6 +225,34 @@ fn test_local_scatter() {
 }
 
 #[test]
+fn test_local_scatter_mismatched_input_numel_panics() {
+    let world_size = 2;
+    let communicators = LocalCommunicator::create_cluster(world_size);
+    let mut handles = vec![];
+
+    for comm in communicators {
+        handles.push(thread::spawn(move || {
+            let backend = SequentialBackend::new();
+            let mut tensor = Tensor::zeros_on([2], &backend);
+            let input = if comm.rank() == 0 {
+                vec![
+                    Tensor::from_slice_on([2], &[1.0f32, 2.0], &backend),
+                    Tensor::from_slice_on([1], &[3.0f32], &backend),
+                ]
+            } else {
+                vec![]
+            };
+            comm.scatter(&mut tensor, &input, 0, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "scatter with mismatched root input numel should panic on at least one rank"
+    );
+}
+
+#[test]
 fn test_local_all_reduce_sliced() {
     let world_size = 2;
     let communicators = LocalCommunicator::create_cluster(world_size);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,19 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-146: LocalCommunicator collective SSOT hardening [COMPLETE]
+
+- [x] [patch] Extended staged-payload guards to `all_gather` and `gather`
+  (`slot_vec_ref` + `assert_numel`) to remove unchecked `Any` downcasts and
+  enforce explicit payload shape validation.
+- [x] [patch] Added `clear_staging` helper in `coeus-dist/src/local.rs` and
+  reused it across `all_reduce`, `broadcast`, `all_gather`, `reduce`, `gather`,
+  and `scatter` to remove duplicated staging-clear logic.
+- [x] [patch] Added root-side `scatter` input `numel` validation and a focused
+  panic contract test:
+  `coeus-dist/tests/dist_tests.rs::test_local_scatter_mismatched_input_numel_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_local_ -- --nocapture`
+  (13/13 pass); `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-144: LocalCommunicator contention and safety hardening [COMPLETE]
 
 - [x] [patch] Refactored `coeus-dist/src/local.rs::all_reduce` so reduction is

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -17,6 +17,18 @@ idiomatic `loss.backward()`, and land differential PyTorch parity for InstanceNo
 - [x] Removed stale `coeus-python/tests/pycoeus*.pyd` shadowing artifacts.
 - [x] Evidence: `pytest test_pytorch_parity.py` 24/24; `clippy -D warnings` + `fmt` clean.
 
+### Previous Sprint: MS-146 - LocalCommunicator collective SSOT hardening [COMPLETE]
+**Objective**: Complete local collective hardening by removing unchecked staged
+payload reads, deduplicating staging cleanup, and enforcing scatter payload
+shape contracts.
+
+- [x] [patch] Applied staged payload guards to `all_gather` and `gather`.
+- [x] [patch] Added and reused `clear_staging` helper across local collectives.
+- [x] [patch] Added `scatter` root input `numel` validation and panic contract
+  coverage (`test_local_scatter_mismatched_input_numel_panics`).
+- [x] Evidence: `cargo test -p coeus-dist test_local_ -- --nocapture` passes
+  13/13; `cargo clippy -p coeus-dist --all-targets -- -D warnings` passes.
+
 ### Previous Sprint: MS-144 - LocalCommunicator contention and safety hardening [COMPLETE]
 **Objective**: Resolve a distributed-runtime hotspot by eliminating redundant
 `all_reduce` work across ranks, hardening staged payload validation, and


### PR DESCRIPTION
## Summary
- add guarded staged payload reads to LocalCommunicator all_gather/gather
- deduplicate staging clear paths via clear_staging helper
- enforce scatter root input numel contract and add panic contract test
- update backlog/checklist/changelog for MS-146 traceability

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist test_local_ -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the `LocalCommunicator` collective operations by adding staged payload validation to `all_gather` and `gather` operations, deduplicating staging cleanup logic via a new `clear_staging` helper method, and enforcing tensor shape contracts on `scatter` root input with a dedicated panic test. The changes improve safety by removing unchecked downcasts and ensure consistent cleanup patterns across all local collective operations.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `coeus-dist/src/local.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/backlog.md` |
| 5 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->