### PR TITLE
Harden TCP broadcast numel contract

### DIFF
--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -88,14 +88,27 @@ impl Communicator for TcpCommunicator {
         let rank = self.mesh.rank();
         let size = self.mesh.size();
         Self::assert_root(root, size);
+        let numel = tensor.numel();
         if size <= 1 {
             return;
         }
-        if tensor.numel() == 0 {
-            return;
-        }
 
+        // Exchange expected payload lengths first so rank-shape mismatches fail fast
+        // instead of desynchronizing the byte stream.
+        let local_numel_bytes = (numel as u64).to_le_bytes();
         if rank == root {
+            for other in 0..size {
+                if other == root {
+                    continue;
+                }
+                let mut peer_numel_bytes = [0u8; 8];
+                self.mesh.recv(other, &mut peer_numel_bytes);
+                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
+                Self::assert_numel("broadcast", other, peer_numel, numel);
+            }
+            if numel == 0 {
+                return;
+            }
             with_tensor_host_bytes(tensor, backend, |slice| {
                 for other in 0..size {
                     if other != root {
@@ -104,6 +117,10 @@ impl Communicator for TcpCommunicator {
                 }
             });
         } else {
+            self.mesh.send(root, &local_numel_bytes);
+            if numel == 0 {
+                return;
+            }
             recv_tensor_data(tensor, backend, |slice| {
                 self.mesh.recv(root, slice);
             });

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -497,6 +497,36 @@ fn test_tcp_broadcast() {
 }
 
 #[test]
+fn test_tcp_broadcast_mismatched_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+
+            let mut tensor = if rank == 0 {
+                Tensor::from_slice_on([2], &[10.0f32, 20.0], &backend)
+            } else {
+                Tensor::zeros_on([1], &backend)
+            };
+
+            comm.broadcast(&mut tensor, 0, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "TCP broadcast with mismatched tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
 fn test_tcp_all_gather() {
     let world_size = 2;
     let addresses = get_free_ports(world_size);


### PR DESCRIPTION
## Summary
- add a pre-payload numel handshake in TcpCommunicator::broadcast so root validates peer tensor lengths before sending payload bytes
- enforce the same contract for zero-numel broadcasts by running handshake validation before fast return
- add 	est_tcp_broadcast_mismatched_numel_panics to cover fail-fast mismatch behavior

## Validation
- cargo test -p coeus-dist broadcast -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the TCP broadcast operation by adding a pre-payload handshake that validates tensor lengths between the root and peer ranks before transmitting data. The root rank now collects and verifies the `numel` (number of elements) from all peers to ensure they match, causing a fail-fast panic if there's a mismatch rather than desynchronizing the byte stream. The validation also runs for zero-numel broadcasts before the early return. A new test `test_tcp_broadcast_mismatched_numel_panics` verifies that mismatched tensor sizes trigger a panic as expected.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `coeus-dist/src/tcp/collectives.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->