### PR TITLE
dist: cover tcpmesh constructor address contract

### DIFF
--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -766,6 +766,13 @@ fn test_tcp_mesh_new_rank_out_of_bounds_panics() {
     let _mesh = TcpMesh::new(1, 1, &addresses);
 }
 
+#[test]
+#[should_panic(expected = "addresses list length must match world size")]
+fn test_tcp_mesh_new_addresses_len_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let _mesh = TcpMesh::new(0, 2, &addresses);
+}
+
 // ── all_reduce with Max / Min / Product reduce ops ──
 //
 // world_size = 3, rank r contributes [r+1, r+2] -> ranks [1,2], [2,3], [3,4].

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,16 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-159: TcpMesh constructor contract coverage [COMPLETE]
+
+- [x] [patch] Added panic-contract coverage for constructor input mismatch:
+  `test_tcp_mesh_new_addresses_len_mismatch_panics` asserting the
+  `addresses.len() == world_size` contract.
+- [x] [patch] Retained existing constructor/rank panic coverage
+  (`test_tcp_mesh_new_rank_out_of_bounds_panics`) and validated both
+  invariants together via focused selector.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_mesh_new_ -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-158: Local zero-numel rooted contract coverage [COMPLETE]
 
 - [x] [patch] Added panic-contract tests proving rooted LocalCommunicator


### PR DESCRIPTION
## Summary
- add panic-contract test for TcpMesh constructor addresses/world_size mismatch
- document MS-159 constructor contract coverage in backlog

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist test_tcp_mesh_new_ -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a panic test to verify that the `TcpMesh` constructor correctly validates that the addresses list length matches the world size parameter. The test `test_tcp_mesh_new_addresses_len_mismatch_panics` ensures the constructor panics with an appropriate error message when given mismatched inputs. Documentation in the backlog records this as sprint MS-159 completion, covering the constructor contract validation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/backlog.md` |
| 2 | `coeus-dist/tests/dist_tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->