### PR TITLE
dist: enforce tcpmesh non-zero world size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@
 
 ### Fixed
 
+- **TcpMesh zero-world-size constructor guard** — added explicit
+  `world_size > 0` assertion in `TcpMesh::new` so invalid zero-sized process
+  groups fail with a direct contract error.
+- **TcpMesh zero-world-size panic-contract test** — added
+  `test_tcp_mesh_new_zero_world_size_panics`.
 - **TCP zero-numel rooted contract bypass** — TCP `gather` and `scatter` now
   enforce root output/input length contracts before the zero-numel fast-return,
   so invalid rooted call shapes fail fast consistently.

--- a/coeus-dist/src/tcp/mesh.rs
+++ b/coeus-dist/src/tcp/mesh.rs
@@ -13,6 +13,7 @@ pub struct TcpMesh {
 impl TcpMesh {
     /// Create a new TCP mesh connecting all ranks.
     pub fn new(rank: usize, size: usize, addresses: &[SocketAddr]) -> Self {
+        assert!(size > 0, "world size must be > 0");
         assert!(rank < size, "rank must be less than world size");
         assert_eq!(
             addresses.len(),

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -780,6 +780,13 @@ fn test_tcp_mesh_new_rank_out_of_bounds_panics() {
 }
 
 #[test]
+#[should_panic(expected = "world size must be > 0")]
+fn test_tcp_mesh_new_zero_world_size_panics() {
+    let addresses: Vec<std::net::SocketAddr> = vec![];
+    let _mesh = TcpMesh::new(0, 0, &addresses);
+}
+
+#[test]
 #[should_panic(expected = "addresses list length must match world size")]
 fn test_tcp_mesh_new_addresses_len_mismatch_panics() {
     let addresses = get_free_ports(1);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,14 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-162: TcpMesh non-zero world-size invariant [COMPLETE]
+
+- [x] [patch] Added explicit `TcpMesh::new` invariant `world_size > 0` for
+  clearer constructor contract semantics before rank/address validation.
+- [x] [patch] Added panic-contract coverage
+  `test_tcp_mesh_new_zero_world_size_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_mesh_new_ -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-161: KL/MarginRanking loss parity coverage [COMPLETE]
 
 - [x] [patch] Added tracked `coeus_autograd::{kl_divergence,


### PR DESCRIPTION
## Summary
- add explicit TcpMesh::new world_size > 0 invariant
- add panic-contract test for zero-world-size constructor call
- validate constructor contract trio: zero-size, rank bound, addresses length mismatch
- update backlog/changelog/plan for MS-162

## Validation
- cargo fmt -p coeus-dist
- cargo test -p coeus-dist test_tcp_mesh_new_ -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds an explicit constructor guard to `TcpMesh::new` requiring `world_size > 0`, preventing invalid zero-sized process groups from being created. The change includes a corresponding panic-contract test `test_tcp_mesh_new_zero_world_size_panics` that validates the assertion fires correctly, completing the constructor validation trilogy alongside existing rank-bounds and address-length checks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/tcp/mesh.rs` |
| 2 | `coeus-dist/tests/dist_tests.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection setup validation so attempts to create a mesh with zero total members now fail with a clear error instead of proceeding unexpectedly.
  * Added coverage to ensure this validation continues to behave consistently.

* **Documentation**
  * Updated release notes and backlog tracking to reflect the completed fix and its verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->