### PR TITLE
Harden TCP reduce numel contract

### DIFF
--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -182,6 +182,22 @@ impl Communicator for TcpCommunicator {
             return;
         }
         let numel = tensor.numel();
+        let local_numel_bytes = (numel as u64).to_le_bytes();
+
+        if rank == root {
+            for other in 0..size {
+                if other == root {
+                    continue;
+                }
+                let mut peer_numel_bytes = [0u8; 8];
+                self.mesh.recv(other, &mut peer_numel_bytes);
+                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
+                Self::assert_numel("reduce input", other, peer_numel, numel);
+            }
+        } else {
+            self.mesh.send(root, &local_numel_bytes);
+        }
+
         if numel == 0 {
             return;
         }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -615,6 +615,36 @@ fn test_tcp_reduce() {
 }
 
 #[test]
+fn test_tcp_reduce_mismatched_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+
+            let mut tensor = if rank == 0 {
+                Tensor::from_slice_on([2], &[1.0f32, 2.0], &backend)
+            } else {
+                Tensor::from_slice_on([1], &[3.0f32], &backend)
+            };
+
+            comm.reduce::<f32, _, Sum>(&mut tensor, 0, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "TCP reduce with mismatched tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
 fn test_tcp_gather() {
     let world_size = 2;
     let addresses = get_free_ports(world_size);


### PR DESCRIPTION
## Summary
- add a pre-payload numel handshake in TcpCommunicator::reduce so root validates peer tensor lengths before receiving payload bytes
- enforce this validation before the zero-numel fast return for consistent reduce shape contracts
- add 	est_tcp_reduce_mismatched_numel_panics to cover fail-fast mismatch behavior

## Validation
- cargo test -p coeus-dist test_tcp_reduce -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the `TcpCommunicator::reduce` operation by adding a pre-payload handshake to validate that all participating ranks have tensors with matching element counts (`numel`). The root rank now receives and validates each peer's tensor size before accepting the actual data payload, ensuring shape consistency and enabling fail-fast behavior when tensor dimensions mismatch across ranks. This validation occurs before the zero-numel early return to enforce consistent contracts. A new test `test_tcp_reduce_mismatched_numel_panics` verifies that mismatched tensor sizes correctly trigger a panic.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `coeus-dist/src/tcp/collectives.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `reduce` behavior for TCP communication by checking that all ranks use tensors with the same number of elements before starting the reduction.
  * Mismatched tensor sizes now fail fast instead of continuing with an invalid reduction.
* **Tests**
  * Added coverage for TCP reduce operations with mismatched tensor sizes to verify the expected panic occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->