### PR TITLE
dist: cover tcp all_gather zero-numel contract

### DIFF
--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -643,6 +643,19 @@ fn test_tcp_all_gather_mismatched_output_numel_panics() {
 }
 
 #[test]
+#[should_panic(expected = "all_gather output length mismatch")]
+fn test_tcp_all_gather_zero_numel_output_len_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+
+    let tensor = Tensor::zeros_on([0], &backend);
+    let mut output: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.all_gather(&tensor, &mut output, &backend);
+}
+
+#[test]
 #[should_panic(expected = "scatter input numel mismatch")]
 fn test_tcp_scatter_mismatched_input_numel_panics() {
     let addresses = get_free_ports(1);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,15 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-160: TCP all_gather zero-numel rooted contract coverage [COMPLETE]
+
+- [x] [patch] Added `test_tcp_all_gather_zero_numel_output_len_mismatch_panics`
+  to prove TCP `all_gather` enforces output length contracts even when
+  `numel == 0`.
+- [x] [patch] Completed zero-numel rooted panic-contract parity across local and
+  TCP collectives (`all_gather`, `gather`, `scatter`).
+- [x] Evidence: `cargo test -p coeus-dist zero_numel_ -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-159: TcpMesh constructor contract coverage [COMPLETE]
 
 - [x] [patch] Added panic-contract coverage for constructor input mismatch:


### PR DESCRIPTION
## Summary
- add panic-contract test for tcp all_gather output length mismatch on zero-numel tensors
- complete zero-numel rooted contract coverage across local and tcp collectives
- update backlog and session plan for MS-160

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist zero_numel_ -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a panic-contract test to ensure TCP `all_gather` properly validates output length constraints for zero-numel tensors, completing the zero-numel rooted contract coverage across both local and TCP collectives. The change includes a single new test case `test_tcp_all_gather_zero_numel_output_len_mismatch_panics` and updates the project backlog to document MS-160 completion.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->