### PR TITLE
Refactor TCP handshake logic to shared helpers

### DIFF
--- a/coeus-dist/src/tcp/collectives.rs
+++ b/coeus-dist/src/tcp/collectives.rs
@@ -36,6 +36,66 @@ impl TcpCommunicator {
     fn assert_root(root: usize, size: usize) {
         assert!(root < size, "collective root out of bounds");
     }
+
+    #[inline]
+    fn numel_bytes(numel: usize) -> [u8; 8] {
+        (numel as u64).to_le_bytes()
+    }
+
+    #[inline]
+    fn recv_numel_from(&self, peer: usize) -> usize {
+        let mut peer_numel_bytes = [0u8; 8];
+        self.mesh.recv(peer, &mut peer_numel_bytes);
+        u64::from_le_bytes(peer_numel_bytes) as usize
+    }
+
+    #[inline]
+    fn rooted_numel_handshake(
+        &self,
+        collective: &'static str,
+        rank: usize,
+        size: usize,
+        root: usize,
+        numel: usize,
+    ) {
+        let local_numel_bytes = Self::numel_bytes(numel);
+        if rank == root {
+            for other in 0..size {
+                if other == root {
+                    continue;
+                }
+                let peer_numel = self.recv_numel_from(other);
+                Self::assert_numel(collective, other, peer_numel, numel);
+            }
+        } else {
+            self.mesh.send(root, &local_numel_bytes);
+        }
+    }
+
+    #[inline]
+    fn pairwise_numel_handshake(
+        &self,
+        collective: &'static str,
+        rank: usize,
+        size: usize,
+        numel: usize,
+    ) {
+        let local_numel_bytes = Self::numel_bytes(numel);
+        for other in 0..size {
+            if other == rank {
+                continue;
+            }
+            if rank < other {
+                self.mesh.send(other, &local_numel_bytes);
+                let peer_numel = self.recv_numel_from(other);
+                Self::assert_numel(collective, other, peer_numel, numel);
+            } else {
+                let peer_numel = self.recv_numel_from(other);
+                self.mesh.send(other, &local_numel_bytes);
+                Self::assert_numel(collective, other, peer_numel, numel);
+            }
+        }
+    }
 }
 
 impl Communicator for TcpCommunicator {
@@ -95,17 +155,8 @@ impl Communicator for TcpCommunicator {
 
         // Exchange expected payload lengths first so rank-shape mismatches fail fast
         // instead of desynchronizing the byte stream.
-        let local_numel_bytes = (numel as u64).to_le_bytes();
+        self.rooted_numel_handshake("broadcast", rank, size, root, numel);
         if rank == root {
-            for other in 0..size {
-                if other == root {
-                    continue;
-                }
-                let mut peer_numel_bytes = [0u8; 8];
-                self.mesh.recv(other, &mut peer_numel_bytes);
-                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
-                Self::assert_numel("broadcast", other, peer_numel, numel);
-            }
             if numel == 0 {
                 return;
             }
@@ -117,7 +168,6 @@ impl Communicator for TcpCommunicator {
                 }
             });
         } else {
-            self.mesh.send(root, &local_numel_bytes);
             if numel == 0 {
                 return;
             }
@@ -137,28 +187,10 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         assert_eq!(output.len(), size, "all_gather output length mismatch");
         let numel = tensor.numel();
-        let local_numel_bytes = (numel as u64).to_le_bytes();
         for (idx, out) in output.iter().enumerate().take(size) {
             Self::assert_numel("all_gather output", idx, out.numel(), numel);
         }
-        for other in 0..size {
-            if other == rank {
-                continue;
-            }
-            if rank < other {
-                self.mesh.send(other, &local_numel_bytes);
-                let mut peer_numel_bytes = [0u8; 8];
-                self.mesh.recv(other, &mut peer_numel_bytes);
-                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
-                Self::assert_numel("all_gather input", other, peer_numel, numel);
-            } else {
-                let mut peer_numel_bytes = [0u8; 8];
-                self.mesh.recv(other, &mut peer_numel_bytes);
-                self.mesh.send(other, &local_numel_bytes);
-                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
-                Self::assert_numel("all_gather input", other, peer_numel, numel);
-            }
-        }
+        self.pairwise_numel_handshake("all_gather input", rank, size, numel);
         if numel == 0 {
             return;
         }
@@ -201,21 +233,7 @@ impl Communicator for TcpCommunicator {
             return;
         }
         let numel = tensor.numel();
-        let local_numel_bytes = (numel as u64).to_le_bytes();
-
-        if rank == root {
-            for other in 0..size {
-                if other == root {
-                    continue;
-                }
-                let mut peer_numel_bytes = [0u8; 8];
-                self.mesh.recv(other, &mut peer_numel_bytes);
-                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
-                Self::assert_numel("reduce input", other, peer_numel, numel);
-            }
-        } else {
-            self.mesh.send(root, &local_numel_bytes);
-        }
+        self.rooted_numel_handshake("reduce input", rank, size, root, numel);
 
         if numel == 0 {
             return;
@@ -254,24 +272,13 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         Self::assert_root(root, size);
         let numel = tensor.numel();
-        let local_numel_bytes = (numel as u64).to_le_bytes();
         if rank == root {
             assert_eq!(output.len(), size, "gather output length mismatch on root");
             for (idx, out) in output.iter().enumerate().take(size) {
                 Self::assert_numel("gather output", idx, out.numel(), numel);
             }
-            for other in 0..size {
-                if other == root {
-                    continue;
-                }
-                let mut peer_numel_bytes = [0u8; 8];
-                self.mesh.recv(other, &mut peer_numel_bytes);
-                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
-                Self::assert_numel("gather input", other, peer_numel, numel);
-            }
-        } else {
-            self.mesh.send(root, &local_numel_bytes);
         }
+        self.rooted_numel_handshake("gather input", rank, size, root, numel);
         if numel == 0 {
             return;
         }
@@ -305,24 +312,13 @@ impl Communicator for TcpCommunicator {
         let size = self.mesh.size();
         Self::assert_root(root, size);
         let numel = tensor.numel();
-        let local_numel_bytes = (numel as u64).to_le_bytes();
         if rank == root {
             assert_eq!(input.len(), size, "scatter input length mismatch on root");
             for (idx, in_tensor) in input.iter().enumerate().take(size) {
                 Self::assert_numel("scatter input", idx, in_tensor.numel(), numel);
             }
-            for other in 0..size {
-                if other == root {
-                    continue;
-                }
-                let mut peer_numel_bytes = [0u8; 8];
-                self.mesh.recv(other, &mut peer_numel_bytes);
-                let peer_numel = u64::from_le_bytes(peer_numel_bytes) as usize;
-                Self::assert_numel("scatter target", other, peer_numel, numel);
-            }
-        } else {
-            self.mesh.send(root, &local_numel_bytes);
         }
+        self.rooted_numel_handshake("scatter target", rank, size, root, numel);
         if numel == 0 {
             return;
         }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -578,16 +578,25 @@ fn test_tcp_all_gather_mismatched_peer_numel_panics() {
                 Tensor::from_slice_on([1], &[3.0f32], &backend)
             };
             let mut output = if rank == 0 {
-                vec![Tensor::zeros_on([2], &backend), Tensor::zeros_on([2], &backend)]
+                vec![
+                    Tensor::zeros_on([2], &backend),
+                    Tensor::zeros_on([2], &backend),
+                ]
             } else {
-                vec![Tensor::zeros_on([1], &backend), Tensor::zeros_on([1], &backend)]
+                vec![
+                    Tensor::zeros_on([1], &backend),
+                    Tensor::zeros_on([1], &backend),
+                ]
             };
 
             comm.all_gather(&tensor, &mut output, &backend);
         }));
     }
 
-    let panicked = handles.into_iter().map(|h| h.join().is_err()).collect::<Vec<_>>();
+    let panicked = handles
+        .into_iter()
+        .map(|h| h.join().is_err())
+        .collect::<Vec<_>>();
     assert!(
         panicked.iter().any(|&p| p),
         "TCP all_gather with mismatched peer tensor numel should panic on at least one rank"
@@ -613,16 +622,25 @@ fn test_tcp_all_gather_zero_numel_mismatched_peer_numel_panics() {
                 Tensor::zeros_on([1], &backend)
             };
             let mut output = if rank == 0 {
-                vec![Tensor::zeros_on([0], &backend), Tensor::zeros_on([0], &backend)]
+                vec![
+                    Tensor::zeros_on([0], &backend),
+                    Tensor::zeros_on([0], &backend),
+                ]
             } else {
-                vec![Tensor::zeros_on([1], &backend), Tensor::zeros_on([1], &backend)]
+                vec![
+                    Tensor::zeros_on([1], &backend),
+                    Tensor::zeros_on([1], &backend),
+                ]
             };
 
             comm.all_gather(&tensor, &mut output, &backend);
         }));
     }
 
-    let panicked = handles.into_iter().map(|h| h.join().is_err()).collect::<Vec<_>>();
+    let panicked = handles
+        .into_iter()
+        .map(|h| h.join().is_err())
+        .collect::<Vec<_>>();
     assert!(
         panicked.iter().any(|&p| p),
         "TCP all_gather zero-numel with mismatched peer tensor numel should panic on at least one rank"
@@ -771,7 +789,10 @@ fn test_tcp_gather_mismatched_peer_numel_panics() {
                 Tensor::from_slice_on([1], &[3.0f32], &backend)
             };
             let mut output = if rank == 1 {
-                vec![Tensor::zeros_on([2], &backend), Tensor::zeros_on([2], &backend)]
+                vec![
+                    Tensor::zeros_on([2], &backend),
+                    Tensor::zeros_on([2], &backend),
+                ]
             } else {
                 vec![]
             };
@@ -804,7 +825,10 @@ fn test_tcp_gather_zero_numel_mismatched_peer_numel_panics() {
                 Tensor::zeros_on([1], &backend)
             };
             let mut output = if rank == 1 {
-                vec![Tensor::zeros_on([0], &backend), Tensor::zeros_on([0], &backend)]
+                vec![
+                    Tensor::zeros_on([0], &backend),
+                    Tensor::zeros_on([0], &backend),
+                ]
             } else {
                 vec![]
             };
@@ -911,7 +935,10 @@ fn test_tcp_scatter_zero_numel_mismatched_target_numel_panics() {
                 Tensor::zeros_on([1], &backend)
             };
             let input = if rank == 0 {
-                vec![Tensor::zeros_on([0], &backend), Tensor::zeros_on([0], &backend)]
+                vec![
+                    Tensor::zeros_on([0], &backend),
+                    Tensor::zeros_on([0], &backend),
+                ]
             } else {
                 vec![]
             };

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,17 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-169: TCP handshake SSOT refactor [COMPLETE]
+
+- [x] [patch] Extracted shared `TcpCommunicator` helpers for numel metadata
+  exchange (`numel_bytes`, `recv_numel_from`, `rooted_numel_handshake`,
+  `pairwise_numel_handshake`) to remove duplicated handshake logic across
+  `broadcast`, `reduce`, `gather`, `scatter`, and `all_gather`.
+- [x] [patch] Preserved fail-fast contract semantics/messages while reducing
+  repeated per-collective control-flow branches (SRP/SSOT/DRY cleanup).
+- [x] Validation attempt was blocked by existing unrelated workspace changes in
+  `coeus-ops` producing conflicting `BackendOps` impl errors during
+  `cargo test -p coeus-dist --test dist_tests test_tcp_all_gather -- --nocapture`.
+
 ## Sprint MS-168: TCP all_gather peer numel handshake [COMPLETE]
 
 - [x] [patch] Added per-peer pre-payload numel handshakes in TCP `all_gather`


### PR DESCRIPTION
## Summary
- extract shared TcpCommunicator helpers for numel metadata exchange: 
umel_bytes, ecv_numel_from, ooted_numel_handshake, pairwise_numel_handshake
- route roadcast, educe, gather, scatter, and ll_gather through these helpers to remove duplicated handshake branches
- preserve existing fail-fast contract semantics and panic messages while consolidating handshake flow

## Validation
- cargo fmt -p coeus-dist
- attempted: cargo test -p coeus-dist --test dist_tests test_tcp_all_gather -- --nocapture (blocked by existing unrelated coeus-ops conflicting BackendOps impl errors in workspace working tree)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors TCP collective communication code by extracting shared helper methods for numel (number of elements) metadata exchange during handshakes. Four new helper methods (`numel_bytes`, `recv_numel_from`, `rooted_numel_handshake`, and `pairwise_numel_handshake`) are introduced to consolidate duplicated handshake logic across `broadcast`, `reduce`, `gather`, `scatter`, and `all_gather` operations. The refactoring preserves existing fail-fast contract semantics and panic messages while reducing code duplication. Test file formatting changes are also included to improve code consistency.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/src/tcp/collectives.rs` |
| 2 | `coeus-dist/tests/dist_tests.rs` |
| 3 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of tensor collective operations by validating tensor sizes earlier before data transfer.
  * Reduced size-mismatch issues across broadcast, reduce, gather, scatter, and all-gather operations.

* **Documentation**
  * Added a new backlog entry reflecting completion of the TCP handshake cleanup work and related validation notes.

* **Style**
  * Updated test formatting for readability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->