### PR TITLE
docs(cuda): Add missing doc comments to 90 public items

### DIFF
--- a/coeus-cuda/src/backend/mod.rs
+++ b/coeus-cuda/src/backend/mod.rs
@@ -5,7 +5,9 @@ use std::sync::OnceLock;
 
 pub mod ops;
 
+/// Trait combining [`Scalar`] with the CUDA type-name mapping required for kernel codegen.
 pub trait CudaScalar: Scalar + leto_ops::Scalar {
+    /// CUDA C type name string used in NVRTC-compiled kernel source.
     const CUDA_TYPE: &'static str;
 }
 
@@ -45,6 +47,7 @@ pub struct CudaBackend;
 impl coeus_core::backend::private::Sealed for CudaBackend {}
 
 impl CudaBackend {
+    /// Construct a new CUDA backend instance.
     pub const fn new() -> Self {
         Self
     }

--- a/coeus-cuda/src/driver.rs
+++ b/coeus-cuda/src/driver.rs
@@ -1,46 +1,66 @@
 use libloading::Library;
 use std::sync::{Arc, OnceLock};
 
+/// CUDA device ordinal type alias matching the C API.
 pub type CUdevice = i32;
+/// CUDA context handle type alias matching the C API.
 pub type CUcontext = *mut std::ffi::c_void;
+/// CUDA device pointer type alias matching the C API.
 pub type CUdeviceptr = u64;
+/// CUDA driver API result code type alias matching the C API.
 pub type CUresult = i32;
+/// CUDA module handle type alias matching the C API.
 pub type CUmodule = *mut std::ffi::c_void;
+/// CUDA kernel function handle type alias matching the C API.
 pub type CUfunction = *mut std::ffi::c_void;
+/// CUDA stream handle type alias matching the C API.
 pub type CUstream = *mut std::ffi::c_void;
 
 /// Dynamically loaded CUDA driver function pointers.
 pub struct CudaDriver {
+    /// Owning handle to the dynamically loaded CUDA driver library.
     _lib: Library,
+    /// Function pointer to `cuInit` — initializes the CUDA driver API.
     pub cu_init: unsafe extern "C" fn(flags: u32) -> CUresult,
+    /// Function pointer to `cuDeviceGet` — retrieves a device handle by ordinal.
     pub cu_device_get: unsafe extern "C" fn(device: *mut CUdevice, ordinal: i32) -> CUresult,
+    /// Function pointer to `cuCtxCreate` — creates a CUDA execution context.
     pub cu_ctx_create:
         unsafe extern "C" fn(pctx: *mut CUcontext, flags: u32, dev: CUdevice) -> CUresult,
+    /// Function pointer to `cuMemAlloc` — allocates device memory.
     pub cu_mem_alloc: unsafe extern "C" fn(dptr: *mut CUdeviceptr, bytesize: usize) -> CUresult,
+    /// Function pointer to `cuMemFree` — frees device memory.
     pub cu_mem_free: unsafe extern "C" fn(dptr: CUdeviceptr) -> CUresult,
+    /// Function pointer to `cuMemcpyHtoD` — copies data from host to device.
     pub cu_memcpy_htod: unsafe extern "C" fn(
         dst_device: CUdeviceptr,
         src_host: *const std::ffi::c_void,
         byte_count: usize,
     ) -> CUresult,
+    /// Function pointer to `cuMemcpyDtoH` — copies data from device to host.
     pub cu_memcpy_dtoh: unsafe extern "C" fn(
         dst_host: *mut std::ffi::c_void,
         src_device: CUdeviceptr,
         byte_count: usize,
     ) -> CUresult,
+    /// Function pointer to `cuMemcpyDtoD` — copies data between device buffers.
     pub cu_memcpy_dtod: unsafe extern "C" fn(
         dst_device: CUdeviceptr,
         src_device: CUdeviceptr,
         byte_count: usize,
     ) -> CUresult,
+    /// Function pointer to `cuModuleLoadData` — loads a module from an in-memory image.
     pub cu_module_load_data:
         unsafe extern "C" fn(module: *mut CUmodule, image: *const std::ffi::c_void) -> CUresult,
+    /// Function pointer to `cuModuleGetFunction` — retrieves a kernel function from a loaded module.
     pub cu_module_get_function: unsafe extern "C" fn(
         hfunc: *mut CUfunction,
         hmod: CUmodule,
         name: *const std::ffi::c_char,
     ) -> CUresult,
+    /// Function pointer to `cuModuleUnload` — unloads a loaded CUDA module.
     pub cu_module_unload: unsafe extern "C" fn(hmod: CUmodule) -> CUresult,
+    /// Function pointer to `cuLaunchKernel` — launches a CUDA kernel on the device.
     #[allow(non_snake_case)]
     pub cu_launch_kernel: unsafe extern "C" fn(
         f: CUfunction,
@@ -289,13 +309,18 @@ pub fn get_borrowed_stream() -> Option<Arc<cuda_core::Stream>> {
 }
 
 #[allow(non_camel_case_types)]
+/// NVRTC program handle type alias matching the C API.
 pub type nvrtcProgram = *mut std::ffi::c_void;
 #[allow(non_camel_case_types)]
+/// NVRTC result code type alias matching the C API.
 pub type nvrtcResult = i32;
 
+/// Dynamically loaded NVRTC library function pointers.
 #[allow(non_snake_case)]
 pub struct NvrtcDriver {
+    /// Owning handle to the dynamically loaded NVRTC library.
     _lib: Library,
+    /// Function pointer to `nvrtcCreateProgram` — creates an NVRTC compilation program.
     pub nvrtcCreateProgram: unsafe extern "C" fn(
         prog: *mut nvrtcProgram,
         src: *const std::ffi::c_char,
@@ -304,26 +329,34 @@ pub struct NvrtcDriver {
         headers: *const *const std::ffi::c_char,
         includeNames: *const *const std::ffi::c_char,
     ) -> nvrtcResult,
+    /// Function pointer to `nvrtcCompileProgram` — compiles an NVRTC program to PTX.
     pub nvrtcCompileProgram: unsafe extern "C" fn(
         prog: nvrtcProgram,
         numOptions: std::ffi::c_int,
         options: *const *const std::ffi::c_char,
     ) -> nvrtcResult,
+    /// Function pointer to `nvrtcGetPTXSize` — retrieves the size of the compiled PTX output.
     pub nvrtcGetPTXSize:
         unsafe extern "C" fn(prog: nvrtcProgram, ptxSize: *mut usize) -> nvrtcResult,
+    /// Function pointer to `nvrtcGetPTX` — retrieves the compiled PTX source string.
     pub nvrtcGetPTX:
         unsafe extern "C" fn(prog: nvrtcProgram, ptx: *mut std::ffi::c_char) -> nvrtcResult,
+    /// Function pointer to `nvrtcGetProgramLogSize` — retrieves the size of the compilation log.
     pub nvrtcGetProgramLogSize:
         unsafe extern "C" fn(prog: nvrtcProgram, logSize: *mut usize) -> nvrtcResult,
+    /// Function pointer to `nvrtcGetProgramLog` — retrieves the compilation log string.
     pub nvrtcGetProgramLog:
         unsafe extern "C" fn(prog: nvrtcProgram, log: *mut std::ffi::c_char) -> nvrtcResult,
+    /// Function pointer to `nvrtcDestroyProgram` — destroys an NVRTC program.
     pub nvrtcDestroyProgram: unsafe extern "C" fn(prog: *mut nvrtcProgram) -> nvrtcResult,
+    /// Function pointer to `nvrtcGetErrorString` — retrieves a human-readable error string.
     pub nvrtcGetErrorString: unsafe extern "C" fn(result: nvrtcResult) -> *const std::ffi::c_char,
 }
 
 static NVRTC_DRIVER: OnceLock<Option<NvrtcDriver>> = OnceLock::new();
 
 impl NvrtcDriver {
+    /// Retrieve a reference to the dynamically loaded NVRTC driver singleton if available.
     #[allow(non_snake_case)]
     pub fn get() -> Option<&'static Self> {
         NVRTC_DRIVER

--- a/coeus-cuda/src/kernels/fuse.rs
+++ b/coeus-cuda/src/kernels/fuse.rs
@@ -38,6 +38,9 @@ impl Drop for SafeCachedKernel {
 // kernel reference regardless of lock type.
 static KERNEL_CACHE: OnceLock<RwLock<HashMap<String, Arc<SafeCachedKernel>>>> = OnceLock::new();
 
+/// Compile a CUDA C source string to PTX using the NVRTC driver.
+///
+/// Returns the PTX assembly string on success or an error message on failure.
 pub fn compile_cuda_to_ptx(src: &str) -> Result<String, String> {
     let nvrtc = NvrtcDriver::get().ok_or_else(|| "NVRTC driver not available".to_string())?;
 

--- a/coeus-cuda/src/kernels/launch_conv.rs
+++ b/coeus-cuda/src/kernels/launch_conv.rs
@@ -5,6 +5,10 @@ use crate::driver::CudaDriver;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the 1-D convolution kernel on the GPU.
+///
+/// Computes forward 1-D convolution with optional bias, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_conv1d(
     input: &CudaStorage<f32>,
     weight: &CudaStorage<f32>,
@@ -76,6 +80,10 @@ pub fn launch_conv1d(
     }
 }
 
+/// Launch the 2-D convolution kernel on the GPU.
+///
+/// Computes forward 2-D convolution with optional bias, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_conv2d(
     input: &CudaStorage<f32>,
     weight: &CudaStorage<f32>,
@@ -147,6 +155,10 @@ pub fn launch_conv2d(
     }
 }
 
+/// Launch the 1-D convolution backward kernel on the GPU.
+///
+/// Computes gradients for input and weight from the 1-D convolution backward pass.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_conv1d_backward(
     grad_out: &CudaStorage<f32>,
     grad_out_layout: &Layout,
@@ -314,6 +326,10 @@ pub fn launch_conv1d_backward(
     true
 }
 
+/// Launch the 2-D convolution backward kernel on the GPU.
+///
+/// Computes gradients for input and weight from the 2-D convolution backward pass.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_conv2d_backward(
     grad_out: &CudaStorage<f32>,
     grad_out_layout: &Layout,
@@ -481,6 +497,10 @@ pub fn launch_conv2d_backward(
     true
 }
 
+/// Launch the 3-D convolution kernel on the GPU.
+///
+/// Computes forward 3-D convolution with optional bias, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_conv3d(
     input: &CudaStorage<f32>,
     weight: &CudaStorage<f32>,
@@ -552,6 +572,10 @@ pub fn launch_conv3d(
     }
 }
 
+/// Launch the 3-D convolution backward kernel on the GPU.
+///
+/// Computes gradients for input and weight from the 3-D convolution backward pass.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_conv3d_backward(
     grad_out: &CudaStorage<f32>,
     grad_out_layout: &Layout,

--- a/coeus-cuda/src/kernels/launch_matmul.rs
+++ b/coeus-cuda/src/kernels/launch_matmul.rs
@@ -3,6 +3,10 @@ use crate::driver::{get_cuda_context, CudaDriver};
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the tiled matrix multiplication kernel on the GPU.
+///
+/// Computes `c = a × b` using the PTX-compiled tiled matmul kernel. Returns `true`
+/// if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_matmul_tiled(
     a: &CudaStorage<f32>,
     b: &CudaStorage<f32>,
@@ -36,31 +40,31 @@ extern "C" __global__ void matmul_kernel(
 ) {
     __shared__ float A_shared[256];
     __shared__ float B_shared[256];
-    
+
     unsigned int tx = threadIdx.x;
     unsigned int ty = threadIdx.y;
     unsigned int bx = blockIdx.x;
     unsigned int by = blockIdx.y;
     unsigned int dx = blockDim.x;
     unsigned int dy = blockDim.y;
-    
+
     unsigned int col = bx * dx + tx;
     unsigned int row = by * dy + ty;
-    
+
     unsigned int m = a_layout.shape[0];
     unsigned int k = a_layout.shape[1];
     unsigned int n = b_layout.shape[1];
-    
+
     unsigned int stride_a_row = a_layout.strides[0];
     unsigned int stride_a_col = a_layout.strides[1];
     unsigned int stride_b_row = b_layout.strides[0];
     unsigned int stride_b_col = b_layout.strides[1];
-    
+
     float sum = 0.0f;
-    
+
     unsigned int num_tiles = (k + 15) / 16;
     unsigned int local_idx = ty * 16 + tx;
-    
+
     for (unsigned int tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
         unsigned int col_a = tile_idx * 16 + tx;
         float val_a = 0.0f;
@@ -69,7 +73,7 @@ extern "C" __global__ void matmul_kernel(
             val_a = a[offset_a];
         }
         A_shared[local_idx] = val_a;
-        
+
         unsigned int row_b = tile_idx * 16 + ty;
         float val_b = 0.0f;
         if (row_b < k && col < n) {
@@ -77,16 +81,16 @@ extern "C" __global__ void matmul_kernel(
             val_b = b[offset_b];
         }
         B_shared[local_idx] = val_b;
-        
+
         __syncthreads();
-        
+
         for (unsigned int i = 0; i < 16; ++i) {
             sum += A_shared[ty * 16 + i] * B_shared[i * 16 + tx];
         }
-        
+
         __syncthreads();
     }
-    
+
     if (row < m && col < n) {
         unsigned int stride_c_row = c_layout.strides[0];
         unsigned int stride_c_col = c_layout.strides[1];

--- a/coeus-cuda/src/kernels/launch_ops.rs
+++ b/coeus-cuda/src/kernels/launch_ops.rs
@@ -6,6 +6,10 @@ use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
 use crate::storage::CudaStorage;
 use coeus_core::{ComputeBackend, Layout};
 
+/// Launch a contiguous binary element-wise kernel on the GPU.
+///
+/// Computes `c = op(a, b)` over `n` contiguous elements. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_contiguous_binary<T: CudaScalar>(
     op: coeus_ops::BinaryOp,
     a: &CudaStorage<T>,
@@ -86,6 +90,10 @@ extern "C" __global__ void contiguous_binary_kernel(
     }
 }
 
+/// Launch a contiguous unary element-wise kernel on the GPU.
+///
+/// Computes `c = op(a)` over `n` contiguous elements. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn launch_contiguous_unary<T: CudaScalar>(
     op: coeus_ops::UnaryOp,
     a: &CudaStorage<T>,
@@ -188,6 +196,11 @@ extern "C" __global__ void contiguous_unary_kernel(
     }
 }
 
+/// Launch a strided binary element-wise kernel on the GPU.
+///
+/// Computes `c = op(a, b)` over `n` elements using the provided layouts for
+/// strided indexing. Returns `true` if the kernel launched successfully, `false`
+/// if the driver or context is unavailable.
 pub fn launch_strided_binary<T: CudaScalar>(
     op: coeus_ops::BinaryOp,
     a: &CudaStorage<T>,
@@ -235,18 +248,18 @@ extern "C" __global__ void binary_strided_kernel(
     GpuLayoutInfo a_layout = layout_infos[0];
     GpuLayoutInfo b_layout = layout_infos[1];
     GpuLayoutInfo c_layout = layout_infos[2];
-    
+
     unsigned int temp = idx;
     unsigned int off_a = a_layout.offset;
     unsigned int off_b = b_layout.offset;
     unsigned int off_c = c_layout.offset;
-    
+
     for (unsigned int d = 0; d < c_layout.ndim; ++d) {{
         unsigned int coord = temp / c_layout.strides[d];
         temp = temp % c_layout.strides[d];
-        
+
         off_c += coord * c_layout.strides[d];
-        
+
         if (d >= c_layout.ndim - a_layout.ndim) {{
             unsigned int ad = d + a_layout.ndim - c_layout.ndim;
             if (a_layout.shape[ad] > 1) {{
@@ -260,7 +273,7 @@ extern "C" __global__ void binary_strided_kernel(
             }}
         }}
     }}
-    
+
     {cuda_type} val_a = a[off_a];
     {cuda_type} val_b = b[off_b];
     c[off_c] = {op_expr};
@@ -322,6 +335,11 @@ extern "C" __global__ void binary_strided_kernel(
     }
 }
 
+/// Launch a strided unary element-wise kernel on the GPU.
+///
+/// Computes `c = op(a)` over `n` elements using the provided layouts for strided
+/// indexing. Returns `true` if the kernel launched successfully, `false` if the
+/// driver or context is unavailable.
 pub fn launch_strided_unary<T: CudaScalar>(
     op: coeus_ops::UnaryOp,
     a: &CudaStorage<T>,
@@ -391,17 +409,17 @@ extern "C" __global__ void unary_strided_kernel(
 
     GpuLayoutInfo a_layout = layout_infos[0];
     GpuLayoutInfo c_layout = layout_infos[1];
-    
+
     unsigned int temp = idx;
     unsigned int off_a = a_layout.offset;
     unsigned int off_c = c_layout.offset;
-    
+
     for (unsigned int d = 0; d < c_layout.ndim; ++d) {{
         unsigned int coord = temp / c_layout.strides[d];
         temp = temp % c_layout.strides[d];
-        
+
         off_c += coord * c_layout.strides[d];
-        
+
         if (d >= c_layout.ndim - a_layout.ndim) {{
             unsigned int ad = d + a_layout.ndim - c_layout.ndim;
             if (a_layout.shape[ad] > 1) {{
@@ -409,7 +427,7 @@ extern "C" __global__ void unary_strided_kernel(
             }}
         }}
     }}
-    
+
     {cuda_type} val_a = a[off_a];
     c[off_c] = {op_expr};
 }}

--- a/coeus-cuda/src/kernels/mod.rs
+++ b/coeus-cuda/src/kernels/mod.rs
@@ -1,12 +1,22 @@
+/// Kernel module for scaled-dot-product attention operations.
 pub mod attention;
+/// Kernel module for transposed convolution operations.
 pub mod conv_transpose;
+/// Kernel module for fused element-wise expression compilation and dispatch.
 pub mod fuse;
+/// Kernel module for convolution kernel launch helpers.
 pub mod launch_conv;
+/// Kernel module for tiled matrix multiplication kernel launch.
 pub mod launch_matmul;
+/// Kernel module for element-wise operator kernel launches.
 pub mod launch_ops;
+/// Kernel module for optimizer step kernels.
 pub mod optim;
+/// Kernel module for pooling operations.
 pub mod pool;
+/// Kernel module for embedded PTX kernel source.
 pub mod ptx;
+/// Kernel module for reduction operations.
 pub mod reduce;
 
 pub use attention::{launch_sdp_attention, launch_sdp_attention_backward};
@@ -37,16 +47,22 @@ use crate::storage::CudaStorage;
 use coeus_core::{ComputeBackend, Layout};
 use std::sync::OnceLock;
 
+/// GPU-side layout descriptor passed to CUDA kernels as a POD struct.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct GpuLayoutInfo {
+    /// Element offset into the underlying buffer.
     pub offset: u32,
+    /// Number of dimensions in the layout.
     pub ndim: u32,
+    /// Per-dimension shape, padded to 8 entries.
     pub shape: [u32; 8],
+    /// Per-dimension strides, padded to 8 entries.
     pub strides: [u32; 8],
 }
 
 impl GpuLayoutInfo {
+    /// Convert a CPU [`Layout`] into a GPU-compatible layout descriptor.
     pub fn from_layout(layout: &Layout) -> Self {
         let mut shape = [0u32; 8];
         let mut strides = [0u32; 8];
@@ -65,6 +81,7 @@ impl GpuLayoutInfo {
     }
 }
 
+/// Create a device buffer containing the serialized GPU layout descriptor.
 pub fn create_layout_buffer(layout: &Layout) -> CudaStorage<u32> {
     let gpu_layout = GpuLayoutInfo::from_layout(layout);
     let size_u32 = std::mem::size_of::<GpuLayoutInfo>() / 4;
@@ -97,6 +114,7 @@ unsafe impl Sync for CudaModuleWrapper {}
 
 static CUDA_MODULE: OnceLock<Option<CudaModuleWrapper>> = OnceLock::new();
 
+/// Retrieve the lazily-loaded CUDA module singleton containing the embedded PTX kernels.
 pub fn get_cuda_module() -> Option<CUmodule> {
     CUDA_MODULE
         .get_or_init(|| {
@@ -121,6 +139,7 @@ pub fn get_cuda_module() -> Option<CUmodule> {
         .map(|wrapper| wrapper.module)
 }
 
+/// Look up a kernel function by name from the loaded CUDA module.
 pub fn get_cuda_function(name: &str) -> Option<CUfunction> {
     let drv = CudaDriver::get()?;
     let module = get_cuda_module()?;

--- a/coeus-cuda/src/kernels/optim/adagrad.rs
+++ b/coeus-cuda/src/kernels/optim/adagrad.rs
@@ -3,6 +3,10 @@ use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the AdaGrad optimizer step kernel on the GPU.
+///
+/// Updates parameters using the AdaGrad accumulation rule. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_adagrad_step(
     param: &mut CudaStorage<f32>,

--- a/coeus-cuda/src/kernels/optim/adam.rs
+++ b/coeus-cuda/src/kernels/optim/adam.rs
@@ -3,6 +3,10 @@ use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the Adam optimizer step kernel on the GPU.
+///
+/// Updates parameters using the Adam first/second moment estimates. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_adam_step(
     param: &mut CudaStorage<f32>,

--- a/coeus-cuda/src/kernels/optim/adamw.rs
+++ b/coeus-cuda/src/kernels/optim/adamw.rs
@@ -3,6 +3,10 @@ use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the AdamW optimizer step kernel on the GPU.
+///
+/// Updates parameters using the AdamW decoupled weight decay rule. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_adamw_step(
     param: &mut CudaStorage<f32>,

--- a/coeus-cuda/src/kernels/optim/mod.rs
+++ b/coeus-cuda/src/kernels/optim/mod.rs
@@ -1,7 +1,12 @@
+/// Kernel module for AdaGrad optimizer step.
 pub mod adagrad;
+/// Kernel module for Adam optimizer step.
 pub mod adam;
+/// Kernel module for AdamW optimizer step.
 pub mod adamw;
+/// Kernel module for RMSprop optimizer step.
 pub mod rmsprop;
+/// Kernel module for SGD optimizer step.
 pub mod sgd;
 
 pub use adagrad::launch_adagrad_step;

--- a/coeus-cuda/src/kernels/optim/rmsprop.rs
+++ b/coeus-cuda/src/kernels/optim/rmsprop.rs
@@ -3,6 +3,10 @@ use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the RMSprop optimizer step kernel on the GPU.
+///
+/// Updates parameters using the RMSprop moving-average squared gradient rule. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_rmsprop_step(
     param: &mut CudaStorage<f32>,

--- a/coeus-cuda/src/kernels/optim/sgd.rs
+++ b/coeus-cuda/src/kernels/optim/sgd.rs
@@ -3,6 +3,10 @@ use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Launch the SGD optimizer step kernel on the GPU.
+///
+/// Updates parameters using the SGD (with optional momentum) update rule. Returns `true` if the
+/// kernel launched successfully, `false` if the driver or context is unavailable.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_sgd_step(
     param: &mut CudaStorage<f32>,

--- a/coeus-cuda/src/kernels/pool/avg.rs
+++ b/coeus-cuda/src/kernels/pool/avg.rs
@@ -7,6 +7,10 @@ use crate::kernels::fuse::get_or_create_kernel;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Dispatch the 2-D average pooling forward kernel on the GPU.
+///
+/// Computes average pooling over 2-D windows with the given kernel size, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_avg_pool2d<T: CudaScalar>(
     input: &CudaStorage<T>,
     input_layout: &Layout,
@@ -140,6 +144,10 @@ extern "C" __global__ void avg_pool2d_kernel(
     }
 }
 
+/// Dispatch the 2-D average pooling backward kernel on the GPU.
+///
+/// Computes input gradients for 2-D average pooling. Returns `true` if the kernel
+/// launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_avg_pool2d_backward<T: CudaScalar>(
     grad_out: &CudaStorage<T>,
     grad_out_layout: &Layout,

--- a/coeus-cuda/src/kernels/pool/avg3d.rs
+++ b/coeus-cuda/src/kernels/pool/avg3d.rs
@@ -7,6 +7,10 @@ use crate::kernels::fuse::get_or_create_kernel;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Dispatch the 3-D average pooling forward kernel on the GPU.
+///
+/// Computes average pooling over 3-D windows with the given kernel size, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_avg_pool3d<T: CudaScalar>(
     input: &CudaStorage<T>,
     input_layout: &Layout,
@@ -148,6 +152,10 @@ extern "C" __global__ void avg_pool3d_kernel(
     }
 }
 
+/// Dispatch the 3-D average pooling backward kernel on the GPU.
+///
+/// Computes input gradients for 3-D average pooling. Returns `true` if the kernel
+/// launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_avg_pool3d_backward<T: CudaScalar>(
     grad_out: &CudaStorage<T>,
     grad_out_layout: &Layout,

--- a/coeus-cuda/src/kernels/pool/max.rs
+++ b/coeus-cuda/src/kernels/pool/max.rs
@@ -7,6 +7,10 @@ use crate::kernels::fuse::get_or_create_kernel;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Dispatch the 2-D max pooling forward kernel on the GPU.
+///
+/// Computes max pooling over 2-D windows with the given kernel size, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_max_pool2d<T: CudaScalar>(
     input: &CudaStorage<T>,
     input_layout: &Layout,
@@ -156,6 +160,10 @@ extern "C" __global__ void max_pool2d_kernel(
     }
 }
 
+/// Dispatch the 2-D max pooling backward kernel on the GPU.
+///
+/// Computes input gradients for 2-D max pooling using the forward input for argmax lookup.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_max_pool2d_backward<T: CudaScalar>(
     grad_out: &CudaStorage<T>,
     grad_out_layout: &Layout,

--- a/coeus-cuda/src/kernels/pool/max3d.rs
+++ b/coeus-cuda/src/kernels/pool/max3d.rs
@@ -7,6 +7,10 @@ use crate::kernels::fuse::get_or_create_kernel;
 use crate::storage::CudaStorage;
 use coeus_core::Layout;
 
+/// Dispatch the 3-D max pooling forward kernel on the GPU.
+///
+/// Computes max pooling over 3-D windows with the given kernel size, stride, padding, and dilation.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_max_pool3d<T: CudaScalar>(
     input: &CudaStorage<T>,
     input_layout: &Layout,
@@ -165,6 +169,10 @@ extern "C" __global__ void max_pool3d_kernel(
     }
 }
 
+/// Dispatch the 3-D max pooling backward kernel on the GPU.
+///
+/// Computes input gradients for 3-D max pooling using the forward input for argmax lookup.
+/// Returns `true` if the kernel launched successfully, `false` if the driver or context is unavailable.
 pub fn dispatch_max_pool3d_backward<T: CudaScalar>(
     grad_out: &CudaStorage<T>,
     grad_out_layout: &Layout,

--- a/coeus-cuda/src/kernels/pool/mod.rs
+++ b/coeus-cuda/src/kernels/pool/mod.rs
@@ -1,6 +1,10 @@
+/// Kernel module for 2-D average pooling.
 pub mod avg;
+/// Kernel module for 3-D average pooling.
 pub mod avg3d;
+/// Kernel module for 2-D max pooling.
 pub mod max;
+/// Kernel module for 3-D max pooling.
 pub mod max3d;
 
 pub use avg::{dispatch_avg_pool2d, dispatch_avg_pool2d_backward};

--- a/coeus-cuda/src/kernels/ptx.rs
+++ b/coeus-cuda/src/kernels/ptx.rs
@@ -1,3 +1,4 @@
 // ── Embedded PTX source for CUDA kernels ──
 
+/// Embedded PTX source string compiled from the hand-written CUDA kernels.
 pub const PTX_SOURCE: &str = include_str!("ptx.ptx");

--- a/coeus-cuda/src/lib.rs
+++ b/coeus-cuda/src/lib.rs
@@ -46,6 +46,7 @@ pub mod driver;
 
 mod fallback;
 #[cfg(feature = "cuda")]
+/// CUDA kernel modules and launch helpers for on-device computation.
 pub mod kernels;
 
 #[cfg(feature = "cuda")]

--- a/coeus-cuda/src/storage.rs
+++ b/coeus-cuda/src/storage.rs
@@ -6,6 +6,7 @@ use themis::{MemoryTier, PlacementHint};
 
 /// Device storage allocated on an NVIDIA GPU using the hephaestus-cuda backend.
 pub struct CudaStorage<T> {
+    /// Reference-counted GPU device buffer backing this storage.
     pub buffer: Arc<CudaBuffer<T>>,
 }
 


### PR DESCRIPTION
Add /// doc comments to all 90 undocumented public items across 21 files in coeus-cuda, resolving the workspace-wide clippy gate blockage from #![deny(missing_docs)].

No code logic changed — only doc comments added.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive documentation comments to 90 previously undocumented public items across 21 files in the `coeus-cuda` crate. All changes are purely additive doc comments (using `///` and `//!` syntax) with no modifications to actual code logic, resolving a workspace-wide Clippy gate blockage caused by the `#![deny(missing_docs)]` lint. The documentation covers backend traits, CUDA driver FFI bindings, kernel launch functions, optimizer steps, pooling operations, and storage structures.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-cuda/src/backend/mod.rs` |
| 2 | `coeus-cuda/src/storage.rs` |
| 3 | `coeus-cuda/src/lib.rs` |
| 4 | `coeus-cuda/src/driver.rs` |
| 5 | `coeus-cuda/src/kernels/mod.rs` |
| 6 | `coeus-cuda/src/kernels/ptx.rs` |
| 7 | `coeus-cuda/src/kernels/fuse.rs` |
| 8 | `coeus-cuda/src/kernels/launch_ops.rs` |
| 9 | `coeus-cuda/src/kernels/launch_matmul.rs` |
| 10 | `coeus-cuda/src/kernels/launch_conv.rs` |
| 11 | `coeus-cuda/src/kernels/pool/mod.rs` |
| 12 | `coeus-cuda/src/kernels/pool/avg.rs` |
| 13 | `coeus-cuda/src/kernels/pool/avg3d.rs` |
| 14 | `coeus-cuda/src/kernels/pool/max.rs` |
| 15 | `coeus-cuda/src/kernels/pool/max3d.rs` |
| 16 | `coeus-cuda/src/kernels/optim/mod.rs` |
| 17 | `coeus-cuda/src/kernels/optim/sgd.rs` |
| 18 | `coeus-cuda/src/kernels/optim/adam.rs` |
| 19 | `coeus-cuda/src/kernels/optim/adamw.rs` |
| 20 | `coeus-cuda/src/kernels/optim/adagrad.rs` |
| 21 | `coeus-cuda/src/kernels/optim/rmsprop.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->