### PR TITLE
Enforce zero-numel numel contracts in collectives

### DIFF
--- a/coeus-dist/src/local.rs
+++ b/coeus-dist/src/local.rs
@@ -274,6 +274,14 @@ impl Communicator for LocalCommunicator {
             "LocalCommunicator all_gather output length mismatch"
         );
         let numel = tensor.numel();
+        for (r, out) in output.iter().enumerate() {
+            assert_eq!(
+                out.numel(),
+                numel,
+                "LocalCommunicator all_gather output numel mismatch at rank {}",
+                r
+            );
+        }
         if numel == 0 {
             return;
         }
@@ -373,14 +381,22 @@ impl Communicator for LocalCommunicator {
             root < self.size,
             "LocalCommunicator gather root out of bounds"
         );
+        let numel = tensor.numel();
         if self.rank == root {
             assert_eq!(
                 output.len(),
                 self.size,
                 "LocalCommunicator gather output length mismatch on root"
             );
+            for (r, out) in output.iter().enumerate() {
+                assert_eq!(
+                    out.numel(),
+                    numel,
+                    "LocalCommunicator gather output numel mismatch on root at rank {}",
+                    r
+                );
+            }
         }
-        let numel = tensor.numel();
         if numel == 0 {
             return;
         }
@@ -424,14 +440,22 @@ impl Communicator for LocalCommunicator {
             root < self.size,
             "LocalCommunicator scatter root out of bounds"
         );
+        let numel = tensor.numel();
         if self.rank == root {
             assert_eq!(
                 input.len(),
                 self.size,
                 "LocalCommunicator scatter input length mismatch on root"
             );
+            for (r, in_tensor) in input.iter().enumerate() {
+                assert_eq!(
+                    in_tensor.numel(),
+                    numel,
+                    "LocalCommunicator scatter input numel mismatch on root at rank {}",
+                    r
+                );
+            }
         }
-        let numel = tensor.numel();
         if numel == 0 {
             return;
         }
@@ -441,15 +465,7 @@ impl Communicator for LocalCommunicator {
                 .iter()
                 .enumerate()
                 .take(self.size)
-                .map(|(r, in_tensor)| {
-                    assert_eq!(
-                        in_tensor.numel(),
-                        numel,
-                        "LocalCommunicator scatter input numel mismatch on root at rank {}",
-                        r
-                    );
-                    get_tensor_host_data(in_tensor, backend).into_owned()
-                })
+                .map(|(_, in_tensor)| get_tensor_host_data(in_tensor, backend).into_owned())
                 .collect::<Vec<Vec<T>>>();
 
             let mut bufs = self.shared.buffers.lock().unwrap();

--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -120,11 +120,11 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         assert_eq!(output.len(), size, "all_gather output length mismatch");
         let numel = tensor.numel();
-        if numel == 0 {
-            return;
-        }
         for (idx, out) in output.iter().enumerate().take(size) {
             Self::assert_numel("all_gather output", idx, out.numel(), numel);
+        }
+        if numel == 0 {
+            return;
         }
 
         let self_host_data = get_tensor_host_data(tensor, backend);
@@ -201,18 +201,18 @@ impl Communicator for TcpCommunicator {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
         Self::assert_root(root, size);
+        let numel = tensor.numel();
         if rank == root {
             assert_eq!(output.len(), size, "gather output length mismatch on root");
+            for (idx, out) in output.iter().enumerate().take(size) {
+                Self::assert_numel("gather output", idx, out.numel(), numel);
+            }
         }
-        let numel = tensor.numel();
         if numel == 0 {
             return;
         }
 
         if rank == root {
-            for (idx, out) in output.iter().enumerate().take(size) {
-                Self::assert_numel("gather output", idx, out.numel(), numel);
-            }
             let self_host_data = get_tensor_host_data(tensor, backend);
             copy_host_slice_to_tensor(&self_host_data, &mut output[root], backend);
 
@@ -240,18 +240,18 @@ impl Communicator for TcpCommunicator {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
         Self::assert_root(root, size);
+        let numel = tensor.numel();
         if rank == root {
             assert_eq!(input.len(), size, "scatter input length mismatch on root");
+            for (idx, in_tensor) in input.iter().enumerate().take(size) {
+                Self::assert_numel("scatter input", idx, in_tensor.numel(), numel);
+            }
         }
-        let numel = tensor.numel();
         if numel == 0 {
             return;
         }
 
         if rank == root {
-            for (idx, in_tensor) in input.iter().enumerate().take(size) {
-                Self::assert_numel("scatter input", idx, in_tensor.numel(), numel);
-            }
             let self_host_data = get_tensor_host_data(&input[root], backend);
             copy_host_slice_to_tensor(&self_host_data, tensor, backend);
 

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -301,8 +301,18 @@ fn test_local_scatter_root_out_of_bounds_panics() {
 fn test_local_all_gather_zero_numel_output_len_mismatch_panics() {
     let comm = LocalCommunicator::create_cluster(1).remove(0);
     let backend = SequentialBackend::new();
-    let tensor = Tensor::zeros_on([0], &backend);
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
     let mut output: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.all_gather(&tensor, &mut output, &backend);
+}
+
+#[test]
+#[should_panic(expected = "LocalCommunicator all_gather output numel mismatch at rank 0")]
+fn test_local_all_gather_zero_numel_output_numel_mismatch_panics() {
+    let comm = LocalCommunicator::create_cluster(1).remove(0);
+    let backend = SequentialBackend::new();
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
+    let mut output = vec![Tensor::zeros_on([1], &backend)];
     comm.all_gather(&tensor, &mut output, &backend);
 }
 
@@ -311,8 +321,18 @@ fn test_local_all_gather_zero_numel_output_len_mismatch_panics() {
 fn test_local_gather_zero_numel_output_len_mismatch_panics() {
     let comm = LocalCommunicator::create_cluster(1).remove(0);
     let backend = SequentialBackend::new();
-    let tensor = Tensor::zeros_on([0], &backend);
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
     let mut output: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.gather(&tensor, &mut output, 0, &backend);
+}
+
+#[test]
+#[should_panic(expected = "LocalCommunicator gather output numel mismatch on root at rank 0")]
+fn test_local_gather_zero_numel_output_numel_mismatch_panics() {
+    let comm = LocalCommunicator::create_cluster(1).remove(0);
+    let backend = SequentialBackend::new();
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
+    let mut output = vec![Tensor::zeros_on([1], &backend)];
     comm.gather(&tensor, &mut output, 0, &backend);
 }
 
@@ -321,8 +341,18 @@ fn test_local_gather_zero_numel_output_len_mismatch_panics() {
 fn test_local_scatter_zero_numel_input_len_mismatch_panics() {
     let comm = LocalCommunicator::create_cluster(1).remove(0);
     let backend = SequentialBackend::new();
-    let mut tensor = Tensor::zeros_on([0], &backend);
+    let mut tensor = Tensor::<f32, _>::zeros_on([0], &backend);
     let input: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.scatter(&mut tensor, &input, 0, &backend);
+}
+
+#[test]
+#[should_panic(expected = "LocalCommunicator scatter input numel mismatch on root at rank 0")]
+fn test_local_scatter_zero_numel_input_numel_mismatch_panics() {
+    let comm = LocalCommunicator::create_cluster(1).remove(0);
+    let backend = SequentialBackend::new();
+    let mut tensor = Tensor::<f32, _>::zeros_on([0], &backend);
+    let input = vec![Tensor::zeros_on([1], &backend)];
     comm.scatter(&mut tensor, &input, 0, &backend);
 }
 
@@ -650,8 +680,21 @@ fn test_tcp_all_gather_zero_numel_output_len_mismatch_panics() {
     let comm = TcpCommunicator::new(mesh);
     let backend = SequentialBackend::new();
 
-    let tensor = Tensor::zeros_on([0], &backend);
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
     let mut output: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.all_gather(&tensor, &mut output, &backend);
+}
+
+#[test]
+#[should_panic(expected = "all_gather output numel mismatch")]
+fn test_tcp_all_gather_zero_numel_output_numel_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
+    let mut output = vec![Tensor::zeros_on([1], &backend)];
     comm.all_gather(&tensor, &mut output, &backend);
 }
 
@@ -721,8 +764,20 @@ fn test_tcp_gather_zero_numel_output_len_mismatch_panics() {
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
     let backend = SequentialBackend::new();
-    let tensor = Tensor::zeros_on([0], &backend);
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
     let mut output: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.gather(&tensor, &mut output, 0, &backend);
+}
+
+#[test]
+#[should_panic(expected = "gather output numel mismatch")]
+fn test_tcp_gather_zero_numel_output_numel_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let tensor = Tensor::<f32, _>::zeros_on([0], &backend);
+    let mut output = vec![Tensor::zeros_on([1], &backend)];
     comm.gather(&tensor, &mut output, 0, &backend);
 }
 
@@ -733,8 +788,20 @@ fn test_tcp_scatter_zero_numel_input_len_mismatch_panics() {
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
     let backend = SequentialBackend::new();
-    let mut tensor = Tensor::zeros_on([0], &backend);
+    let mut tensor = Tensor::<f32, _>::zeros_on([0], &backend);
     let input: Vec<Tensor<f32, SequentialBackend>> = vec![];
+    comm.scatter(&mut tensor, &input, 0, &backend);
+}
+
+#[test]
+#[should_panic(expected = "scatter input numel mismatch")]
+fn test_tcp_scatter_zero_numel_input_numel_mismatch_panics() {
+    let addresses = get_free_ports(1);
+    let mesh = TcpMesh::new(0, 1, &addresses);
+    let comm = TcpCommunicator::new(mesh);
+    let backend = SequentialBackend::new();
+    let mut tensor = Tensor::<f32, _>::zeros_on([0], &backend);
+    let input = vec![Tensor::zeros_on([1], &backend)];
     comm.scatter(&mut tensor, &input, 0, &backend);
 }
 


### PR DESCRIPTION
## Summary
- enforce local and TCP all_gather/gather/scatter output/input numel contracts before zero-numel early returns
- preserve existing rooted length and bounds contracts while closing zero-numel numel-mismatch bypass paths
- add panic-contract tests for zero-numel numel-mismatch cases across LocalCommunicator and TcpCommunicator

## Validation
- cargo test -p coeus-dist zero_numel_ -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enforces numel (number of elements) validation contracts for zero-element tensors in collective operations (`all_gather`, `gather`, and `scatter`) across both `LocalCommunicator` and `TcpCommunicator` implementations. Previously, these operations would return early when encountering zero-element tensors without validating that input/output tensor dimensions match, creating a bypass path for numel mismatches. The changes move numel validation checks before the early-return logic to ensure contract enforcement even for empty tensors, and adds corresponding panic tests to verify the new validation behavior.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `coeus-dist/src/local.rs` |
| 3 | `coeus-dist/src/tcp/collectives.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->