### PR TITLE
Harden TCP all_gather peer numel contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@
 
 ### Fixed
 
+- **TCP all_gather peer-numel handshake contract** — `all_gather` now exchanges
+  and validates per-peer tensor `numel` metadata before payload transfer,
+  including the zero-numel path, so cross-rank shape mismatches fail fast
+  instead of risking stream desynchronization.
 - **TCP rooted peer-numel handshake contracts** — rooted `gather` and `scatter`
   now exchange and validate per-rank tensor `numel` metadata before payload
   transfer, including zero-numel paths, so cross-rank shape mismatches fail fast

--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -137,8 +137,27 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         assert_eq!(output.len(), size, "all_gather output length mismatch");
         let numel = tensor.numel();
+        let local_numel_bytes = (numel as u64).to_le_bytes();
         for (idx, out) in output.iter().enumerate().take(size) {
             Self::assert_numel("all_gather output", idx, out.numel(), numel);
+        }
+        for other in 0..size {
+            if other == rank {
+                continue;
+            }
+            if rank < other {
+                self.mesh.send(other, &local_numel_bytes);
+                let mut peer_numel_bytes = [0u8; 8];
+                self.mesh.recv(other, &mut peer_numel_bytes);
+                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
+                Self::assert_numel("all_gather input", other, peer_numel, numel);
+            } else {
+                let mut peer_numel_bytes = [0u8; 8];
+                self.mesh.recv(other, &mut peer_numel_bytes);
+                self.mesh.send(other, &local_numel_bytes);
+                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
+                Self::assert_numel("all_gather input", other, peer_numel, numel);
+            }
         }
         if numel == 0 {
             return;

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -560,6 +560,76 @@ fn test_tcp_all_gather() {
 }
 
 #[test]
+fn test_tcp_all_gather_mismatched_peer_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+
+            let tensor = if rank == 0 {
+                Tensor::from_slice_on([2], &[1.0f32, 2.0], &backend)
+            } else {
+                Tensor::from_slice_on([1], &[3.0f32], &backend)
+            };
+            let mut output = if rank == 0 {
+                vec![Tensor::zeros_on([2], &backend), Tensor::zeros_on([2], &backend)]
+            } else {
+                vec![Tensor::zeros_on([1], &backend), Tensor::zeros_on([1], &backend)]
+            };
+
+            comm.all_gather(&tensor, &mut output, &backend);
+        }));
+    }
+
+    let panicked = handles.into_iter().map(|h| h.join().is_err()).collect::<Vec<_>>();
+    assert!(
+        panicked.iter().any(|&p| p),
+        "TCP all_gather with mismatched peer tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
+fn test_tcp_all_gather_zero_numel_mismatched_peer_numel_panics() {
+    let world_size = 2;
+    let addresses = get_free_ports(world_size);
+    let mut handles = vec![];
+
+    for rank in 0..world_size {
+        let addrs = addresses.clone();
+        handles.push(thread::spawn(move || {
+            let mesh = TcpMesh::new(rank, world_size, &addrs);
+            let comm = TcpCommunicator::new(mesh);
+            let backend = SequentialBackend::new();
+
+            let tensor = if rank == 0 {
+                Tensor::<f32, _>::zeros_on([0], &backend)
+            } else {
+                Tensor::zeros_on([1], &backend)
+            };
+            let mut output = if rank == 0 {
+                vec![Tensor::zeros_on([0], &backend), Tensor::zeros_on([0], &backend)]
+            } else {
+                vec![Tensor::zeros_on([1], &backend), Tensor::zeros_on([1], &backend)]
+            };
+
+            comm.all_gather(&tensor, &mut output, &backend);
+        }));
+    }
+
+    let panicked = handles.into_iter().map(|h| h.join().is_err()).collect::<Vec<_>>();
+    assert!(
+        panicked.iter().any(|&p| p),
+        "TCP all_gather zero-numel with mismatched peer tensor numel should panic on at least one rank"
+    );
+}
+
+#[test]
 fn test_tcp_barrier() {
     let world_size = 2;
     let addresses = get_free_ports(world_size);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,18 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-168: TCP all_gather peer numel handshake [COMPLETE]
+
+- [x] [patch] Added per-peer pre-payload numel handshakes in TCP `all_gather`
+  so each rank validates partner tensor length contracts before payload exchange.
+- [x] [patch] Enforced handshake validation before the zero-numel fast path, so
+  cross-rank zero-numel mismatches fail fast instead of bypassing the collective
+  contract.
+- [x] [patch] Added panic-contract coverage:
+  `test_tcp_all_gather_mismatched_peer_numel_panics` and
+  `test_tcp_all_gather_zero_numel_mismatched_peer_numel_panics`.
+- [x] Evidence: `cargo test -p coeus-dist test_tcp_all_gather -- --nocapture`;
+  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
 ## Sprint MS-167: TCP gather/scatter peer numel handshakes [COMPLETE]
 
 - [x] [patch] Added pre-payload peer-numel handshakes in TCP rooted


### PR DESCRIPTION
## Summary
- add pairwise pre-payload 
umel handshakes in TCP ll_gather
- validate partner tensor sizes before payload transfer, including zero-numel paths
- add panic-contract tests for non-zero and zero-numel peer-size mismatches
- update changelog and backlog sprint tracking

## Validation
- cargo test -p coeus-dist test_tcp_all_gather -- --nocapture
- cargo clippy -p coeus-dist --all-targets -- -D warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the TCP `all_gather` collective operation by adding pairwise pre-payload numel (number of elements) handshakes between all peers. Each rank now validates that partner tensor sizes match before any payload transfer occurs, ensuring cross-rank shape mismatches fail fast rather than causing stream desynchronization. The handshake validation applies to both non-zero and zero-numel cases. Two new panic-contract tests verify the behavior for mismatched peer tensors in both scenarios.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/tcp/collectives.rs` |
| 2 | `coeus-dist/tests/dist_tests.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->