### PR TITLE
dist: enforce tcp rooted contracts on zero-numel paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@
 
 ### Fixed
 
+- **TCP zero-numel rooted contract bypass** — TCP `gather` and `scatter` now
+  enforce root output/input length contracts before the zero-numel fast-return,
+  so invalid rooted call shapes fail fast consistently.
+- **TCP zero-numel rooted panic-contract tests** — added
+  `test_tcp_gather_zero_numel_output_len_mismatch_panics` and
+  `test_tcp_scatter_zero_numel_input_len_mismatch_panics`.
 - **TCP rooted-collective root panic coverage completion** — added
   `test_tcp_reduce_root_out_of_bounds_panics`,
   `test_tcp_gather_root_out_of_bounds_panics`, and

--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -201,13 +201,15 @@ impl Communicator for TcpCommunicator {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
         Self::assert_root(root, size);
+        if rank == root {
+            assert_eq!(output.len(), size, "gather output length mismatch on root");
+        }
         let numel = tensor.numel();
         if numel == 0 {
             return;
         }
 
         if rank == root {
-            assert_eq!(output.len(), size, "gather output length mismatch on root");
             for (idx, out) in output.iter().enumerate().take(size) {
                 Self::assert_numel("gather output", idx, out.numel(), numel);
             }
@@ -238,13 +240,15 @@ impl Communicator for TcpCommunicator {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
         Self::assert_root(root, size);
+        if rank == root {
+            assert_eq!(input.len(), size, "scatter input length mismatch on root");
+        }
         let numel = tensor.numel();
         if numel == 0 {
             return;
         }
 
         if rank == root {
-            assert_eq!(input.len(), size, "scatter input length mismatch on root");
             for (idx, in_tensor) in input.iter().enumerate().take(size) {
                 Self::assert_numel("scatter input", idx, in_tensor.numel(), numel);
             }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -628,6 +628,30 @@ fn test_tcp_scatter_root_out_of_bounds_panics() {
 }
 
 #[test]
+#[should_panic(expected = "gather output length mismatch on root")]
+fn test_tcp_gather_zero_numel_output_len_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let tensor = Tensor::zeros_on([0], &backend);
+    let mut output: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.gather(&tensor, &mut output, 0, &backend);
+}
+
+#[test]
+#[should_panic(expected = "scatter input length mismatch on root")]
+fn test_tcp_scatter_zero_numel_input_len_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let mut tensor = Tensor::zeros_on([0], &backend);
+    let input: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.scatter(&mut tensor, &input, 0, &backend);
+}
+
+#[test]
 #[should_panic(expected = "send peer must differ from local rank")]
 fn test_tcp_mesh_send_self_panics() {
     let addresses = get_free_ports(1);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,17 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-155: TCP zero-numel rooted contract enforcement [COMPLETE]
+
+- [x] [patch] Enforced TCP `gather` root output-length contract before zero-numel
+  early-return, so invalid root output lengths no longer bypass validation.
+- [x] [patch] Enforced TCP `scatter` root input-length contract before zero-numel
+  early-return, so invalid root input lengths no longer bypass validation.
+- [x] [patch] Added panic-contract tests:
+  `test_tcp_gather_zero_numel_output_len_mismatch_panics`,
+  `test_tcp_scatter_zero_numel_input_len_mismatch_panics`.
+- [x] Evidence: `cargo test -p coeus-dist zero_numel_ -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-154: SiLU/Mish gradient value semantics [COMPLETE]
 
 - [x] [patch] Replaced residual existence-only gradient checks in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -18,6 +18,18 @@ including module and non-contiguous view paths.
   `rustup run nightly cargo nextest run -p coeus-nn --test nn_silu_tests --test nn_mish_tests`
   (6/6).
 
+### Previous Sprint: MS-155 - TCP zero-numel rooted contract enforcement [COMPLETE]
+**Objective**: Close rooted-contract bypasses in TCP `gather`/`scatter` where
+zero-numel tensors previously skipped root length validation.
+
+- [x] [patch] Moved root length checks ahead of zero-numel fast-return in TCP
+  `gather` and `scatter`.
+- [x] [patch] Added panic-contract tests for zero-numel mismatch paths
+  (`test_tcp_gather_zero_numel_output_len_mismatch_panics`,
+  `test_tcp_scatter_zero_numel_input_len_mismatch_panics`).
+- [x] Evidence: `cargo test -p coeus-dist zero_numel_ -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ### Previous Sprint: MS-153 - CrossEntropy/NLL loss PyTorch differential parity [COMPLETE]
 **Objective**: Add value-semantic forward+backward differential parity for the
 classification loss path (cross_entropy_loss, nll_loss over log_softmax),


### PR DESCRIPTION
## Summary
- move TCP gather/scatter root length checks ahead of zero-numel early-return
- add panic-contract tests for rooted zero-numel length mismatches
- update backlog/checklist/changelog/plan for MS-155

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist zero_numel_ -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a contract enforcement bug in TCP distributed collectives where `gather` and `scatter` operations would skip root length validation when given zero-element tensors. The fix moves the root length checks before the zero-numel early-return path, ensuring that invalid rooted call shapes now fail consistently regardless of tensor size. Two new panic-contract tests verify that zero-numel tensors with mismatched lengths correctly trigger assertions on the root rank.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `coeus-dist/src/tcp/collectives.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/backlog.md` |
| 5 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->