### PR TITLE
dist: harden tcp mesh and root invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@
 
 ### Fixed
 
+- **TcpMesh peer-invariant enforcement** — added shared
+  `TcpMesh::stream_for_peer` guardrails and routed `send`/`recv` through bounds,
+  self-peer, and stream-established checks for explicit failure diagnostics.
+- **TcpMesh constructor invariant** — `TcpMesh::new` now asserts `rank < size`
+  before binding/connection setup.
+- **Tcp collective root bounds** — added shared `TcpCommunicator::assert_root`
+  and enforced root bounds in `broadcast`, `reduce`, `gather`, and `scatter`.
+- **TCP invariant panic-contract tests** — added
+  `test_tcp_broadcast_root_out_of_bounds_panics`,
+  `test_tcp_mesh_send_self_panics`, and `test_tcp_mesh_recv_self_panics`.
 - **TcpCommunicator payload-shape contract enforcement** — added shared
   `TcpCommunicator::assert_numel` checks for `all_gather`, `gather`, and
   `scatter` so mismatched tensor shapes fail fast with explicit rank-indexed

--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -31,6 +31,11 @@ impl TcpCommunicator {
             "{collective} numel mismatch at rank index {index}: expected {expected_numel}, got {actual_numel}",
         );
     }
+
+    #[inline]
+    fn assert_root(root: usize, size: usize) {
+        assert!(root < size, "collective root out of bounds");
+    }
 }
 
 impl Communicator for TcpCommunicator {
@@ -82,6 +87,7 @@ impl Communicator for TcpCommunicator {
     ) {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
+        Self::assert_root(root, size);
         if size <= 1 {
             return;
         }
@@ -154,6 +160,7 @@ impl Communicator for TcpCommunicator {
     ) {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
+        Self::assert_root(root, size);
         if size <= 1 {
             return;
         }
@@ -193,6 +200,7 @@ impl Communicator for TcpCommunicator {
     ) {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
+        Self::assert_root(root, size);
         let numel = tensor.numel();
         if numel == 0 {
             return;
@@ -229,6 +237,7 @@ impl Communicator for TcpCommunicator {
     ) {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
+        Self::assert_root(root, size);
         let numel = tensor.numel();
         if numel == 0 {
             return;

--- a/coeus-dist/src/tcp/mesh.rs
+++ b/coeus-dist/src/tcp/mesh.rs
@@ -13,6 +13,7 @@ pub struct TcpMesh {
 impl TcpMesh {
     /// Create a new TCP mesh connecting all ranks.
     pub fn new(rank: usize, size: usize, addresses: &[SocketAddr]) -> Self {
+        assert!(rank < size, "rank must be less than world size");
         assert_eq!(
             addresses.len(),
             size,
@@ -80,6 +81,15 @@ impl TcpMesh {
         }
     }
 
+    #[inline]
+    fn stream_for_peer(&self, peer: usize, op: &'static str) -> &Mutex<TcpStream> {
+        assert!(peer < self.size, "{op} peer out of bounds");
+        assert!(peer != self.rank, "{op} peer must differ from local rank");
+        self.streams[peer]
+            .as_ref()
+            .unwrap_or_else(|| panic!("{op} stream not established for peer {peer}"))
+    }
+
     /// Access local rank.
     #[inline]
     pub fn rank(&self) -> usize {
@@ -95,7 +105,7 @@ impl TcpMesh {
     /// Send raw bytes to a target rank.
     #[inline]
     pub fn send(&self, target: usize, bytes: &[u8]) {
-        let stream_mutex = self.streams[target].as_ref().expect("stream not found");
+        let stream_mutex = self.stream_for_peer(target, "send");
         let mut stream = stream_mutex.lock().unwrap();
         moirai::global().block_on(async {
             stream
@@ -108,7 +118,7 @@ impl TcpMesh {
     /// Receive raw bytes from a source rank.
     #[inline]
     pub fn recv(&self, source: usize, bytes: &mut [u8]) {
-        let stream_mutex = self.streams[source].as_ref().expect("stream not found");
+        let stream_mutex = self.stream_for_peer(source, "recv");
         let mut stream = stream_mutex.lock().unwrap();
         moirai::global().block_on(async {
             stream

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -581,6 +581,34 @@ fn test_tcp_scatter_mismatched_input_numel_panics() {
     comm.scatter(&mut tensor, &input, 0, &backend);
 }
 
+#[test]
+#[should_panic(expected = "collective root out of bounds")]
+fn test_tcp_broadcast_root_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let mut tensor = Tensor::from_slice_on([1], &[1.0f32], &backend);
+    comm.broadcast(&mut tensor, 1, &backend);
+}
+
+#[test]
+#[should_panic(expected = "send peer must differ from local rank")]
+fn test_tcp_mesh_send_self_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    mesh.send(0, &[1u8]);
+}
+
+#[test]
+#[should_panic(expected = "recv peer must differ from local rank")]
+fn test_tcp_mesh_recv_self_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let mut byte = [0u8; 1];
+    mesh.recv(0, &mut byte);
+}
+
 // ── all_reduce with Max / Min / Product reduce ops ──
 //
 // world_size = 3, rank r contributes [r+1, r+2] -> ranks [1,2], [2,3], [3,4].

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,20 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-148: TcpMesh/collective invariant hardening [COMPLETE]
+
+- [x] [patch] Added `TcpMesh` peer-invariant guardrail via shared
+  `stream_for_peer` (`peer < size`, `peer != rank`, stream established) and
+  routed `send`/`recv` through it for explicit fail-fast diagnostics.
+- [x] [patch] Added `TcpMesh::new` invariant `rank < size`.
+- [x] [patch] Added shared `TcpCommunicator::assert_root` and enforced root
+  bounds in `broadcast`, `reduce`, `gather`, and `scatter`.
+- [x] [patch] Added panic-contract coverage:
+  `test_tcp_broadcast_root_out_of_bounds_panics`,
+  `test_tcp_mesh_send_self_panics`, and `test_tcp_mesh_recv_self_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_mesh_ -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_broadcast_root_out_of_bounds_panics -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-152: FeedForward binding module split [COMPLETE]
 
 - [x] [patch] Promoted `coeus-python/src/nn/feedforward.rs` to

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -24,6 +24,22 @@ vertical module tree while preserving the public PyO3 export surface.
   `D:\miniforge3\python.exe -m pytest coeus-python/tests/test_pytorch_parity.py -q`
   (27/27).
 
+### Previous Sprint: MS-148 - TcpMesh/collective invariant hardening [COMPLETE]
+**Objective**: Harden TCP distributed-runtime safety contracts by enforcing peer
+and root invariants explicitly at the mesh/collective boundaries.
+
+- [x] [patch] Added `TcpMesh` shared peer guard path (`stream_for_peer`) and
+  routed `send`/`recv` through explicit peer/rank/stream checks.
+- [x] [patch] Added `rank < size` invariant in `TcpMesh::new`.
+- [x] [patch] Added shared `TcpCommunicator::assert_root` and enforced root
+  bounds in `broadcast`, `reduce`, `gather`, and `scatter`.
+- [x] [patch] Added panic-contract tests
+  (`test_tcp_broadcast_root_out_of_bounds_panics`,
+  `test_tcp_mesh_send_self_panics`, `test_tcp_mesh_recv_self_panics`).
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_mesh_ -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_broadcast_root_out_of_bounds_panics -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ### Previous Sprint: MS-151 - MaxPool2d/AvgPool2d PyTorch differential parity [COMPLETE]
 **Objective**: Add value-semantic forward+backward differential parity for 2D
 pooling, previously absent from the PyTorch parity suite (only binding smoke tests).


### PR DESCRIPTION
## Summary
- add shared TcpMesh peer invariant guard path and route send/recv through it
- enforce rank<size in TcpMesh::new
- add shared TCP collective root-bounds checks for broadcast/reduce/gather/scatter
- add panic-contract tests for invalid root and self-peer mesh operations
- update backlog/checklist/changelog for MS-148 traceability

## Validation
- cargo test -p coeus-dist test_tcp_mesh_ -- --nocapture
- cargo test -p coeus-dist test_tcp_broadcast_root_out_of_bounds_panics -- --nocapture
- cargo test -p coeus-dist test_tcp_all_gather_mismatched_output_numel_panics -- --nocapture
- cargo test -p coeus-dist test_tcp_scatter_mismatched_input_numel_panics -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the distributed TCP runtime by adding explicit invariant checks and guardrails for safe peer-to-peer communication and collective operations. The changes enforce that peer ranks are valid (within bounds and not self), that ranks are less than world size during `TcpMesh` construction, and that collective operation root ranks are within bounds. A shared `stream_for_peer` method centralizes peer validation for send/receive operations, while a shared `assert_root` method validates root parameters in broadcast, reduce, gather, and scatter. Three new panic-contract tests verify the enforcement of these invariants, ensuring fail-fast behavior with explicit diagnostics when invalid parameters are provided.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/tcp/mesh.rs` |
| 2 | `coeus-dist/src/tcp/collectives.rs` |
| 3 | `coeus-dist/tests/dist_tests.rs` |
| 4 | `CHANGELOG.md` |
| 5 | `docs/backlog.md` |
| 6 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for TCP mesh and collective operations to prevent invalid peer, root, and rank values.
  * Sending or receiving to the local peer now fails clearly, and out-of-range collective roots are rejected.
  * Improved error handling for uninitialized peer streams with more specific failures.
* **Tests**
  * Added coverage for invalid root values and self-send/self-receive failures.
* **Documentation**
  * Updated release notes and checklists to reflect the new TCP invariant checks and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->