### PR TITLE
dist: complete tcp mesh contract hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@
 
 ### Fixed
 
+- **TcpMesh duplicate stream-slot guardrails** — `TcpMesh::new` now asserts that
+  outgoing and incoming stream slots are unpopulated before assignment, making
+  malformed or duplicated peer-handshake paths fail fast.
+- **TCP mesh bounds panic-contract tests** — added
+  `test_tcp_mesh_send_out_of_bounds_panics`,
+  `test_tcp_mesh_recv_out_of_bounds_panics`, and
+  `test_tcp_mesh_new_rank_out_of_bounds_panics`.
 - **TcpMesh peer-invariant enforcement** — added shared
   `TcpMesh::stream_for_peer` guardrails and routed `send`/`recv` through bounds,
   self-peer, and stream-established checks for explicit failure diagnostics.

--- a/coeus-dist/src/tcp/mesh.rs
+++ b/coeus-dist/src/tcp/mesh.rs
@@ -49,6 +49,10 @@ impl TcpMesh {
                         }
                     }
                 };
+                assert!(
+                    streams[other].is_none(),
+                    "outgoing stream slot already populated for peer {other}"
+                );
                 streams[other] = Some(Mutex::new(stream));
             }
 
@@ -69,6 +73,10 @@ impl TcpMesh {
                 assert!(
                     incoming_rank < rank,
                     "incoming rank must be less than current rank"
+                );
+                assert!(
+                    streams[incoming_rank].is_none(),
+                    "incoming stream slot already populated for peer {incoming_rank}"
                 );
                 streams[incoming_rank] = Some(Mutex::new(s_mut));
             }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -609,6 +609,30 @@ fn test_tcp_mesh_recv_self_panics() {
     mesh.recv(0, &mut byte);
 }
 
+#[test]
+#[should_panic(expected = "send peer out of bounds")]
+fn test_tcp_mesh_send_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    mesh.send(1, &[1u8]);
+}
+
+#[test]
+#[should_panic(expected = "recv peer out of bounds")]
+fn test_tcp_mesh_recv_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let mut byte = [0u8; 1];
+    mesh.recv(1, &mut byte);
+}
+
+#[test]
+#[should_panic(expected = "rank must be less than world size")]
+fn test_tcp_mesh_new_rank_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let _mesh = TcpMesh::new(1, 1, &addresses);
+}
+
 // ── all_reduce with Max / Min / Product reduce ops ──
 //
 // world_size = 3, rank r contributes [r+1, r+2] -> ranks [1,2], [2,3], [3,4].

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,18 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-149: TcpMesh contract completion [COMPLETE]
+
+- [x] [patch] Added defensive duplicate-slot guards in `TcpMesh::new` for both
+  outgoing and incoming stream assignment paths.
+- [x] [patch] Added panic-contract coverage for mesh bounds and constructor
+  invariants:
+  `test_tcp_mesh_send_out_of_bounds_panics`,
+  `test_tcp_mesh_recv_out_of_bounds_panics`, and
+  `test_tcp_mesh_new_rank_out_of_bounds_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_mesh_ -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_mesh_new_rank_out_of_bounds_panics -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-148: TcpMesh/collective invariant hardening [COMPLETE]
 
 - [x] [patch] Added `TcpMesh` peer-invariant guardrail via shared

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -24,6 +24,18 @@ vertical module tree while preserving the public PyO3 export surface.
   `D:\miniforge3\python.exe -m pytest coeus-python/tests/test_pytorch_parity.py -q`
   (27/27).
 
+### Previous Sprint: MS-149 - TcpMesh contract completion [COMPLETE]
+**Objective**: Complete TCP mesh contract hardening with defensive slot
+invariants and explicit panic-contract coverage for bounds/constructor errors.
+
+- [x] [patch] Added duplicate-slot guards in `TcpMesh::new` for outgoing and
+  incoming stream assignment.
+- [x] [patch] Added panic-contract tests for send/recv out-of-bounds and
+  constructor rank bounds.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_mesh_ -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_mesh_new_rank_out_of_bounds_panics -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ### Previous Sprint: MS-148 - TcpMesh/collective invariant hardening [COMPLETE]
 **Objective**: Harden TCP distributed-runtime safety contracts by enforcing peer
 and root invariants explicitly at the mesh/collective boundaries.


### PR DESCRIPTION
## Summary
- add defensive duplicate stream-slot guards in TcpMesh::new
- add panic-contract tests for tcp mesh send/recv out-of-bounds
- add panic-contract test for TcpMesh::new rank bound invariant
- update backlog/checklist/changelog/plan for MS-149

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist test_tcp_mesh_ -- --nocapture
- cargo test -p coeus-dist test_tcp_mesh_new_rank_out_of_bounds_panics -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes the contract hardening for `TcpMesh` by adding defensive duplicate stream-slot guards in the `TcpMesh::new` constructor to ensure outgoing and incoming stream slots are unpopulated before assignment. It also adds panic-contract tests to verify that out-of-bounds peer access and invalid rank initialization properly panic with clear error messages. Documentation is updated to reflect completion of milestone MS-149.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/tcp/mesh.rs` |
| 2 | `coeus-dist/tests/dist_tests.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/checklist.md` |
| 5 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->