### PR TITLE
dist: harden tcp collective payload contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@
 
 ### Fixed
 
+- **TcpCommunicator payload-shape contract enforcement** — added shared
+  `TcpCommunicator::assert_numel` checks for `all_gather`, `gather`, and
+  `scatter` so mismatched tensor shapes fail fast with explicit rank-indexed
+  diagnostics instead of late I/O failures.
+- **Tcp root self-path allocation cleanup** — replaced root self
+  `tensor.clone()` assignments in TCP `all_gather`, `gather`, and `scatter`
+  with `get_tensor_host_data` + `copy_host_slice_to_tensor`, preserving
+  preallocated destination tensors and avoiding unnecessary root-side
+  allocations.
+- **TCP mismatch panic-contract tests** — added
+  `test_tcp_all_gather_mismatched_output_numel_panics` and
+  `test_tcp_scatter_mismatched_input_numel_panics` in
+  `coeus-dist/tests/dist_tests.rs`.
 - **Local gather/all-gather staged payload safety** — `LocalCommunicator`
   now validates staged payload type and `numel` in both `all_gather` and
   `gather` via shared helpers, removing unchecked downcasts.

--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -18,6 +18,19 @@ impl TcpCommunicator {
     pub fn new(mesh: TcpMesh) -> Self {
         Self { mesh }
     }
+
+    #[inline]
+    fn assert_numel(
+        collective: &'static str,
+        index: usize,
+        actual_numel: usize,
+        expected_numel: usize,
+    ) {
+        assert_eq!(
+            actual_numel, expected_numel,
+            "{collective} numel mismatch at rank index {index}: expected {expected_numel}, got {actual_numel}",
+        );
+    }
 }
 
 impl Communicator for TcpCommunicator {
@@ -100,11 +113,16 @@ impl Communicator for TcpCommunicator {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
         assert_eq!(output.len(), size, "all_gather output length mismatch");
-        if tensor.numel() == 0 {
+        let numel = tensor.numel();
+        if numel == 0 {
             return;
         }
+        for (idx, out) in output.iter().enumerate().take(size) {
+            Self::assert_numel("all_gather output", idx, out.numel(), numel);
+        }
 
-        output[rank] = tensor.clone();
+        let self_host_data = get_tensor_host_data(tensor, backend);
+        copy_host_slice_to_tensor(&self_host_data, &mut output[rank], backend);
 
         with_tensor_host_bytes(tensor, backend, |send_raw_slice| {
             for (other, out_tensor) in output.iter_mut().enumerate().take(size) {
@@ -175,13 +193,18 @@ impl Communicator for TcpCommunicator {
     ) {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
-        if tensor.numel() == 0 {
+        let numel = tensor.numel();
+        if numel == 0 {
             return;
         }
 
         if rank == root {
             assert_eq!(output.len(), size, "gather output length mismatch on root");
-            output[root] = tensor.clone();
+            for (idx, out) in output.iter().enumerate().take(size) {
+                Self::assert_numel("gather output", idx, out.numel(), numel);
+            }
+            let self_host_data = get_tensor_host_data(tensor, backend);
+            copy_host_slice_to_tensor(&self_host_data, &mut output[root], backend);
 
             for (other, out_tensor) in output.iter_mut().enumerate().take(size) {
                 if other != root {
@@ -206,13 +229,18 @@ impl Communicator for TcpCommunicator {
     ) {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
-        if tensor.numel() == 0 {
+        let numel = tensor.numel();
+        if numel == 0 {
             return;
         }
 
         if rank == root {
             assert_eq!(input.len(), size, "scatter input length mismatch on root");
-            *tensor = input[root].clone();
+            for (idx, in_tensor) in input.iter().enumerate().take(size) {
+                Self::assert_numel("scatter input", idx, in_tensor.numel(), numel);
+            }
+            let self_host_data = get_tensor_host_data(&input[root], backend);
+            copy_host_slice_to_tensor(&self_host_data, tensor, backend);
 
             for (other, in_tensor) in input.iter().enumerate().take(size) {
                 if other != root {

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -555,6 +555,32 @@ fn test_tcp_scatter() {
     }
 }
 
+#[test]
+#[should_panic(expected = "all_gather output numel mismatch")]
+fn test_tcp_all_gather_mismatched_output_numel_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+
+    let tensor = Tensor::from_slice_on([2], &[1.0f32, 2.0], &backend);
+    let mut output = vec![Tensor::zeros_on([1], &backend)];
+    comm.all_gather(&tensor, &mut output, &backend);
+}
+
+#[test]
+#[should_panic(expected = "scatter input numel mismatch")]
+fn test_tcp_scatter_mismatched_input_numel_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+
+    let mut tensor = Tensor::zeros_on([2], &backend);
+    let input = vec![Tensor::from_slice_on([1], &[3.0f32], &backend)];
+    comm.scatter(&mut tensor, &input, 0, &backend);
+}
+
 // ── all_reduce with Max / Min / Product reduce ops ──
 //
 // world_size = 3, rank r contributes [r+1, r+2] -> ranks [1,2], [2,3], [3,4].

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,21 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-147: TcpCommunicator staging contract hardening [COMPLETE]
+
+- [x] [patch] Added shared TCP collective numel contract guard
+  (`TcpCommunicator::assert_numel`) and applied it to `all_gather`, `gather`,
+  and `scatter` to fail fast on payload shape mismatches.
+- [x] [patch] Removed allocation-heavy root self-copy paths in `all_gather`,
+  `gather`, and `scatter` by replacing `tensor.clone()` assignment with
+  `get_tensor_host_data` + `copy_host_slice_to_tensor`, preserving preallocated
+  output tensors and reducing avoidable allocations.
+- [x] [patch] Added focused panic-contract tests:
+  `test_tcp_all_gather_mismatched_output_numel_panics` and
+  `test_tcp_scatter_mismatched_input_numel_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_all_gather -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_scatter -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-146: LocalCommunicator collective SSOT hardening [COMPLETE]
 
 - [x] [patch] Extended staged-payload guards to `all_gather` and `gather`

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -17,6 +17,22 @@ idiomatic `loss.backward()`, and land differential PyTorch parity for InstanceNo
 - [x] Removed stale `coeus-python/tests/pycoeus*.pyd` shadowing artifacts.
 - [x] Evidence: `pytest test_pytorch_parity.py` 24/24; `clippy -D warnings` + `fmt` clean.
 
+### Previous Sprint: MS-147 - TcpCommunicator staging contract hardening [COMPLETE]
+**Objective**: Harden TCP collective payload contracts to fail fast on shape
+mismatches and reduce redundant allocation/copy patterns in root self-paths.
+
+- [x] [patch] Added shared TCP collective numel contract checks and applied them
+  to `all_gather`, `gather`, and `scatter`.
+- [x] [patch] Replaced root self `tensor.clone()` assignments with
+  `get_tensor_host_data` + `copy_host_slice_to_tensor` to preserve preallocated
+  outputs and reduce avoidable allocations.
+- [x] [patch] Added panic-contract coverage for TCP mismatch paths
+  (`test_tcp_all_gather_mismatched_output_numel_panics`,
+  `test_tcp_scatter_mismatched_input_numel_panics`).
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_all_gather -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_scatter -- --nocapture`; `cargo clippy
+  -p coeus-dist --all-targets -- -D warnings`.
+
 ### Previous Sprint: MS-146 - LocalCommunicator collective SSOT hardening [COMPLETE]
 **Objective**: Complete local collective hardening by removing unchecked staged
 payload reads, deduplicating staging cleanup, and enforcing scatter payload


### PR DESCRIPTION
## Summary
- add rank-indexed numel contract checks for tcp all_gather/gather/scatter
- replace root self clone assignment paths with copy into preallocated tensors
- add panic-contract tests for tcp mismatch cases
- update backlog/checklist/changelog for MS-147

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist test_tcp_all_gather -- --nocapture
- cargo test -p coeus-dist test_tcp_scatter -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the TCP collective operations (`all_gather`, `gather`, and `scatter`) by adding strict payload shape validation that fails fast with clear diagnostics when tensor dimensions mismatch across ranks, and replaces inefficient root self-copy patterns that used `clone()` with direct memory copy operations using preallocated buffers. Two new panic-contract tests verify that the validation correctly catches mismatched tensor shapes in `all_gather` and `scatter` operations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/tcp/collectives.rs` |
| 2 | `coeus-dist/tests/dist_tests.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/backlog.md` |
| 5 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->