### PR TITLE
dist: complete tcp rooted-collective panic contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
 
 ### Fixed
 
+- **TCP rooted-collective root panic coverage completion** — added
+  `test_tcp_reduce_root_out_of_bounds_panics`,
+  `test_tcp_gather_root_out_of_bounds_panics`, and
+  `test_tcp_scatter_root_out_of_bounds_panics` so `broadcast/reduce/gather/scatter`
+  all have explicit root-bound panic contracts.
 - **TcpMesh duplicate stream-slot guardrails** — `TcpMesh::new` now asserts that
   outgoing and incoming stream slots are unpopulated before assignment, making
   malformed or duplicated peer-handshake paths fail fast.

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -593,6 +593,41 @@ fn test_tcp_broadcast_root_out_of_bounds_panics() {
 }
 
 #[test]
+#[should_panic(expected = "collective root out of bounds")]
+fn test_tcp_reduce_root_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let mut tensor = Tensor::from_slice_on([1], &[1.0f32], &backend);
+    comm.reduce::<f32, _, Sum>(&mut tensor, 1, &backend);
+}
+
+#[test]
+#[should_panic(expected = "collective root out of bounds")]
+fn test_tcp_gather_root_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let tensor = Tensor::from_slice_on([1], &[1.0f32], &backend);
+    let mut output = vec![Tensor::zeros_on([1], &backend)];
+    comm.gather(&tensor, &mut output, 1, &backend);
+}
+
+#[test]
+#[should_panic(expected = "collective root out of bounds")]
+fn test_tcp_scatter_root_out_of_bounds_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let mut tensor = Tensor::zeros_on([1], &backend);
+    let input = vec![Tensor::from_slice_on([1], &[1.0f32], &backend)];
+    comm.scatter(&mut tensor, &input, 1, &backend);
+}
+
+#[test]
 #[should_panic(expected = "send peer must differ from local rank")]
 fn test_tcp_mesh_send_self_panics() {
     let addresses = get_free_ports(1);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,15 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-150: TCP collective root contract completion [COMPLETE]
+
+- [x] [patch] Added explicit panic-contract tests for TCP root out-of-bounds
+  paths across all rooted collectives:
+  `test_tcp_reduce_root_out_of_bounds_panics`,
+  `test_tcp_gather_root_out_of_bounds_panics`,
+  `test_tcp_scatter_root_out_of_bounds_panics`.
+- [x] Evidence: `cargo test -p coeus-dist root_out_of_bounds_panics -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-149: TcpMesh contract completion [COMPLETE]
 
 - [x] [patch] Added defensive duplicate-slot guards in `TcpMesh::new` for both

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -24,6 +24,15 @@ vertical module tree while preserving the public PyO3 export surface.
   `D:\miniforge3\python.exe -m pytest coeus-python/tests/test_pytorch_parity.py -q`
   (27/27).
 
+### Previous Sprint: MS-150 - TCP collective root contract completion [COMPLETE]
+**Objective**: Close remaining root-out-of-bounds panic-contract gaps across TCP
+collectives for complete rooted-op safety coverage.
+
+- [x] [patch] Added root-out-of-bounds panic tests for TCP `reduce`, `gather`,
+  and `scatter`.
+- [x] Evidence: `cargo test -p coeus-dist root_out_of_bounds_panics -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ### Previous Sprint: MS-149 - TcpMesh contract completion [COMPLETE]
 **Objective**: Complete TCP mesh contract hardening with defensive slot
 invariants and explicit panic-contract coverage for bounds/constructor errors.


### PR DESCRIPTION
## Summary
- add root-out-of-bounds panic tests for tcp reduce/gather/scatter
- complete rooted collective panic-contract coverage across broadcast/reduce/gather/scatter
- update backlog/checklist/changelog/plan for MS-150

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist root_out_of_bounds_panics -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes the panic-contract test coverage for TCP rooted collective operations by adding three missing root-out-of-bounds panic tests for `reduce`, `gather`, and `scatter` operations. This ensures all rooted collectives (`broadcast`, `reduce`, `gather`, `scatter`) now have explicit validation that they panic correctly when the root parameter exceeds the communicator size. The changes also update project documentation (backlog, checklist, and changelog) to reflect the completion of milestone MS-150.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->