### PR TITLE
feat(nn): Add KL divergence and margin ranking loss with autograd backward

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -82,11 +82,13 @@ pub use ops::{
     gelu_tanh,
     huber_loss,
     index_select,
+    kl_divergence,
     layernorm,
     leaky_relu,
     log,
     log_softmax,
     log_sum_exp,
+    margin_ranking_loss,
     masked_fill,
     matmul,
     // New axis reductions

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -32,8 +32,9 @@ pub use linalg::{matmul, sparse_matmul, sparse_matmul_coo, transpose_2d};
 pub use nn::{
     avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, binary_cross_entropy, conv1d,
     conv2d, conv3d, conv_transpose1d, conv_transpose2d, cosine_embedding_loss, cross_entropy_loss,
-    dropout, huber_loss, layernorm, log_softmax, max_pool2d, max_pool3d, nll_loss, rmsnorm,
-    sdp_attention, softmax, AttentionMask, BatchNormArgs, CausalMask, NullMask,
+    dropout, huber_loss, kl_divergence, layernorm, log_softmax, margin_ranking_loss, max_pool2d,
+    max_pool3d, nll_loss, rmsnorm, sdp_attention, softmax, AttentionMask, BatchNormArgs,
+    CausalMask, NullMask,
 };
 
 pub use embedding::{embedding, embedding_with_padding_idx};

--- a/coeus-autograd/src/ops/nn/loss/kl_div.rs
+++ b/coeus-autograd/src/ops/nn/loss/kl_div.rs
@@ -1,0 +1,151 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for KL divergence loss.
+///
+/// Computes `mean(target * (log(target) - input))` where `input` holds
+/// log-probabilities and `target` holds probabilities. The gradient w.r.t.
+/// `input` is `-target / N * grad_out` per element.
+pub struct KlDivLossNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Target probabilities copied to host for backward.
+    pub target_host: Vec<T>,
+    /// Number of elements in the loss reduction.
+    pub n: usize,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for KlDivLossNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "kl_divergence"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        if let Some(Some(ref g)) = input_grads.get(0) {
+            let mut host_grad = [T::zero()];
+            let temp_grad;
+            let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+                grad_out
+            } else {
+                temp_grad = grad_out.to_contiguous_on(&backend);
+                &temp_grad
+            };
+            backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+            let g_out = host_grad[0];
+            let n_t = T::from_f64(self.n as f64);
+            let scale = g_out / n_t;
+
+            // d(loss)/d(input_i) = -target_i / N * grad_out
+            let mut d_input = vec![T::zero(); self.n];
+            for i in 0..self.n {
+                d_input[i] = (T::zero() - self.target_host[i]) * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on([self.n], &d_input, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked KL Divergence loss (PyTorch `F.kl_div` with `reduction='mean'`).
+///
+/// `input`: log-probabilities (log Q), `target`: probabilities (P).
+/// Computes `mean(target * (log(target) - input))`.
+/// Returns a scalar Var (shape `[1]`).
+pub fn kl_divergence<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    let backend = B::default();
+    let n = input.tensor.numel();
+    assert_eq!(
+        target.tensor.numel(),
+        n,
+        "input and target must have the same number of elements"
+    );
+
+    let i_cont;
+    let i_raw = if input.tensor.is_contiguous() && input.tensor.layout().offset() == 0 {
+        &input.tensor
+    } else {
+        i_cont = input.tensor.to_contiguous_on(&backend);
+        &i_cont
+    };
+    let t_cont;
+    let t_raw = if target.tensor.is_contiguous() && target.tensor.layout().offset() == 0 {
+        &target.tensor
+    } else {
+        t_cont = target.tensor.to_contiguous_on(&backend);
+        &t_cont
+    };
+
+    let i_host: std::borrow::Cow<[T]> = if let Some(s) = i_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(i_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let t_host: std::borrow::Cow<[T]> = if let Some(s) = t_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(t_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    // loss = mean(target * (log(target) - input))
+    // For target == 0, the term is 0 (0 * log(0) = 0 by convention).
+    let mut loss_val = T::zero();
+    let mut target_owned = vec![T::zero(); n];
+    for i in 0..n {
+        let p = t_host[i];
+        target_owned[i] = p;
+        let log_q = i_host[i];
+        let term = if p == T::zero() {
+            T::zero()
+        } else {
+            p * (p.log_op() - log_q)
+        };
+        loss_val = loss_val + term;
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad = crate::grad_mode::should_track_var(input);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = KlDivLossNode {
+            output_grad,
+            inputs: vec![input.clone()],
+            target_host: target_owned,
+            n,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/loss/margin_ranking.rs
+++ b/coeus-autograd/src/ops/nn/loss/margin_ranking.rs
@@ -1,0 +1,168 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for margin ranking loss.
+///
+/// Computes `mean(max(0, -target * (input1 - input2) + margin))`.
+/// The gradient w.r.t. `input1` is `-target / N * grad_out` and w.r.t.
+/// `input2` is `target / N * grad_out`, both only where the hinge is active.
+pub struct MarginRankingLossNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation (input1, input2).
+    pub inputs: Vec<Var<T, B>>,
+    /// Target labels (+1 or -1) copied to host for backward.
+    pub target_host: Vec<T>,
+    /// Per-element hinge activation mask (1.0 if active, 0.0 if not).
+    pub mask: Vec<T>,
+    /// Number of elements in the loss reduction.
+    pub n: usize,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for MarginRankingLossNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "margin_ranking_loss"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let mut host_grad = [T::zero()];
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+        let g_out = host_grad[0];
+        let n_t = T::from_f64(self.n as f64);
+        let scale = g_out / n_t;
+
+        // d(loss)/d(input1_i) = -target_i * mask_i / N * grad_out
+        // d(loss)/d(input2_i) =  target_i * mask_i / N * grad_out
+        if let Some(Some(ref g1)) = input_grads.get(0) {
+            let mut d1 = vec![T::zero(); self.n];
+            for i in 0..self.n {
+                d1[i] = (T::zero() - self.target_host[i]) * self.mask[i] * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on([self.n], &d1, &backend);
+            let gl = g1.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+        if let Some(Some(ref g2)) = input_grads.get(1) {
+            let mut d2 = vec![T::zero(); self.n];
+            for i in 0..self.n {
+                d2[i] = self.target_host[i] * self.mask[i] * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on([self.n], &d2, &backend);
+            let gl = g2.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked Margin Ranking loss (PyTorch `F.margin_ranking_loss` with
+/// `reduction='mean'`).
+///
+/// `input1`, `input2`: shape `[N]`, `target`: `&[T]` of +1 or -1, `margin`:
+/// threshold. Computes `mean(max(0, -target * (input1 - input2) + margin))`.
+/// Returns a scalar Var (shape `[1]`).
+pub fn margin_ranking_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input1: &Var<T, B>,
+    input2: &Var<T, B>,
+    target: &[T],
+    margin: T,
+) -> Var<T, B> {
+    let backend = B::default();
+    let n = input1.tensor.numel();
+    assert_eq!(
+        input2.tensor.numel(),
+        n,
+        "input1 and input2 must have the same number of elements"
+    );
+    assert_eq!(target.len(), n, "target length must match input length");
+
+    let i1_cont;
+    let i1_raw = if input1.tensor.is_contiguous() && input1.tensor.layout().offset() == 0 {
+        &input1.tensor
+    } else {
+        i1_cont = input1.tensor.to_contiguous_on(&backend);
+        &i1_cont
+    };
+    let i2_cont;
+    let i2_raw = if input2.tensor.is_contiguous() && input2.tensor.layout().offset() == 0 {
+        &input2.tensor
+    } else {
+        i2_cont = input2.tensor.to_contiguous_on(&backend);
+        &i2_cont
+    };
+
+    let i1_host: std::borrow::Cow<[T]> = if let Some(s) = i1_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(i1_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let i2_host: std::borrow::Cow<[T]> = if let Some(s) = i2_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(i2_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let zero = T::zero();
+    let mut loss_val = zero;
+    let mut mask = vec![zero; n];
+    for i in 0..n {
+        let diff = i1_host[i] - i2_host[i];
+        let raw = (T::zero() - target[i]) * diff + margin;
+        let hinge = if raw > zero { raw } else { zero };
+        if hinge > zero {
+            mask[i] = T::one();
+        }
+        loss_val = loss_val + hinge;
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad =
+        crate::grad_mode::should_track_var(input1) || crate::grad_mode::should_track_var(input2);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = MarginRankingLossNode {
+            output_grad,
+            inputs: vec![input1.clone(), input2.clone()],
+            target_host: target.to_vec(),
+            mask,
+            n,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -6,6 +6,10 @@ pub mod cosine;
 pub mod cross_entropy;
 /// Huber loss.
 pub mod huber;
+/// KL divergence loss.
+pub mod kl_div;
+/// Margin ranking loss.
+pub mod margin_ranking;
 /// Negative log-likelihood loss.
 pub mod nll;
 
@@ -13,4 +17,6 @@ pub use bce::{binary_cross_entropy, BinaryCrossEntropyNode};
 pub use cosine::{cosine_embedding_loss, CosineEmbeddingLossNode};
 pub use cross_entropy::{cross_entropy_loss, CrossEntropyLossNode};
 pub use huber::{huber_loss, HuberLossNode};
+pub use kl_div::{kl_divergence, KlDivLossNode};
+pub use margin_ranking::{margin_ranking_loss, MarginRankingLossNode};
 pub use nll::{nll_loss, NllLossNode};

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -22,7 +22,8 @@ pub use conv::{conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d};
 pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
-    binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, nll_loss,
+    binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, kl_divergence,
+    margin_ranking_loss, nll_loss,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -80,7 +80,8 @@ pub use init::{kaiming_uniform, xavier_uniform};
 pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
-    binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, mse_loss, nll_loss,
+    binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, kl_divergence,
+    margin_ranking_loss, mse_loss, nll_loss,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -131,6 +131,32 @@ pub fn huber_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::huber_loss(pred, target, delta)
 }
 
+/// KL divergence loss.
+///
+/// `input` is log-probabilities and `target` is probabilities. Computes
+/// `mean(target * (log(target) - input))`.
+#[inline]
+pub fn kl_divergence<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    coeus_autograd::kl_divergence(input, target)
+}
+
+/// Margin ranking loss.
+///
+/// `target` contains `+1` or `-1` labels. Computes
+/// `mean(max(0, -target * (input1 - input2) + margin))`.
+#[inline]
+pub fn margin_ranking_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input1: &Var<T, B>,
+    input2: &Var<T, B>,
+    target: &[T],
+    margin: T,
+) -> Var<T, B> {
+    coeus_autograd::margin_ranking_loss(input1, input2, target, margin)
+}
+
 /// Cosine Embedding Loss.
 /// x1: `[N, D]`, x2: `[N, D]`, y: `[N]`, margin: threshold.
 #[inline]

--- a/coeus-nn/tests/burn_live_parity.rs
+++ b/coeus-nn/tests/burn_live_parity.rs
@@ -5774,3 +5774,151 @@ fn bilinear_no_bias_output_shape() {
     let out = bil.bilinear_forward(&x1, &x2);
     assert_eq!(out.tensor.shape(), &[2, 5]);
 }
+
+// ── KL Divergence loss (analytical reference) ────────────────────────────────
+
+#[test]
+fn kl_divergence_zero_when_p_equals_q_analytical() {
+    // When P == Q, KL(P || Q) = 0.
+    // P = [0.5, 0.5], log Q = [log(0.5), log(0.5)]
+    // loss = mean(0.5 * (log(0.5) - log(0.5))) = 0
+    // Evidence tier: analytical derivation.
+    use coeus_nn::kl_divergence;
+
+    let log_q = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(
+            vec![2],
+            &[-std::f32::consts::LN_2, -std::f32::consts::LN_2],
+        ),
+        true,
+    );
+    let p = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[0.5_f32, 0.5]),
+        false,
+    );
+    let loss = kl_divergence(&log_q, &p);
+    assert_close_rel("kl_div_zero", loss.tensor.as_slice(), &[0.0_f32], 1e-5);
+}
+
+#[test]
+fn kl_divergence_forward_and_backward_match_analytical() {
+    // P = [0.5, 0.5], log Q = [log(0.3), log(0.7)]
+    // loss = mean([
+    //     0.5*(log(0.5) - log(0.3)),
+    //     0.5*(log(0.5) - log(0.7)),
+    // ])
+    //      = (0.5*log(5/3) + 0.5*log(5/7)) / 2
+    //      ≈ 0.04359
+    // grad w.r.t. input = -P / N * grad_out = [-0.25, -0.25] (grad_out = 1, N = 2)
+    // Evidence tier: analytical derivation.
+    use coeus_nn::kl_divergence;
+
+    let log_q = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[-1.2039728_f32, -0.35667494]),
+        true,
+    );
+    let p = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[0.5_f32, 0.5]),
+        false,
+    );
+    let loss = kl_divergence(&log_q, &p);
+    let expected_loss =
+        (0.5_f32 * (0.5_f32.ln() - 0.3_f32.ln()) + 0.5_f32 * (0.5_f32.ln() - 0.7_f32.ln())) / 2.0;
+    assert_close_rel(
+        "kl_div_forward",
+        loss.tensor.as_slice(),
+        &[expected_loss],
+        1e-5,
+    );
+
+    loss.backward();
+    let g = log_q.grad.as_ref().unwrap().read();
+    let g_slice = g.as_slice();
+    assert_close_rel("kl_div_grad", g_slice, &[-0.25_f32, -0.25_f32], 1e-5);
+}
+
+// ── Margin Ranking loss (analytical reference) ───────────────────────────────
+
+#[test]
+fn margin_ranking_loss_forward_and_backward_match_analytical() {
+    // input1 = [2, 1], input2 = [1, 2], target = [1, 1], margin = 1
+    // hinge[0] = max(0, -1*(2-1) + 1) = max(0, 0) = 0  (inactive)
+    // hinge[1] = max(0, -1*(1-2) + 1) = max(0, 2) = 2  (active)
+    // loss = mean(0, 2) = 1.0
+    // grad w.r.t. input1 = [-target*mask/N] = [-1*0/2, -1*1/2] = [0, -0.5]
+    // grad w.r.t. input2 = [ target*mask/N] = [ 1*0/2,  1*1/2] = [0,  0.5]
+    // Evidence tier: analytical derivation.
+    use coeus_nn::margin_ranking_loss;
+
+    let input1 = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[2.0_f32, 1.0]),
+        true,
+    );
+    let input2 = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[1.0_f32, 2.0]),
+        true,
+    );
+    let loss = margin_ranking_loss(&input1, &input2, &[1.0_f32, 1.0], 1.0);
+    assert_close_rel(
+        "margin_ranking_forward",
+        loss.tensor.as_slice(),
+        &[1.0_f32],
+        1e-5,
+    );
+
+    loss.backward();
+    let g1 = input1.grad.as_ref().unwrap().read();
+    assert_close_rel(
+        "margin_ranking_grad1",
+        g1.as_slice(),
+        &[0.0_f32, -0.5],
+        1e-5,
+    );
+    let g2 = input2.grad.as_ref().unwrap().read();
+    assert_close_rel("margin_ranking_grad2", g2.as_slice(), &[0.0_f32, 0.5], 1e-5);
+}
+
+#[test]
+fn margin_ranking_loss_target_minus_one_flips_gradient_sign() {
+    // target = -1 flips the sign: hinge = max(0, (input1 - input2) + margin)
+    // input1 = [2, 1], input2 = [1, 2], target = [-1, -1], margin = 1
+    // hinge[0] = max(0, (2-1) + 1) = max(0, 2) = 2  (active)
+    // hinge[1] = max(0, (1-2) + 1) = max(0, 0) = 0  (inactive)
+    // loss = mean(2, 0) = 1.0
+    // grad w.r.t. input1 = [-(-1)*mask/N] = [1*1/2, 1*0/2] = [0.5, 0]
+    // grad w.r.t. input2 = [ (-1)*mask/N] = [-1*1/2, -1*0/2] = [-0.5, 0]
+    // Evidence tier: analytical derivation.
+    use coeus_nn::margin_ranking_loss;
+
+    let input1 = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[2.0_f32, 1.0]),
+        true,
+    );
+    let input2 = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &[1.0_f32, 2.0]),
+        true,
+    );
+    let loss = margin_ranking_loss(&input1, &input2, &[-1.0_f32, -1.0], 1.0);
+    assert_close_rel(
+        "margin_ranking_neg_forward",
+        loss.tensor.as_slice(),
+        &[1.0_f32],
+        1e-5,
+    );
+
+    loss.backward();
+    let g1 = input1.grad.as_ref().unwrap().read();
+    assert_close_rel(
+        "margin_ranking_neg_grad1",
+        g1.as_slice(),
+        &[0.5_f32, 0.0],
+        1e-5,
+    );
+    let g2 = input2.grad.as_ref().unwrap().read();
+    assert_close_rel(
+        "margin_ranking_neg_grad2",
+        g2.as_slice(),
+        &[-0.5_f32, 0.0],
+        1e-5,
+    );
+}

--- a/coeus-nn/tests/loss_parity.rs
+++ b/coeus-nn/tests/loss_parity.rs
@@ -1,6 +1,7 @@
 //! Differential parity for loss functions:
 //!   `mse_loss`, `nll_loss`, `huber_loss`,
-//!   `binary_cross_entropy`, `cosine_embedding_loss`.
+//!   `binary_cross_entropy`, `kl_divergence`, `margin_ranking_loss`,
+//!   `cosine_embedding_loss`.
 //!
 //! (`cross_entropy_loss` is already covered by `nn_parity::test_cross_entropy_loss_parity`.)
 //!
@@ -8,6 +9,8 @@
 //!   mse_loss(x, x) = 0                          (exact — identical tensors)
 //!   nll_loss([[-1,-2,-3]], [0]) = 1.0            (exact — pick index 0, val=-(-1)=1)
 //!   huber_loss([2.0],[0.0], δ=1.0) = 1.5        (exact — δ*(|err|-0.5δ) = 1*(2-0.5))
+//!   kl_divergence(log([0.25,0.75]), [0.25,0.75]) = 0 (exact — P == Q)
+//!   margin_ranking_loss([2,0,1,2], [1,1,1,1], [1,-1,1,-1], m=0.5) = 0.5
 //!   cosine_embedding_loss([1,0],[1,0], y=1) = 0  (exact — cos=1, loss=max(0,0)=0)
 //!
 //! binary_cross_entropy(pred=0.5, target=0) = -log(1-0.5) = log(2) (1-ULP eps)
@@ -18,7 +21,10 @@ use coeus_autograd::Var;
 use coeus_core::{
     CpuAddressableStorage, CpuAddressableStorageMut, MoiraiBackend, SequentialBackend,
 };
-use coeus_nn::{binary_cross_entropy, cosine_embedding_loss, huber_loss, mse_loss, nll_loss};
+use coeus_nn::{
+    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, margin_ranking_loss,
+    mse_loss, nll_loss,
+};
 use coeus_ops::BackendOps;
 use coeus_tensor::Tensor;
 
@@ -75,6 +81,29 @@ where
     assert!(
         (bce_val - bce_expected).abs() <= 2.0 * f64::EPSILON * bce_expected,
         "BCE pred=0.5 target=0 → ln(2): got {bce_val:.17}, expected {bce_expected:.17}"
+    );
+
+    // KL divergence is zero when target probabilities match input log-probabilities.
+    let probs = [0.25_f64, 0.75_f64];
+    let log_probs = [probs[0].ln(), probs[1].ln()];
+    let kl_input = v(&[2], &log_probs, backend);
+    let kl_target = v(&[2], &probs, backend);
+    let kl = kl_divergence(&kl_input, &kl_target);
+    assert!(
+        kl.tensor.as_slice()[0].abs() <= 2.0 * f64::EPSILON,
+        "kl_divergence(P || P) = 0"
+    );
+
+    // Margin ranking:
+    // samples 0/1 are inactive, sample 2 has hinge 0.5, sample 3 has hinge 1.5.
+    // mean = (0 + 0 + 0.5 + 1.5) / 4 = 0.5.
+    let mr_i1 = v(&[4], &[2.0, 0.0, 1.0, 2.0], backend);
+    let mr_i2 = v(&[4], &[1.0, 1.0, 1.0, 1.0], backend);
+    let mr = margin_ranking_loss(&mr_i1, &mr_i2, &[1.0, -1.0, 1.0, -1.0], 0.5);
+    assert_eq!(
+        mr.tensor.as_slice(),
+        &[0.5_f64],
+        "margin_ranking_loss mixed active/inactive hinges"
     );
 
     // Cosine embedding loss: identical unit vectors, y=1 → loss=0 exactly.

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -1,6 +1,9 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
-use coeus_nn::{binary_cross_entropy, cosine_embedding_loss, huber_loss, nll_loss};
+use coeus_nn::{
+    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, margin_ranking_loss,
+    nll_loss,
+};
 use coeus_tensor::Tensor;
 
 #[test]
@@ -124,6 +127,57 @@ fn test_huber_loss() {
 
     loss.backward();
     assert!(pred.grad().is_some());
+}
+
+#[test]
+fn test_kl_divergence_loss() {
+    let input_data = [0.25_f64.ln(), 0.75_f64.ln()];
+    let target_data = [0.25_f64, 0.75_f64];
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2], &input_data),
+        true,
+    );
+    let target = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2], &target_data),
+        false,
+    );
+
+    let loss = kl_divergence(&input, &target);
+    assert_eq!(loss.tensor.shape(), &[1]);
+    assert!(loss.tensor.as_slice()[0].abs() <= 2.0 * f64::EPSILON);
+
+    loss.backward();
+    let grad = input.grad().expect("invariant: KL input requires grad");
+    let grad_slice = grad.as_slice();
+    assert!((grad_slice[0] + 0.125).abs() < 1e-12);
+    assert!((grad_slice[1] + 0.375).abs() < 1e-12);
+}
+
+#[test]
+fn test_margin_ranking_loss() {
+    let input1 = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([4], &[2.0, 0.0, 1.0, 2.0]),
+        true,
+    );
+    let input2 = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([4], &[1.0, 1.0, 1.0, 1.0]),
+        true,
+    );
+    let target = [1.0_f64, -1.0, 1.0, -1.0];
+
+    let loss = margin_ranking_loss(&input1, &input2, &target, 0.5);
+    assert_eq!(loss.tensor.shape(), &[1]);
+    assert_eq!(loss.tensor.as_slice(), &[0.5_f64]);
+
+    loss.backward();
+    let g1 = input1
+        .grad()
+        .expect("invariant: margin ranking input1 requires grad");
+    let g2 = input2
+        .grad()
+        .expect("invariant: margin ranking input2 requires grad");
+    assert_eq!(g1.as_slice(), &[0.0, 0.0, -0.25, 0.25]);
+    assert_eq!(g2.as_slice(), &[0.0, 0.0, 0.25, -0.25]);
 }
 
 #[test]


### PR DESCRIPTION
Add two standard PyTorch parity loss functions with full autograd backward support, analytical tests, and differential parity tests.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds two new loss functions to the neural network module: **KL divergence** (`kl_divergence`) and **margin ranking loss** (`margin_ranking_loss`). Both loss functions implement full autograd backward support with custom backward nodes (`KlDivLossNode` and `MarginRankingLossNode`), compute mean-reduced losses matching PyTorch semantics, and include comprehensive testing with analytical gradient verification and differential parity tests against expected closed-form results.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/kl_div.rs` |
| 2 | `coeus-autograd/src/ops/nn/loss/margin_ranking.rs` |
| 3 | `coeus-nn/tests/burn_live_parity.rs` |
| 4 | `coeus-nn/tests/nn_loss_tests.rs` |
| 5 | `coeus-nn/tests/loss_parity.rs` |
| 6 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 7 | `coeus-autograd/src/ops/nn/mod.rs` |
| 8 | `coeus-autograd/src/ops/mod.rs` |
| 9 | `coeus-autograd/src/lib.rs` |
| 10 | `coeus-nn/src/loss.rs` |
| 11 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->