### PR TITLE
Harden TCP gather/scatter peer numel contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@
 
 ### Fixed
 
+- **TCP rooted peer-numel handshake contracts** — rooted `gather` and `scatter`
+  now exchange and validate per-rank tensor `numel` metadata before payload
+  transfer, including zero-numel paths, so cross-rank shape mismatches fail fast
+  instead of risking stream desynchronization.
 - **Zero-numel collective shape validation** — local and TCP `all_gather`,
   `gather`, and `scatter` now validate per-rank output/input tensor element
   counts before zero-numel early returns, so malformed zero-sized collectives no

--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -235,11 +235,23 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         Self::assert_root(root, size);
         let numel = tensor.numel();
+        let local_numel_bytes = (numel as u64).to_le_bytes();
         if rank == root {
             assert_eq!(output.len(), size, "gather output length mismatch on root");
             for (idx, out) in output.iter().enumerate().take(size) {
                 Self::assert_numel("gather output", idx, out.numel(), numel);
             }
+            for other in 0..size {
+                if other == root {
+                    continue;
+                }
+                let mut peer_numel_bytes = [0u8; 8];
+                self.mesh.recv(other, &mut peer_numel_bytes);
+                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
+                Self::assert_numel("gather input", other, peer_numel, numel);
+            }
+        } else {
+            self.mesh.send(root, &local_numel_bytes);
         }
         if numel == 0 {
             return;
@@ -274,11 +286,23 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         Self::assert_root(root, size);
         let numel = tensor.numel();
+        let local_numel_bytes = (numel as u64).to_le_bytes();
         if rank == root {
             assert_eq!(input.len(), size, "scatter input length mismatch on root");
             for (idx, in_tensor) in input.iter().enumerate().take(size) {
                 Self::assert_numel("scatter input", idx, in_tensor.numel(), numel);
             }
+            for other in 0..size {
+                if other == root {
+                    continue;
+                }
+                let mut peer_numel_bytes = [0u8; 8];
+                self.mesh.recv(other, &mut peer_numel_bytes);
+                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
+                Self::assert_numel("scatter target", other, peer_numel, numel);
+            }
+        } else {
+            self.mesh.send(root, &local_numel_bytes);
         }
         if numel == 0 {
             return;

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -684,6 +684,72 @@ fn test_tcp_gather() {
 }
 
 #[test]
+fn test_tcp_gather_mismatched_peer_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+            let tensor = if rank == 1 {
+                Tensor::from_slice_on([2], &[11.0f32, 12.0], &backend)
+            } else {
+                Tensor::from_slice_on([1], &[3.0f32], &backend)
+            };
+            let mut output = if rank == 1 {
+                vec![Tensor::zeros_on([2], &backend), Tensor::zeros_on([2], &backend)]
+            } else {
+                vec![]
+            };
+
+            comm.gather(&tensor, &mut output, 1, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "TCP gather with mismatched peer tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
+fn test_tcp_gather_zero_numel_mismatched_peer_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+            let tensor = if rank == 1 {
+                Tensor::<f32, _>::zeros_on([0], &backend)
+            } else {
+                Tensor::zeros_on([1], &backend)
+            };
+            let mut output = if rank == 1 {
+                vec![Tensor::zeros_on([0], &backend), Tensor::zeros_on([0], &backend)]
+            } else {
+                vec![]
+            };
+
+            comm.gather(&tensor, &mut output, 1, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "TCP gather zero-numel with mismatched peer tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
 fn test_tcp_scatter() {
     let world_size = 2;
     let addresses = get_free_ports(world_size);
@@ -717,6 +783,77 @@ fn test_tcp_scatter() {
     for h in handles {
         h.join().unwrap();
     }
+}
+
+#[test]
+fn test_tcp_scatter_mismatched_target_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+
+            let mut tensor = if rank == 0 {
+                Tensor::zeros_on([2], &backend)
+            } else {
+                Tensor::zeros_on([1], &backend)
+            };
+            let input = if rank == 0 {
+                vec![
+                    Tensor::from_slice_on([2], &[100.0f32, 101.0], &backend),
+                    Tensor::from_slice_on([2], &[200.0f32, 201.0], &backend),
+                ]
+            } else {
+                vec![]
+            };
+
+            comm.scatter(&mut tensor, &input, 0, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "TCP scatter with mismatched target tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
+fn test_tcp_scatter_zero_numel_mismatched_target_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+
+            let mut tensor = if rank == 0 {
+                Tensor::<f32, _>::zeros_on([0], &backend)
+            } else {
+                Tensor::zeros_on([1], &backend)
+            };
+            let input = if rank == 0 {
+                vec![Tensor::zeros_on([0], &backend), Tensor::zeros_on([0], &backend)]
+            } else {
+                vec![]
+            };
+
+            comm.scatter(&mut tensor, &input, 0, &backend);
+        }));
+    }
+
+    assert!(
+        handles.into_iter().any(|h| h.join().is_err()),
+        "TCP scatter zero-numel with mismatched target tensor numel should panic on at least one rank"
+    );
 }
 
 #[test]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,21 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-167: TCP gather/scatter peer numel handshakes [COMPLETE]
+
+- [x] [patch] Added pre-payload peer-numel handshakes in TCP rooted
+  `gather`/`scatter` so root validates each participating rank's tensor length
+  before any payload bytes are transferred.
+- [x] [patch] Enforced handshake validation ahead of zero-numel fast returns so
+  zero-sized rooted collectives still fail fast on cross-rank shape mismatch.
+- [x] [patch] Added panic-contract coverage:
+  `test_tcp_gather_mismatched_peer_numel_panics`,
+  `test_tcp_gather_zero_numel_mismatched_peer_numel_panics`,
+  `test_tcp_scatter_mismatched_target_numel_panics`, and
+  `test_tcp_scatter_zero_numel_mismatched_target_numel_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_gather -- --nocapture`;
+  `cargo test -p coeus-dist test_tcp_scatter -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-165: Zero-numel collective numel contracts [COMPLETE]
 
 - [x] [patch] Local `all_gather`, rooted `gather`, and rooted `scatter` now


### PR DESCRIPTION
## Summary
- add pre-payload peer-numel handshakes to rooted TCP gather and scatter
- validate peer tensor lengths at root before payload transfer, including zero-numel paths
- add panic-contract tests for non-zero and zero-numel peer/target mismatch paths
- document sprint and changelog updates for this hardening slice

## Validation
- cargo test -p coeus-dist test_tcp_gather -- --nocapture
- cargo test -p coeus-dist test_tcp_scatter -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a pre-payload handshake mechanism to TCP-based `gather` and `scatter` collective operations. Before transferring any tensor data, the root rank now exchanges and validates tensor element counts (`numel`) with all peer ranks to ensure shape consistency across the distributed system. This validation applies to both regular and zero-numel tensors, enabling fast failure on shape mismatches and preventing potential stream desynchronization issues. The implementation includes comprehensive panic-contract tests covering both non-zero and zero-numel mismatch scenarios.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/backlog.md` |
| 2 | `CHANGELOG.md` |
| 3 | `coeus-dist/src/tcp/collectives.rs` |
| 4 | `coeus-dist/tests/dist_tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP gather/scatter reliability by detecting tensor size mismatches earlier and failing fast before data transfer.
  * Fixed zero-element transfer paths so they now validate sizes consistently and avoid stream desynchronization.
* **Tests**
  * Added coverage for mismatch scenarios to verify gather and scatter correctly fail when tensor sizes do not align.
* **Documentation**
  * Updated the changelog and backlog with the completed TCP collective handshake changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->