### PR TITLE
[codex] Route GPU ops through split traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@
 
 ### Added
 
+- **LayerNorm / RMSNorm JAX parity** — added
+  `test_{layernorm,rmsnorm}_matches_jax`, asserting forward output and
+  input/parameter gradients against formulaic JAX references at f64. Evidence
+  tier: differential/empirical; JAX suite 13/13. ([patch])
+- **Softmax / log-softmax / cross-entropy JAX parity** — added
+  `test_{softmax,log_softmax,cross_entropy_loss}_matches_jax`, asserting
+  forward output and input/logit gradients against `jax.nn` and a fused
+  log-softmax + NLL mean reference at f64. Evidence tier:
+  differential/empirical; JAX suite 11/11. ([patch])
 - **Activation JAX parity (SiLU/Mish/ELU/Softplus/LeakyReLU)** — added
   `test_{silu,mish,elu,softplus,leaky_relu}_matches_jax` to
   `coeus-python/tests/test_jax_parity.py` via a shared

--- a/coeus-cuda/src/backend/ops.rs
+++ b/coeus-cuda/src/backend/ops.rs
@@ -8,7 +8,7 @@ pub mod math;
 pub mod optim;
 pub mod pool;
 
-impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::ElementwiseOps<T> for CudaBackend {
     #[inline]
     fn elementwise_binary(
         &self,
@@ -34,7 +34,9 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
     ) {
         self.cuda_elementwise_unary(op, a, a_layout, c, c_layout);
     }
+}
 
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::MatmulOps<T> for CudaBackend {
     #[inline]
     fn matmul(
         &self,
@@ -47,7 +49,9 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
     ) {
         self.cuda_matmul(a, a_layout, b, b_layout, c, c_layout);
     }
+}
 
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::ReductionOps<T> for CudaBackend {
     #[inline]
     fn reduce(
         &self,
@@ -60,7 +64,10 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
     ) {
         self.cuda_reduce(op, a, a_layout, axis, c, c_layout);
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::ConvOps<T> for CudaBackend {
     #[inline]
     fn conv1d(
         &self,
@@ -189,222 +196,6 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
         );
     }
 
-    #[inline]
-    fn max_pool2d(
-        &self,
-        input: &Self::DeviceBuffer<T>,
-        input_layout: &Layout,
-        kernel_size: usize,
-        stride: usize,
-        padding: usize,
-        dilation: usize,
-        output: &mut Self::DeviceBuffer<T>,
-        output_layout: &Layout,
-    ) {
-        self.cuda_max_pool2d(
-            input,
-            input_layout,
-            kernel_size,
-            stride,
-            padding,
-            dilation,
-            output,
-            output_layout,
-        );
-    }
-
-    #[inline]
-    fn max_pool2d_backward(
-        &self,
-        grad_out: &Self::DeviceBuffer<T>,
-        grad_out_layout: &Layout,
-        input: &Self::DeviceBuffer<T>,
-        input_layout: &Layout,
-        kernel_size: usize,
-        stride: usize,
-        padding: usize,
-        dilation: usize,
-        grad_input: &mut Self::DeviceBuffer<T>,
-        grad_input_layout: &Layout,
-    ) {
-        self.cuda_max_pool2d_backward(
-            grad_out,
-            grad_out_layout,
-            input,
-            input_layout,
-            kernel_size,
-            stride,
-            padding,
-            dilation,
-            grad_input,
-            grad_input_layout,
-        );
-    }
-
-    #[inline]
-    fn avg_pool2d(
-        &self,
-        input: &Self::DeviceBuffer<T>,
-        input_layout: &Layout,
-        kernel_size: usize,
-        stride: usize,
-        padding: usize,
-        dilation: usize,
-        output: &mut Self::DeviceBuffer<T>,
-        output_layout: &Layout,
-    ) {
-        self.cuda_avg_pool2d(
-            input,
-            input_layout,
-            kernel_size,
-            stride,
-            padding,
-            dilation,
-            output,
-            output_layout,
-        );
-    }
-
-    #[inline]
-    fn avg_pool2d_backward(
-        &self,
-        grad_out: &Self::DeviceBuffer<T>,
-        grad_out_layout: &Layout,
-        kernel_size: usize,
-        stride: usize,
-        padding: usize,
-        dilation: usize,
-        grad_input: &mut Self::DeviceBuffer<T>,
-        grad_input_layout: &Layout,
-    ) {
-        self.cuda_avg_pool2d_backward(
-            grad_out,
-            grad_out_layout,
-            kernel_size,
-            stride,
-            padding,
-            dilation,
-            grad_input,
-            grad_input_layout,
-        );
-    }
-
-    #[inline]
-    fn sgd_step(
-        &self,
-        param: &mut Self::DeviceBuffer<T>,
-        param_layout: &Layout,
-        grad: &Self::DeviceBuffer<T>,
-        grad_layout: &Layout,
-        velocity: &mut Self::DeviceBuffer<T>,
-        velocity_layout: &Layout,
-        lr: T,
-        momentum: T,
-    ) where
-        T: coeus_core::Float,
-    {
-        self.cuda_sgd_step(
-            param,
-            param_layout,
-            grad,
-            grad_layout,
-            velocity,
-            velocity_layout,
-            lr,
-            momentum,
-        );
-    }
-
-    #[inline]
-    fn adam_step(
-        &self,
-        param: &mut Self::DeviceBuffer<T>,
-        param_layout: &Layout,
-        grad: &Self::DeviceBuffer<T>,
-        grad_layout: &Layout,
-        m: &mut Self::DeviceBuffer<T>,
-        m_layout: &Layout,
-        v: &mut Self::DeviceBuffer<T>,
-        v_layout: &Layout,
-        lr: T,
-        beta1: T,
-        beta2: T,
-        eps: T,
-        t: usize,
-    ) where
-        T: coeus_core::Float,
-    {
-        self.cuda_adam_step(
-            param,
-            param_layout,
-            grad,
-            grad_layout,
-            m,
-            m_layout,
-            v,
-            v_layout,
-            lr,
-            beta1,
-            beta2,
-            eps,
-            t,
-        );
-    }
-
-    #[inline]
-    fn rmsprop_step(
-        &self,
-        param: &mut Self::DeviceBuffer<T>,
-        param_layout: &Layout,
-        grad: &Self::DeviceBuffer<T>,
-        grad_layout: &Layout,
-        v: &mut Self::DeviceBuffer<T>,
-        v_layout: &Layout,
-        lr: T,
-        alpha: T,
-        eps: T,
-    ) where
-        T: coeus_core::Float,
-    {
-        self.cuda_rmsprop_step(
-            param,
-            param_layout,
-            grad,
-            grad_layout,
-            v,
-            v_layout,
-            lr,
-            alpha,
-            eps,
-        );
-    }
-
-    #[inline]
-    fn adagrad_step(
-        &self,
-        param: &mut Self::DeviceBuffer<T>,
-        param_layout: &Layout,
-        grad: &Self::DeviceBuffer<T>,
-        grad_layout: &Layout,
-        history: &mut Self::DeviceBuffer<T>,
-        history_layout: &Layout,
-        lr: T,
-        eps: T,
-    ) where
-        T: coeus_core::Float,
-    {
-        self.cuda_adagrad_step(
-            param,
-            param_layout,
-            grad,
-            grad_layout,
-            history,
-            history_layout,
-            lr,
-            eps,
-        );
-    }
-
     fn conv3d(
         &self,
         input: &Self::DeviceBuffer<T>,
@@ -528,6 +319,109 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
             output_layout,
         );
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::PoolOps<T> for CudaBackend {
+    #[inline]
+    fn max_pool2d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) {
+        self.cuda_max_pool2d(
+            input,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            output,
+            output_layout,
+        );
+    }
+
+    #[inline]
+    fn max_pool2d_backward(
+        &self,
+        grad_out: &Self::DeviceBuffer<T>,
+        grad_out_layout: &Layout,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        grad_input: &mut Self::DeviceBuffer<T>,
+        grad_input_layout: &Layout,
+    ) {
+        self.cuda_max_pool2d_backward(
+            grad_out,
+            grad_out_layout,
+            input,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        );
+    }
+
+    #[inline]
+    fn avg_pool2d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) {
+        self.cuda_avg_pool2d(
+            input,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            output,
+            output_layout,
+        );
+    }
+
+    #[inline]
+    fn avg_pool2d_backward(
+        &self,
+        grad_out: &Self::DeviceBuffer<T>,
+        grad_out_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        grad_input: &mut Self::DeviceBuffer<T>,
+        grad_input_layout: &Layout,
+    ) {
+        self.cuda_avg_pool2d_backward(
+            grad_out,
+            grad_out_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        );
+    }
 
     fn max_pool3d(
         &self,
@@ -624,7 +518,10 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
             grad_input_layout,
         );
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::AttentionOps<T> for CudaBackend {
     fn sdp_attention(
         &self,
         query: &Self::DeviceBuffer<T>,
@@ -696,6 +593,125 @@ impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::BackendOps<T> for C
             grad_q,
             grad_k,
             grad_v,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar + hephaestus_cuda::CudaScalar> coeus_ops::OptimizerOps<T> for CudaBackend {
+    #[inline]
+    fn sgd_step(
+        &self,
+        param: &mut Self::DeviceBuffer<T>,
+        param_layout: &Layout,
+        grad: &Self::DeviceBuffer<T>,
+        grad_layout: &Layout,
+        velocity: &mut Self::DeviceBuffer<T>,
+        velocity_layout: &Layout,
+        lr: T,
+        momentum: T,
+    ) where
+        T: coeus_core::Float,
+    {
+        self.cuda_sgd_step(
+            param,
+            param_layout,
+            grad,
+            grad_layout,
+            velocity,
+            velocity_layout,
+            lr,
+            momentum,
+        );
+    }
+
+    #[inline]
+    fn adam_step(
+        &self,
+        param: &mut Self::DeviceBuffer<T>,
+        param_layout: &Layout,
+        grad: &Self::DeviceBuffer<T>,
+        grad_layout: &Layout,
+        m: &mut Self::DeviceBuffer<T>,
+        m_layout: &Layout,
+        v: &mut Self::DeviceBuffer<T>,
+        v_layout: &Layout,
+        lr: T,
+        beta1: T,
+        beta2: T,
+        eps: T,
+        t: usize,
+    ) where
+        T: coeus_core::Float,
+    {
+        self.cuda_adam_step(
+            param,
+            param_layout,
+            grad,
+            grad_layout,
+            m,
+            m_layout,
+            v,
+            v_layout,
+            lr,
+            beta1,
+            beta2,
+            eps,
+            t,
+        );
+    }
+
+    #[inline]
+    fn rmsprop_step(
+        &self,
+        param: &mut Self::DeviceBuffer<T>,
+        param_layout: &Layout,
+        grad: &Self::DeviceBuffer<T>,
+        grad_layout: &Layout,
+        v: &mut Self::DeviceBuffer<T>,
+        v_layout: &Layout,
+        lr: T,
+        alpha: T,
+        eps: T,
+    ) where
+        T: coeus_core::Float,
+    {
+        self.cuda_rmsprop_step(
+            param,
+            param_layout,
+            grad,
+            grad_layout,
+            v,
+            v_layout,
+            lr,
+            alpha,
+            eps,
+        );
+    }
+
+    #[inline]
+    fn adagrad_step(
+        &self,
+        param: &mut Self::DeviceBuffer<T>,
+        param_layout: &Layout,
+        grad: &Self::DeviceBuffer<T>,
+        grad_layout: &Layout,
+        history: &mut Self::DeviceBuffer<T>,
+        history_layout: &Layout,
+        lr: T,
+        eps: T,
+    ) where
+        T: coeus_core::Float,
+    {
+        self.cuda_adagrad_step(
+            param,
+            param_layout,
+            grad,
+            grad_layout,
+            history,
+            history_layout,
+            lr,
+            eps,
         );
     }
 

--- a/coeus-cuda/src/backend/ops/conv.rs
+++ b/coeus-cuda/src/backend/ops/conv.rs
@@ -453,7 +453,7 @@ impl CudaBackend {
         let seq_bias = host_bias.map(|hb| coeus_core::CpuStorage::from_slice(&hb));
         let mut seq_out = coeus_core::CpuStorage::from_slice(&vec![T::zero(); output.len()]);
 
-        coeus_ops::BackendOps::conv_transpose1d(
+        coeus_ops::ConvOps::conv_transpose1d(
             &seq,
             &seq_in,
             input_layout,
@@ -541,7 +541,7 @@ impl CudaBackend {
         let seq_bias = host_bias.map(|hb| coeus_core::CpuStorage::from_slice(&hb));
         let mut seq_out = coeus_core::CpuStorage::from_slice(&vec![T::zero(); output.len()]);
 
-        coeus_ops::BackendOps::conv_transpose2d(
+        coeus_ops::ConvOps::conv_transpose2d(
             &seq,
             &seq_in,
             input_layout,

--- a/coeus-cuda/src/backend_stub.rs
+++ b/coeus-cuda/src/backend_stub.rs
@@ -128,7 +128,7 @@ impl Backend for CudaBackend {
     }
 }
 
-impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
+impl<T: CudaScalar> coeus_ops::ElementwiseOps<T> for CudaBackend {
     #[inline]
     fn elementwise_binary(
         &self,
@@ -154,7 +154,9 @@ impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
     ) {
         self.fallback_unary(op, a, a_layout, c, c_layout);
     }
+}
 
+impl<T: CudaScalar> coeus_ops::MatmulOps<T> for CudaBackend {
     #[inline]
     fn matmul(
         &self,
@@ -167,7 +169,9 @@ impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
     ) {
         self.fallback_matmul(a, a_layout, b, b_layout, c, c_layout);
     }
+}
 
+impl<T: CudaScalar> coeus_ops::ReductionOps<T> for CudaBackend {
     #[inline]
     fn reduce(
         &self,
@@ -180,7 +184,10 @@ impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
     ) {
         self.fallback_reduce(op, a, a_layout, axis, c, c_layout);
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar> coeus_ops::ConvOps<T> for CudaBackend {
     #[inline]
     fn conv1d(
         &self,
@@ -372,7 +379,10 @@ impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
             dilation,
         );
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar> coeus_ops::PoolOps<T> for CudaBackend {
     #[inline]
     fn max_pool2d(
         &self,
@@ -572,7 +582,10 @@ impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
             grad_input_layout,
         );
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar> coeus_ops::AttentionOps<T> for CudaBackend {
     #[inline]
     fn sdp_attention(
         &self,
@@ -648,7 +661,10 @@ impl<T: CudaScalar> coeus_ops::BackendOps<T> for CudaBackend {
             grad_v,
         );
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: CudaScalar> coeus_ops::OptimizerOps<T> for CudaBackend {
     #[inline]
     fn sgd_step(
         &self,

--- a/coeus-cuda/src/fallback/ops/attention.rs
+++ b/coeus-cuda/src/fallback/ops/attention.rs
@@ -7,7 +7,7 @@
 use crate::backend::{CudaBackend, CudaScalar};
 use crate::storage::CudaStorage;
 use coeus_core::{ComputeBackend, Layout, Storage};
-use coeus_ops::BackendOps;
+use coeus_ops::AttentionOps;
 
 impl CudaBackend {
     pub(crate) fn fallback_sdp_attention<T: CudaScalar>(

--- a/coeus-cuda/src/fallback/ops/conv.rs
+++ b/coeus-cuda/src/fallback/ops/conv.rs
@@ -38,7 +38,7 @@ impl CudaBackend {
         let seq_bias = host_bias.map(|hb| coeus_core::CpuStorage::from_slice(&hb));
         let mut seq_out = coeus_core::CpuStorage::from_slice(&vec![T::zero(); output.len()]);
 
-        coeus_ops::BackendOps::conv1d(
+        coeus_ops::ConvOps::conv1d(
             &seq,
             &seq_in,
             input_layout,
@@ -86,7 +86,7 @@ impl CudaBackend {
         let seq_bias = host_bias.map(|hb| coeus_core::CpuStorage::from_slice(&hb));
         let mut seq_out = coeus_core::CpuStorage::from_slice(&vec![T::zero(); output.len()]);
 
-        coeus_ops::BackendOps::conv2d(
+        coeus_ops::ConvOps::conv2d(
             &seq,
             &seq_in,
             input_layout,
@@ -143,7 +143,7 @@ impl CudaBackend {
             .as_ref()
             .map(|gb| coeus_core::CpuStorage::from_slice(&vec![T::zero(); gb.len()]));
 
-        coeus_ops::BackendOps::conv1d_backward(
+        coeus_ops::ConvOps::conv1d_backward(
             &seq,
             &seq_go,
             grad_out_layout,
@@ -212,7 +212,7 @@ impl CudaBackend {
             .as_ref()
             .map(|gb| coeus_core::CpuStorage::from_slice(&vec![T::zero(); gb.len()]));
 
-        coeus_ops::BackendOps::conv2d_backward(
+        coeus_ops::ConvOps::conv2d_backward(
             &seq,
             &seq_go,
             grad_out_layout,
@@ -272,7 +272,7 @@ impl CudaBackend {
         let seq_bias = host_bias.map(|hb| coeus_core::CpuStorage::from_slice(&hb));
         let mut seq_out = coeus_core::CpuStorage::from_slice(&vec![T::zero(); output.len()]);
 
-        coeus_ops::BackendOps::conv3d(
+        coeus_ops::ConvOps::conv3d(
             &seq,
             &seq_in,
             input_layout,
@@ -329,7 +329,7 @@ impl CudaBackend {
             .as_ref()
             .map(|gb| coeus_core::CpuStorage::from_slice(&vec![T::zero(); gb.len()]));
 
-        coeus_ops::BackendOps::conv3d_backward(
+        coeus_ops::ConvOps::conv3d_backward(
             &seq,
             &seq_go,
             grad_out_layout,

--- a/coeus-cuda/src/fallback/ops/math.rs
+++ b/coeus-cuda/src/fallback/ops/math.rs
@@ -30,7 +30,7 @@ impl CudaBackend {
         let seq_b = coeus_core::CpuStorage::from_slice(&host_b);
         let mut seq_c = coeus_core::CpuStorage::from_slice(&host_c);
 
-        coeus_ops::BackendOps::elementwise_binary(
+        coeus_ops::ElementwiseOps::elementwise_binary(
             &seq, op, &seq_a, a_layout, &seq_b, b_layout, &mut seq_c, c_layout,
         );
 
@@ -55,7 +55,9 @@ impl CudaBackend {
         let seq_a = coeus_core::CpuStorage::from_slice(&host_a);
         let mut seq_c = coeus_core::CpuStorage::from_slice(&host_c);
 
-        coeus_ops::BackendOps::elementwise_unary(&seq, op, &seq_a, a_layout, &mut seq_c, c_layout);
+        coeus_ops::ElementwiseOps::elementwise_unary(
+            &seq, op, &seq_a, a_layout, &mut seq_c, c_layout,
+        );
 
         use coeus_core::CpuAddressableStorage;
         self.copy_to_device(seq_c.as_slice(), c);
@@ -82,7 +84,7 @@ impl CudaBackend {
         let seq_b = coeus_core::CpuStorage::from_slice(&host_b);
         let mut seq_c = coeus_core::CpuStorage::from_slice(&host_c);
 
-        coeus_ops::BackendOps::matmul(
+        coeus_ops::MatmulOps::matmul(
             &seq, &seq_a, a_layout, &seq_b, b_layout, &mut seq_c, c_layout,
         );
 
@@ -108,7 +110,7 @@ impl CudaBackend {
         let seq_a = coeus_core::CpuStorage::from_slice(&host_a);
         let mut seq_c = coeus_core::CpuStorage::from_slice(&host_c);
 
-        coeus_ops::BackendOps::reduce(&seq, op, &seq_a, a_layout, axis, &mut seq_c, c_layout);
+        coeus_ops::ReductionOps::reduce(&seq, op, &seq_a, a_layout, axis, &mut seq_c, c_layout);
 
         use coeus_core::CpuAddressableStorage;
         self.copy_to_device(seq_c.as_slice(), c);

--- a/coeus-cuda/src/fallback/ops/optim.rs
+++ b/coeus-cuda/src/fallback/ops/optim.rs
@@ -34,7 +34,7 @@ impl CudaBackend {
         let seq_grad = coeus_core::CpuStorage::from_slice(&host_grad);
         let mut seq_velocity = coeus_core::CpuStorage::from_slice(&host_velocity);
 
-        coeus_ops::BackendOps::sgd_step(
+        coeus_ops::OptimizerOps::sgd_step(
             &seq,
             &mut seq_param,
             param_layout,
@@ -84,7 +84,7 @@ impl CudaBackend {
         let mut seq_m = coeus_core::CpuStorage::from_slice(&host_m);
         let mut seq_v = coeus_core::CpuStorage::from_slice(&host_v);
 
-        coeus_ops::BackendOps::adam_step(
+        coeus_ops::OptimizerOps::adam_step(
             &seq,
             &mut seq_param,
             param_layout,
@@ -133,7 +133,7 @@ impl CudaBackend {
         let seq_grad = coeus_core::CpuStorage::from_slice(&host_grad);
         let mut seq_v = coeus_core::CpuStorage::from_slice(&host_v);
 
-        coeus_ops::BackendOps::rmsprop_step(
+        coeus_ops::OptimizerOps::rmsprop_step(
             &seq,
             &mut seq_param,
             param_layout,
@@ -176,7 +176,7 @@ impl CudaBackend {
         let seq_grad = coeus_core::CpuStorage::from_slice(&host_grad);
         let mut seq_history = coeus_core::CpuStorage::from_slice(&host_history);
 
-        coeus_ops::BackendOps::adagrad_step(
+        coeus_ops::OptimizerOps::adagrad_step(
             &seq,
             &mut seq_param,
             param_layout,
@@ -228,7 +228,7 @@ impl CudaBackend {
         let mut seq_m = coeus_core::CpuStorage::from_slice(&host_m);
         let mut seq_v = coeus_core::CpuStorage::from_slice(&host_v);
 
-        coeus_ops::BackendOps::adamw_step(
+        coeus_ops::OptimizerOps::adamw_step(
             &seq,
             &mut seq_param,
             param_layout,

--- a/coeus-cuda/src/fallback/ops/pool.rs
+++ b/coeus-cuda/src/fallback/ops/pool.rs
@@ -28,7 +28,7 @@ impl CudaBackend {
         let seq_in = coeus_core::CpuStorage::from_slice(&host_in);
         let mut seq_out = coeus_core::CpuStorage::from_slice(&host_out);
 
-        coeus_ops::BackendOps::max_pool2d(
+        coeus_ops::PoolOps::max_pool2d(
             &seq,
             &seq_in,
             input_layout,
@@ -69,7 +69,7 @@ impl CudaBackend {
         let seq_in = coeus_core::CpuStorage::from_slice(&host_in);
         let mut seq_gi = coeus_core::CpuStorage::from_slice(&host_gi);
 
-        coeus_ops::BackendOps::max_pool2d_backward(
+        coeus_ops::PoolOps::max_pool2d_backward(
             &seq,
             &seq_go,
             grad_out_layout,
@@ -107,7 +107,7 @@ impl CudaBackend {
         let seq_in = coeus_core::CpuStorage::from_slice(&host_in);
         let mut seq_out = coeus_core::CpuStorage::from_slice(&host_out);
 
-        coeus_ops::BackendOps::avg_pool2d(
+        coeus_ops::PoolOps::avg_pool2d(
             &seq,
             &seq_in,
             input_layout,
@@ -143,7 +143,7 @@ impl CudaBackend {
         let seq_go = coeus_core::CpuStorage::from_slice(&host_go);
         let mut seq_gi = coeus_core::CpuStorage::from_slice(&host_gi);
 
-        coeus_ops::BackendOps::avg_pool2d_backward(
+        coeus_ops::PoolOps::avg_pool2d_backward(
             &seq,
             &seq_go,
             grad_out_layout,
@@ -179,7 +179,7 @@ impl CudaBackend {
         let seq_in = coeus_core::CpuStorage::from_slice(&host_in);
         let mut seq_out = coeus_core::CpuStorage::from_slice(&host_out);
 
-        coeus_ops::BackendOps::max_pool3d(
+        coeus_ops::PoolOps::max_pool3d(
             &seq,
             &seq_in,
             input_layout,
@@ -220,7 +220,7 @@ impl CudaBackend {
         let seq_in = coeus_core::CpuStorage::from_slice(&host_in);
         let mut seq_gi = coeus_core::CpuStorage::from_slice(&host_gi);
 
-        coeus_ops::BackendOps::max_pool3d_backward(
+        coeus_ops::PoolOps::max_pool3d_backward(
             &seq,
             &seq_go,
             grad_out_layout,
@@ -258,7 +258,7 @@ impl CudaBackend {
         let seq_in = coeus_core::CpuStorage::from_slice(&host_in);
         let mut seq_out = coeus_core::CpuStorage::from_slice(&host_out);
 
-        coeus_ops::BackendOps::avg_pool3d(
+        coeus_ops::PoolOps::avg_pool3d(
             &seq,
             &seq_in,
             input_layout,
@@ -294,7 +294,7 @@ impl CudaBackend {
         let seq_go = coeus_core::CpuStorage::from_slice(&host_go);
         let mut seq_gi = coeus_core::CpuStorage::from_slice(&host_gi);
 
-        coeus_ops::BackendOps::avg_pool3d_backward(
+        coeus_ops::PoolOps::avg_pool3d_backward(
             &seq,
             &seq_go,
             grad_out_layout,

--- a/coeus-cuda/tests/cuda/conv_reduce.rs
+++ b/coeus-cuda/tests/cuda/conv_reduce.rs
@@ -32,7 +32,7 @@ fn test_cuda_backend_conv_and_reduce() {
     let mut out_cuda_storage = cuda_b.allocate::<f32>(6);
     let out_layout = coeus_core::Layout::new(vec![1, 2, 3].into());
 
-    coeus_ops::BackendOps::conv1d(
+    coeus_ops::ConvOps::conv1d(
         &cuda_b,
         input_cuda.storage(),
         input_cuda.layout(),
@@ -51,7 +51,7 @@ fn test_cuda_backend_conv_and_reduce() {
     let out_seq = out_tensor_cuda.to_backend_on(&cuda_b, &seq);
 
     let mut out_expected_storage = seq.allocate::<f32>(6);
-    coeus_ops::BackendOps::conv1d(
+    coeus_ops::ConvOps::conv1d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -119,7 +119,7 @@ fn test_cuda_conv_backward() {
         let gi_layout = coeus_core::Layout::new(vec![1, 2, 3].into());
         let gw_layout = coeus_core::Layout::new(vec![2, 2, 1].into());
 
-        coeus_ops::BackendOps::conv1d_backward(
+        coeus_ops::ConvOps::conv1d_backward(
             &cuda_b,
             grad_out_cuda.storage(),
             grad_out_cuda.layout(),
@@ -144,7 +144,7 @@ fn test_cuda_conv_backward() {
         let mut gb_expected = seq.allocate::<f32>(2);
         seq.fill(&mut gb_expected, 0.0);
 
-        coeus_ops::BackendOps::conv1d_backward(
+        coeus_ops::ConvOps::conv1d_backward(
             &seq,
             grad_out_seq.storage(),
             grad_out_seq.layout(),

--- a/coeus-cuda/tests/cuda/optimizer_and_3d.rs
+++ b/coeus-cuda/tests/cuda/optimizer_and_3d.rs
@@ -1,6 +1,6 @@
 use coeus_core::SequentialBackend;
 use coeus_cuda::CudaBackend;
-use coeus_ops::BackendOps;
+use coeus_ops::{ConvOps, OptimizerOps, PoolOps};
 use coeus_tensor::Tensor;
 
 #[test]
@@ -35,8 +35,6 @@ fn test_cuda_adamw_step() {
     let g_cuda_layout = grad_cuda.layout().clone();
     let m_cuda_layout = m_cuda.layout().clone();
     let v_cuda_layout = v_cuda.layout().clone();
-
-    use coeus_ops::BackendOps;
     seq.adamw_step(
         param_seq.storage_mut(),
         &p_seq_layout,
@@ -149,8 +147,6 @@ fn test_cuda_conv3d() {
     let input_cuda_layout = input_cuda.layout().clone();
     let weight_cuda_layout = weight_cuda.layout().clone();
     let out_cuda_layout = out_cuda.layout().clone();
-
-    use coeus_ops::BackendOps;
     seq.conv3d(
         input_seq.storage(),
         &input_seq_layout,

--- a/coeus-cuda/tests/cuda/parity.rs
+++ b/coeus-cuda/tests/cuda/parity.rs
@@ -13,6 +13,7 @@
 
 use coeus_core::SequentialBackend;
 use coeus_cuda::CudaBackend;
+use coeus_ops::{ConvOps, OptimizerOps, PoolOps};
 use coeus_tensor::Tensor;
 
 /// Element-wise tolerance for direct (non-accumulating) ops. f32 transcendental
@@ -364,7 +365,6 @@ fn test_cuda_parity_batched_matmul() {
 
 #[test]
 fn test_cuda_parity_conv1d_forward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -425,7 +425,6 @@ fn test_cuda_parity_conv1d_forward() {
 
 #[test]
 fn test_cuda_parity_conv2d_forward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -487,7 +486,6 @@ fn test_cuda_parity_conv2d_forward() {
 
 #[test]
 fn test_cuda_parity_conv2d_backward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -578,7 +576,6 @@ fn test_cuda_parity_conv2d_backward() {
 
 #[test]
 fn test_cuda_parity_conv3d_forward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -641,7 +638,6 @@ fn test_cuda_parity_conv3d_forward() {
 
 #[test]
 fn test_cuda_parity_conv3d_backward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -733,7 +729,6 @@ fn test_cuda_parity_conv3d_backward() {
 
 #[test]
 fn test_cuda_parity_max_pool2d() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -777,7 +772,6 @@ fn test_cuda_parity_max_pool2d() {
 
 #[test]
 fn test_cuda_parity_avg_pool2d() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -821,7 +815,6 @@ fn test_cuda_parity_avg_pool2d() {
 
 #[test]
 fn test_cuda_parity_max_pool2d_backward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -874,7 +867,6 @@ fn test_cuda_parity_max_pool2d_backward() {
 
 #[test]
 fn test_cuda_parity_avg_pool2d_backward() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -921,7 +913,6 @@ fn test_cuda_parity_avg_pool2d_backward() {
 
 #[test]
 fn test_cuda_parity_adamw_step() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -1012,7 +1003,6 @@ fn test_cuda_parity_roundtrip_identity() {
 
 #[test]
 fn test_cuda_parity_sgd_step() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -1069,7 +1059,6 @@ fn test_cuda_parity_sgd_step() {
 
 #[test]
 fn test_cuda_parity_adam_step() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -1146,7 +1135,6 @@ fn test_cuda_parity_adam_step() {
 
 #[test]
 fn test_cuda_parity_rmsprop_step() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -1205,7 +1193,6 @@ fn test_cuda_parity_rmsprop_step() {
 
 #[test]
 fn test_cuda_parity_adagrad_step() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -1264,7 +1251,6 @@ fn test_cuda_parity_adagrad_step() {
 
 #[test]
 fn test_cuda_parity_conv_transpose1d() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };
@@ -1327,7 +1313,6 @@ fn test_cuda_parity_conv_transpose1d() {
 
 #[test]
 fn test_cuda_parity_conv_transpose2d() {
-    use coeus_ops::BackendOps;
     let Some((s, c)) = backends() else {
         return;
     };

--- a/coeus-cuda/tests/cuda_pool_tests.rs
+++ b/coeus-cuda/tests/cuda_pool_tests.rs
@@ -20,7 +20,7 @@ fn test_cuda_max_pool2d() {
     let mut output_cuda = Tensor::<f32, CudaBackend>::zeros(vec![1, 1, 2, 2]);
 
     let (out_seq_storage, out_seq_layout) = output_seq.storage_mut_and_layout();
-    coeus_ops::BackendOps::max_pool2d(
+    coeus_ops::PoolOps::max_pool2d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -33,7 +33,7 @@ fn test_cuda_max_pool2d() {
     );
 
     let (out_cuda_storage, out_cuda_layout) = output_cuda.storage_mut_and_layout();
-    coeus_ops::BackendOps::max_pool2d(
+    coeus_ops::PoolOps::max_pool2d(
         &cuda_b,
         input_cuda.storage(),
         input_cuda.layout(),
@@ -61,7 +61,7 @@ fn test_cuda_max_pool2d() {
     let mut grad_in_cuda = Tensor::<f32, CudaBackend>::zeros(vec![1, 1, 4, 4]);
 
     let (gi_seq_storage, gi_seq_layout) = grad_in_seq.storage_mut_and_layout();
-    coeus_ops::BackendOps::max_pool2d_backward(
+    coeus_ops::PoolOps::max_pool2d_backward(
         &seq,
         grad_out_seq.storage(),
         grad_out_seq.layout(),
@@ -76,7 +76,7 @@ fn test_cuda_max_pool2d() {
     );
 
     let (gi_cuda_storage, gi_cuda_layout) = grad_in_cuda.storage_mut_and_layout();
-    coeus_ops::BackendOps::max_pool2d_backward(
+    coeus_ops::PoolOps::max_pool2d_backward(
         &cuda_b,
         grad_out_cuda.storage(),
         grad_out_cuda.layout(),
@@ -113,7 +113,7 @@ fn test_cuda_avg_pool2d() {
     let mut output_cuda = Tensor::<f32, CudaBackend>::zeros(vec![1, 1, 2, 2]);
 
     let (out_seq_storage, out_seq_layout) = output_seq.storage_mut_and_layout();
-    coeus_ops::BackendOps::avg_pool2d(
+    coeus_ops::PoolOps::avg_pool2d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -126,7 +126,7 @@ fn test_cuda_avg_pool2d() {
     );
 
     let (out_cuda_storage, out_cuda_layout) = output_cuda.storage_mut_and_layout();
-    coeus_ops::BackendOps::avg_pool2d(
+    coeus_ops::PoolOps::avg_pool2d(
         &cuda_b,
         input_cuda.storage(),
         input_cuda.layout(),
@@ -154,7 +154,7 @@ fn test_cuda_avg_pool2d() {
     let mut grad_in_cuda = Tensor::<f32, CudaBackend>::zeros(vec![1, 1, 4, 4]);
 
     let (gi_seq_storage, gi_seq_layout) = grad_in_seq.storage_mut_and_layout();
-    coeus_ops::BackendOps::avg_pool2d_backward(
+    coeus_ops::PoolOps::avg_pool2d_backward(
         &seq,
         grad_out_seq.storage(),
         grad_out_seq.layout(),
@@ -167,7 +167,7 @@ fn test_cuda_avg_pool2d() {
     );
 
     let (gi_cuda_storage, gi_cuda_layout) = grad_in_cuda.storage_mut_and_layout();
-    coeus_ops::BackendOps::avg_pool2d_backward(
+    coeus_ops::PoolOps::avg_pool2d_backward(
         &cuda_b,
         grad_out_cuda.storage(),
         grad_out_cuda.layout(),

--- a/coeus-python/src/nn/conv.rs
+++ b/coeus-python/src/nn/conv.rs
@@ -537,7 +537,7 @@ impl PyConvTranspose1d {
             let c_out = w_var.tensor.shape()[1];
             let mut out_tensor = coeus_tensor::Tensor::zeros_on([n, c_out, l_out], &bk);
             let (out_storage, out_layout) = out_tensor.storage_mut_and_layout();
-            use coeus_ops::BackendOps;
+            use coeus_ops::ConvOps;
             bk.conv_transpose1d(
                 x_var.tensor.storage(),
                 x_var.tensor.layout(),
@@ -663,7 +663,7 @@ impl PyConvTranspose2d {
             let c_out = w_var.tensor.shape()[1];
             let mut out_tensor = coeus_tensor::Tensor::zeros_on([n, c_out, h_out, w_out], &bk);
             let (out_storage, out_layout) = out_tensor.storage_mut_and_layout();
-            use coeus_ops::BackendOps;
+            use coeus_ops::ConvOps;
             bk.conv_transpose2d(
                 x_var.tensor.storage(),
                 x_var.tensor.layout(),

--- a/coeus-wgpu/src/backend/ops/attention.rs
+++ b/coeus-wgpu/src/backend/ops/attention.rs
@@ -3,7 +3,7 @@ use coeus_core::{
     ComputeBackend, CpuAddressableStorage, CpuAddressableStorageMut, Float, Layout,
     SequentialBackend, Storage,
 };
-use coeus_ops::BackendOps;
+use coeus_ops::AttentionOps;
 
 type WgpuBuffer<T> = <WgpuBackend as ComputeBackend>::DeviceBuffer<T>;
 

--- a/coeus-wgpu/src/backend/ops/mod.rs
+++ b/coeus-wgpu/src/backend/ops/mod.rs
@@ -362,7 +362,7 @@ fn try_hephaestus_contiguous_unary<T: WgpuScalar + hephaestus_wgpu::WgslScalar>(
     }
 }
 
-impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::BackendOps<T>
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::ElementwiseOps<T>
     for WgpuBackend
 {
     #[inline]
@@ -436,7 +436,11 @@ impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::
             kernels::dispatch_unary::<T>(op, &a.buffer, a_layout, &c.buffer, c_layout, c.len());
         }
     }
+}
 
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::MatmulOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn matmul(
         &self,
@@ -449,7 +453,11 @@ impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::
     ) {
         matmul::dispatch_matmul(a, a_layout, b, b_layout, c, c_layout);
     }
+}
 
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::ReductionOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn reduce(
         &self,
@@ -462,7 +470,12 @@ impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::
     ) {
         reduction::dispatch_reduce(op, a, a_layout, axis, c, c_layout);
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::ConvOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn conv1d(
         &self,
@@ -718,7 +731,12 @@ impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::
             output_layout,
         );
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::PoolOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn max_pool2d(
         &self,
@@ -918,7 +936,12 @@ impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::
             grad_input_layout,
         );
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::AttentionOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn sdp_attention(
         &self,
@@ -994,7 +1017,12 @@ impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::
             grad_v,
         });
     }
+}
 
+#[allow(clippy::too_many_arguments)]
+impl<T: WgpuScalar + leto_ops::Scalar + hephaestus_wgpu::WgslScalar> coeus_ops::OptimizerOps<T>
+    for WgpuBackend
+{
     #[inline]
     fn sgd_step(
         &self,

--- a/coeus-wgpu/tests/wgpu/conv.rs
+++ b/coeus-wgpu/tests/wgpu/conv.rs
@@ -19,7 +19,7 @@ fn test_wgpu_conv() {
     let mut out_wgpu_storage = wgpu_b.allocate::<f32>(6);
     let out_layout = coeus_core::Layout::new(vec![1, 2, 3].into());
 
-    coeus_ops::BackendOps::conv1d(
+    coeus_ops::ConvOps::conv1d(
         &wgpu_b,
         input_wgpu.storage(),
         input_wgpu.layout(),
@@ -38,7 +38,7 @@ fn test_wgpu_conv() {
     let out_seq = out_tensor_wgpu.to_backend_on(&wgpu_b, &seq);
 
     let mut out_expected_storage = seq.allocate::<f32>(6);
-    coeus_ops::BackendOps::conv1d(
+    coeus_ops::ConvOps::conv1d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -85,7 +85,7 @@ fn test_wgpu_conv() {
     let mut out_2d_wgpu_storage = wgpu_b.allocate::<f32>(4);
     let out_2d_layout = coeus_core::Layout::new(vec![1, 1, 2, 2].into());
 
-    coeus_ops::BackendOps::conv2d(
+    coeus_ops::ConvOps::conv2d(
         &wgpu_b,
         input_2d_wgpu.storage(),
         input_2d_wgpu.layout(),
@@ -104,7 +104,7 @@ fn test_wgpu_conv() {
     let out_2d_seq = out_2d_tensor_wgpu.to_backend_on(&wgpu_b, &seq);
 
     let mut out_2d_expected_storage = seq.allocate::<f32>(4);
-    coeus_ops::BackendOps::conv2d(
+    coeus_ops::ConvOps::conv2d(
         &seq,
         input_2d_seq.storage(),
         input_2d_seq.layout(),
@@ -164,7 +164,7 @@ fn test_wgpu_conv_backward() {
     let gi_layout = coeus_core::Layout::new(vec![1, 2, 3].into());
     let gw_layout = coeus_core::Layout::new(vec![2, 2, 1].into());
 
-    coeus_ops::BackendOps::conv1d_backward(
+    coeus_ops::ConvOps::conv1d_backward(
         &wgpu_b,
         grad_out_wgpu.storage(),
         grad_out_wgpu.layout(),
@@ -189,7 +189,7 @@ fn test_wgpu_conv_backward() {
     let mut gb_expected = seq.allocate::<f32>(2);
     seq.fill(&mut gb_expected, 0.0);
 
-    coeus_ops::BackendOps::conv1d_backward(
+    coeus_ops::ConvOps::conv1d_backward(
         &seq,
         grad_out_seq.storage(),
         grad_out_seq.layout(),

--- a/coeus-wgpu/tests/wgpu/conv3d.rs
+++ b/coeus-wgpu/tests/wgpu/conv3d.rs
@@ -93,7 +93,7 @@ fn assert_forward_matches_cpu(case: Conv3dCase) {
     let out_layout = coeus_core::Layout::new(output_shape.into());
     let mut out_wgpu_storage = wgpu_b.allocate::<f32>(out_len);
 
-    coeus_ops::BackendOps::conv3d(
+    coeus_ops::ConvOps::conv3d(
         &wgpu_b,
         input_wgpu.storage(),
         input_wgpu.layout(),
@@ -112,7 +112,7 @@ fn assert_forward_matches_cpu(case: Conv3dCase) {
     let out_wgpu_cpu = out_tensor_wgpu.to_backend_on(&wgpu_b, &seq);
 
     let mut out_expected_storage = seq.allocate::<f32>(out_len);
-    coeus_ops::BackendOps::conv3d(
+    coeus_ops::ConvOps::conv3d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -170,7 +170,7 @@ fn assert_backward_matches_cpu(case: Conv3dCase) {
     let gw_layout = coeus_core::Layout::new(weight_shape.into());
     let gb_layout = coeus_core::Layout::new(vec![case.out_channels].into());
 
-    coeus_ops::BackendOps::conv3d_backward(
+    coeus_ops::ConvOps::conv3d_backward(
         &wgpu_b,
         grad_out_wgpu.storage(),
         grad_out_wgpu.layout(),
@@ -195,7 +195,7 @@ fn assert_backward_matches_cpu(case: Conv3dCase) {
     let mut gb_expected = seq.allocate::<f32>(case.out_channels);
     seq.fill(&mut gb_expected, 0.0);
 
-    coeus_ops::BackendOps::conv3d_backward(
+    coeus_ops::ConvOps::conv3d_backward(
         &seq,
         grad_out_seq.storage(),
         grad_out_seq.layout(),

--- a/coeus-wgpu/tests/wgpu/conv_transpose.rs
+++ b/coeus-wgpu/tests/wgpu/conv_transpose.rs
@@ -5,7 +5,7 @@
 // tolerance (f32 sum-order differs between gather and scatter).
 
 use coeus_core::SequentialBackend;
-use coeus_ops::BackendOps;
+use coeus_ops::ConvOps;
 use coeus_tensor::Tensor;
 use coeus_wgpu::WgpuBackend;
 

--- a/coeus-wgpu/tests/wgpu/optimizer.rs
+++ b/coeus-wgpu/tests/wgpu/optimizer.rs
@@ -7,7 +7,7 @@
 // so the device result matches the CPU `f32` arithmetic within tight roundoff.
 
 use coeus_core::SequentialBackend;
-use coeus_ops::BackendOps;
+use coeus_ops::OptimizerOps;
 use coeus_tensor::Tensor;
 use coeus_wgpu::WgpuBackend;
 

--- a/coeus-wgpu/tests/wgpu/parity.rs
+++ b/coeus-wgpu/tests/wgpu/parity.rs
@@ -6,6 +6,7 @@
 // matches the verified CPU path for all supported op families.
 
 use coeus_core::SequentialBackend;
+use coeus_ops::{ConvOps, ElementwiseOps, OptimizerOps, PoolOps};
 use coeus_tensor::Tensor;
 use coeus_wgpu::WgpuBackend;
 
@@ -100,7 +101,6 @@ fn test_wgpu_parity_div() {
 
 #[test]
 fn test_wgpu_hephaestus_contiguous_binary_reuses_output_buffer() {
-    use coeus_ops::BackendOps;
     use std::sync::Arc;
 
     let s = seq();
@@ -143,7 +143,6 @@ fn test_wgpu_hephaestus_contiguous_binary_reuses_output_buffer() {
 
 #[test]
 fn test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer() {
-    use coeus_ops::BackendOps;
     use std::sync::Arc;
 
     let s = seq();
@@ -179,8 +178,6 @@ fn test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer() {
 
 #[test]
 fn test_wgpu_aliasing_unary_neg_matches_cpu() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let data = vec![-4.0f32, -1.5, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0];
@@ -205,8 +202,6 @@ fn test_wgpu_aliasing_unary_neg_matches_cpu() {
 
 #[test]
 fn test_wgpu_aliasing_binary_add_matches_cpu() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let a_data: Vec<f32> = (0..16).map(|x| x as f32 * 0.25 - 2.0).collect();
@@ -466,8 +461,6 @@ fn test_wgpu_parity_batched_matmul() {
 
 #[test]
 fn test_wgpu_parity_conv1d_forward() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let (batch, in_c, len, out_c, ksize) = (2, 3, 8, 4, 3);
@@ -533,8 +526,6 @@ fn test_wgpu_parity_conv1d_forward() {
 
 #[test]
 fn test_wgpu_parity_conv2d_forward() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let (batch, in_c, h, ww, out_c, kh, kw) = (2, 2, 5, 5, 3, 3, 3);
@@ -603,8 +594,6 @@ fn test_wgpu_parity_conv2d_forward() {
 
 #[test]
 fn test_wgpu_parity_max_pool2d() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let data: Vec<f32> = (0..2 * 2 * 4 * 4).map(|x| x as f32 * 0.1).collect();
@@ -646,8 +635,6 @@ fn test_wgpu_parity_max_pool2d() {
 
 #[test]
 fn test_wgpu_parity_avg_pool2d() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let data: Vec<f32> = (0..2 * 2 * 4 * 4).map(|x| x as f32 * 0.1).collect();
@@ -691,8 +678,6 @@ fn test_wgpu_parity_avg_pool2d() {
 
 #[test]
 fn test_wgpu_parity_adamw_step() {
-    use coeus_ops::BackendOps;
-
     let s = seq();
     let w = wgpu();
     let n = 16;

--- a/coeus-wgpu/tests/wgpu/pooling.rs
+++ b/coeus-wgpu/tests/wgpu/pooling.rs
@@ -14,7 +14,7 @@ fn test_wgpu_max_pool2d() {
     let mut out_wgpu_storage = wgpu_b.allocate::<f32>(4);
     let out_layout = coeus_core::Layout::new(vec![1, 1, 2, 2].into());
 
-    coeus_ops::BackendOps::max_pool2d(
+    coeus_ops::PoolOps::max_pool2d(
         &wgpu_b,
         input_wgpu.storage(),
         input_wgpu.layout(),
@@ -42,7 +42,7 @@ fn test_wgpu_max_pool2d() {
     wgpu_b.fill(&mut grad_input_wgpu_storage, 0.0);
     let gi_layout = coeus_core::Layout::new(vec![1, 1, 4, 4].into());
 
-    coeus_ops::BackendOps::max_pool2d_backward(
+    coeus_ops::PoolOps::max_pool2d_backward(
         &wgpu_b,
         grad_out_wgpu.storage(),
         grad_out_wgpu.layout(),
@@ -81,7 +81,7 @@ fn test_wgpu_avg_pool2d() {
     let mut out_wgpu_storage = wgpu_b.allocate::<f32>(4);
     let out_layout = coeus_core::Layout::new(vec![1, 1, 2, 2].into());
 
-    coeus_ops::BackendOps::avg_pool2d(
+    coeus_ops::PoolOps::avg_pool2d(
         &wgpu_b,
         input_wgpu.storage(),
         input_wgpu.layout(),
@@ -109,7 +109,7 @@ fn test_wgpu_avg_pool2d() {
     wgpu_b.fill(&mut grad_input_wgpu_storage, 0.0);
     let gi_layout = coeus_core::Layout::new(vec![1, 1, 4, 4].into());
 
-    coeus_ops::BackendOps::avg_pool2d_backward(
+    coeus_ops::PoolOps::avg_pool2d_backward(
         &wgpu_b,
         grad_out_wgpu.storage(),
         grad_out_wgpu.layout(),
@@ -143,7 +143,7 @@ fn test_wgpu_max_pool3d() {
     let mut out_wgpu_storage = wgpu_b.allocate::<f32>(8);
     let out_layout = coeus_core::Layout::new(vec![1, 1, 2, 2, 2].into());
 
-    coeus_ops::BackendOps::max_pool3d(
+    coeus_ops::PoolOps::max_pool3d(
         &wgpu_b,
         input_wgpu.storage(),
         input_wgpu.layout(),
@@ -160,7 +160,7 @@ fn test_wgpu_max_pool3d() {
     let out_wgpu_cpu = out_wgpu_tensor.to_backend_on(&wgpu_b, &seq);
 
     let mut out_expected_storage = seq.allocate::<f32>(8);
-    coeus_ops::BackendOps::max_pool3d(
+    coeus_ops::PoolOps::max_pool3d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -186,7 +186,7 @@ fn test_wgpu_max_pool3d() {
     wgpu_b.fill(&mut grad_input_wgpu_storage, 0.0);
     let gi_layout = coeus_core::Layout::new(vec![1, 1, 3, 3, 3].into());
 
-    coeus_ops::BackendOps::max_pool3d_backward(
+    coeus_ops::PoolOps::max_pool3d_backward(
         &wgpu_b,
         grad_out_wgpu.storage(),
         grad_out_wgpu.layout(),
@@ -206,7 +206,7 @@ fn test_wgpu_max_pool3d() {
 
     let mut grad_input_expected_storage = seq.allocate::<f32>(27);
     seq.fill(&mut grad_input_expected_storage, 0.0);
-    coeus_ops::BackendOps::max_pool3d_backward(
+    coeus_ops::PoolOps::max_pool3d_backward(
         &seq,
         grad_out_seq.storage(),
         grad_out_seq.layout(),
@@ -237,7 +237,7 @@ fn test_wgpu_avg_pool3d() {
     let mut out_wgpu_storage = wgpu_b.allocate::<f32>(8);
     let out_layout = coeus_core::Layout::new(vec![1, 1, 2, 2, 2].into());
 
-    coeus_ops::BackendOps::avg_pool3d(
+    coeus_ops::PoolOps::avg_pool3d(
         &wgpu_b,
         input_wgpu.storage(),
         input_wgpu.layout(),
@@ -254,7 +254,7 @@ fn test_wgpu_avg_pool3d() {
     let out_wgpu_cpu = out_wgpu_tensor.to_backend_on(&wgpu_b, &seq);
 
     let mut out_expected_storage = seq.allocate::<f32>(8);
-    coeus_ops::BackendOps::avg_pool3d(
+    coeus_ops::PoolOps::avg_pool3d(
         &seq,
         input_seq.storage(),
         input_seq.layout(),
@@ -293,7 +293,7 @@ fn test_wgpu_avg_pool3d() {
     wgpu_b.fill(&mut grad_input_wgpu_storage, 0.0);
     let gi_layout = coeus_core::Layout::new(vec![1, 1, 3, 3, 3].into());
 
-    coeus_ops::BackendOps::avg_pool3d_backward(
+    coeus_ops::PoolOps::avg_pool3d_backward(
         &wgpu_b,
         grad_out_wgpu.storage(),
         grad_out_wgpu.layout(),
@@ -311,7 +311,7 @@ fn test_wgpu_avg_pool3d() {
 
     let mut grad_input_expected_storage = seq.allocate::<f32>(27);
     seq.fill(&mut grad_input_expected_storage, 0.0);
-    coeus_ops::BackendOps::avg_pool3d_backward(
+    coeus_ops::PoolOps::avg_pool3d_backward(
         &seq,
         grad_out_seq.storage(),
         grad_out_seq.layout(),

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,26 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-174: LayerNorm/RMSNorm JAX parity [COMPLETE]
+
+- [x] [patch] Added JAX differential parity for `pycoeus.LayerNorm`,
+  asserting forward output plus input, gamma, and beta gradients at f64.
+- [x] [patch] Added JAX differential parity for `pycoeus.RMSNorm`, asserting
+  forward output plus input and gamma gradients against the formulaic RMSNorm
+  reference at f64.
+- [x] Evidence tier: differential/empirical;
+  `D:\miniforge3\python.exe -m pytest coeus-python/tests/test_jax_parity.py -q`
+  passes 13/13.
+
+## Sprint MS-173: Softmax/log-softmax/cross-entropy JAX parity [COMPLETE]
+
+- [x] [patch] Added JAX differential parity for `pycoeus.softmax` and
+  `pycoeus.log_softmax`, covering forward values and input gradients at f64.
+- [x] [patch] Added JAX differential parity for `pycoeus.cross_entropy_loss`
+  against a fused log-softmax + negative-log-likelihood mean reference.
+- [x] Evidence tier: differential/empirical;
+  `D:\miniforge3\python.exe -m pytest coeus-python/tests/test_jax_parity.py -q`
+  passes 11/11.
+
 ## Sprint MS-172: Deterministic local/TCP numel contract tests [COMPLETE]
 
 - [x] [patch] Replaced the deadlock-prone multi-thread
@@ -10,11 +31,12 @@
   `test_local_gather_mismatched_output_numel_panics`.
 - [x] [patch] Added non-zero TCP rooted gather output-shape panic test:
   `test_tcp_gather_mismatched_output_numel_panics`.
-- [x] Evidence: `cargo test -p coeus-dist --test dist_tests test_local_scatter_mismatched_input_numel_panics -- --nocapture`;
-  `cargo test -p coeus-dist --test dist_tests test_local_all_gather_mismatched_output_numel_panics -- --nocapture`;
-  `cargo test -p coeus-dist --test dist_tests test_local_gather_mismatched_output_numel_panics -- --nocapture`;
-  `cargo test -p coeus-dist --test dist_tests test_tcp_gather_mismatched_output_numel_panics -- --nocapture`;
-  `cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+- [x] Evidence: `rustup run nightly cargo nextest run -p coeus-dist
+  test_local_scatter_mismatched_input_numel_panics
+  test_local_all_gather_mismatched_output_numel_panics
+  test_local_gather_mismatched_output_numel_panics
+  test_tcp_gather_mismatched_output_numel_panics` (4/4);
+  `rustup run nightly cargo clippy -p coeus-dist --all-targets -- -D warnings`.
 
 ## Sprint MS-170: TCP all_reduce mismatch contract coverage [COMPLETE]
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,71 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-168 - Activation JAX parity (SiLU/Mish/ELU/Softplus/LeakyReLU) [COMPLETE]
+### Current Sprint: MS-174 - LayerNorm/RMSNorm JAX parity [COMPLETE]
+**Objective**: Extend the JAX parity harness to normalization modules already
+covered by PyTorch parity.
+**Target version**: 0.5.4 (test-only [patch]).
+
+- [x] [patch] Added `test_layernorm_matches_jax`, asserting forward output and
+  input/gamma/beta gradients against an inline JAX LayerNorm reference at f64.
+- [x] [patch] Added `test_rmsnorm_matches_jax`, asserting forward output and
+  input/gamma gradients against an inline JAX RMSNorm reference at f64.
+- [x] Evidence: `D:\miniforge3\python.exe -m pytest
+  coeus-python/tests/test_jax_parity.py -q` (13/13).
+
+### Previous Sprint: MS-173 - Softmax/log-softmax/cross-entropy JAX parity [COMPLETE]
+**Objective**: Extend the JAX parity harness to the classification softmax path
+covered by PyTorch parity.
+**Target version**: 0.5.4 (test-only [patch]).
+
+- [x] [patch] Added `test_softmax_matches_jax` and
+  `test_log_softmax_matches_jax`, asserting forward output and input gradient
+  against `jax.nn.{softmax,log_softmax}` at f64.
+- [x] [patch] Added `test_cross_entropy_loss_matches_jax`, asserting scalar
+  mean loss and logit gradient against a fused log-softmax + NLL JAX reference.
+- [x] Evidence: `D:\miniforge3\python.exe -m pytest
+  coeus-python/tests/test_jax_parity.py -q` (11/11).
+
+### Previous Sprint: MS-172 - Deterministic local/TCP numel contract tests [COMPLETE]
+**Objective**: Replace thread-join panic detection with deterministic direct
+panic-contract coverage for shape/numel mismatch paths.
+**Target version**: 0.5.4 ([patch]).
+
+- [x] [patch] Replaced the multi-thread local scatter mismatch panic test with
+  a deterministic single-rank root-input numel mismatch test.
+- [x] [patch] Added deterministic non-zero local `all_gather` and rooted
+  `gather` output-numel mismatch tests.
+- [x] [patch] Added deterministic non-zero TCP rooted `gather` output-numel
+  mismatch coverage.
+- [x] Evidence: `rustup run nightly cargo nextest run -p coeus-dist
+  test_local_scatter_mismatched_input_numel_panics
+  test_local_all_gather_mismatched_output_numel_panics
+  test_local_gather_mismatched_output_numel_panics
+  test_tcp_gather_mismatched_output_numel_panics` (4/4);
+  `rustup run nightly cargo clippy -p coeus-dist --all-targets -- -D warnings`.
+
+### Previous Sprint: MS-171 - BackendOps interface segregation [COMPLETE]
+**Objective**: Replace the monolithic backend operation trait body with
+single-concern operation traits while preserving the aggregate `BackendOps`
+bound and CPU kernel delegation.
+**Target version**: 0.5.4 ([patch]).
+
+- [x] [patch] Added `ElementwiseOps`, `MatmulOps`, `ReductionOps`, `ConvOps`,
+  `PoolOps`, `AttentionOps`, and `OptimizerOps` under
+  `coeus-ops/src/backend_ops/traits/`.
+- [x] [patch] Reduced `BackendOps` to a super-trait with a blanket impl so
+  backends compose the aggregate bound from single-concern trait impls.
+- [x] [patch] Split the CPU backend implementation into one impl block per
+  operation concern, eliminating the duplicate blanket-impl coherence failure.
+- [x] [patch] Re-exported the sub-traits at the crate root and updated direct
+  backend-dispatch tests to import the precise operation trait they exercise.
+- [x] Evidence: `rustup run nightly cargo check -p coeus-ops --all-targets`;
+  `rustup run nightly cargo clippy -p coeus-ops --all-targets -- -D warnings`;
+  `rustup run nightly cargo nextest run -p coeus-ops` (189/189);
+  `rustup run nightly cargo test --doc -p coeus-ops` (23/23);
+  `rustup run nightly cargo doc -p coeus-ops --no-deps`.
+
+### Previous Sprint: MS-168 - Activation JAX parity (SiLU/Mish/ELU/Softplus/LeakyReLU) [COMPLETE]
 **Objective**: Extend the JAX parity harness (Linear/MHA/decoder only) to the
 elementwise activations, mirroring the PyTorch activation parity of MS-167.
 **Target version**: 0.5.4 (test-only [patch]).

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -2,9 +2,16 @@
 
 ## Known Gaps & Residual Risks
 
+### ~~G-030: JAX harness lacked LayerNorm/RMSNorm parity~~ **CLOSED**
+**Location**: `coeus-python/tests/test_jax_parity.py`
+**Closed by**: MS-174 — Added `test_{layernorm,rmsnorm}_matches_jax`,
+asserting forward output and gradients against inline f64 JAX references.
+LayerNorm covers input/gamma/beta gradients; RMSNorm covers input/gamma
+gradients. Evidence tier: differential/empirical.
+
 ### ~~G-029: JAX harness lacked softmax/log-softmax/cross-entropy parity~~ **CLOSED**
 **Location**: `coeus-python/tests/test_jax_parity.py`
-**Closed by**: MS-170 — Added `test_{softmax,log_softmax,cross_entropy_loss}_matches_jax`,
+**Closed by**: MS-173 — Added `test_{softmax,log_softmax,cross_entropy_loss}_matches_jax`,
 asserting forward output and gradient against `jax.nn.{softmax,log_softmax}` and a
 fused log-softmax+NLL mean reference at f64. Extends the JAX harness to the
 classification/softmax path, symmetric with the PyTorch coverage. Evidence tier:
@@ -283,6 +290,7 @@ Evidence tier: differential/empirical (PyTorch f64).
 | G-025 GlobalAvg/MaxPool2d differential parity missing | differential | **closed MS-166** |
 | G-026 Elementwise activation differential parity missing | differential | **closed MS-167** |
 | G-027 JAX harness lacked elementwise activation parity | differential | **closed MS-168** |
-| G-029 JAX harness lacked softmax/log-softmax/cross-entropy parity | differential | **closed MS-170** |
+| G-029 JAX harness lacked softmax/log-softmax/cross-entropy parity | differential | **closed MS-173** |
+| G-030 JAX harness lacked LayerNorm/RMSNorm parity | differential | **closed MS-174** |
 | ConvTranspose backward WGPU/CUDA coverage | empirical (forward-only) | deferred |
 | mnemosyne-backend lib.rs docstring stale | documentation | **closed 87da068** |


### PR DESCRIPTION
## Summary
- Route CUDA and WGPU backend implementations through the interface-segregated operation traits.
- Update CUDA/WGPU tests and PyO3 conv-transpose wrapper imports to use the exact operation traits.
- Sync checklist, backlog, gap audit, and changelog for the verified JAX/dist parity slices.

## Verification
- rustup run nightly cargo fmt -p coeus-ops -p coeus-cuda -p coeus-wgpu -p coeus-dist --check
- rustup run nightly cargo check -p coeus-ops --all-targets
- rustup run nightly cargo clippy -p coeus-ops --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-ops (189/189)
- rustup run nightly cargo test --doc -p coeus-ops (23/23)
- rustup run nightly cargo doc -p coeus-ops --no-deps
- rustup run nightly cargo check -p coeus-cuda -p coeus-wgpu --all-targets
- rustup run nightly cargo clippy -p coeus-cuda -p coeus-wgpu --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-cuda (2/2)
- rustup run nightly cargo nextest run -p coeus-wgpu (83/83)
- rustup run nightly cargo clippy -p coeus-dist --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-dist test_local_scatter_mismatched_input_numel_panics test_local_all_gather_mismatched_output_numel_panics test_local_gather_mismatched_output_numel_panics test_tcp_gather_mismatched_output_numel_panics (4/4)
- rustup run nightly cargo check -p coeus-python --all-targets
- rustup run nightly cargo clippy -p coeus-python --all-targets -- -D warnings
- D:\miniforge3\python.exe -m pytest coeus-python/tests/test_jax_parity.py -q (13/13)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the backend operation trait interface by splitting the monolithic `BackendOps` trait into focused, single-concern operation traits (`ElementwiseOps`, `MatmulOps`, `ReductionOps`, `ConvOps`, `PoolOps`, `AttentionOps`, and `OptimizerOps`). Both CUDA and WGPU backend implementations are updated to implement these segregated traits while maintaining backward compatibility through a super-trait pattern. The PR also updates documentation including the changelog, checklist, backlog, and gap audit to reflect recent JAX parity testing additions for LayerNorm, RMSNorm, softmax, log-softmax, and cross-entropy operations, along with deterministic distributed operation contract tests.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `CHANGELOG.md` |
| 5 | `coeus-cuda/src/backend/ops.rs` |
| 6 | `coeus-cuda/src/backend_stub.rs` |
| 7 | `coeus-wgpu/src/backend/ops/mod.rs` |
| 8 | `coeus-cuda/src/backend/ops/conv.rs` |
| 9 | `coeus-cuda/src/fallback/ops/attention.rs` |
| 10 | `coeus-cuda/src/fallback/ops/conv.rs` |
| 11 | `coeus-cuda/src/fallback/ops/math.rs` |
| 12 | `coeus-cuda/src/fallback/ops/optim.rs` |
| 13 | `coeus-cuda/src/fallback/ops/pool.rs` |
| 14 | `coeus-wgpu/src/backend/ops/attention.rs` |
| 15 | `coeus-python/src/nn/conv.rs` |
| 16 | `coeus-cuda/tests/cuda/conv_reduce.rs` |
| 17 | `coeus-cuda/tests/cuda/optimizer_and_3d.rs` |
| 18 | `coeus-cuda/tests/cuda/parity.rs` |
| 19 | `coeus-cuda/tests/cuda_pool_tests.rs` |
| 20 | `coeus-wgpu/tests/wgpu/conv.rs` |
| 21 | `coeus-wgpu/tests/wgpu/conv3d.rs` |
| 22 | `coeus-wgpu/tests/wgpu/conv_transpose.rs` |
| 23 | `coeus-wgpu/tests/wgpu/optimizer.rs` |
| 24 | `coeus-wgpu/tests/wgpu/parity.rs` |
| 25 | `coeus-wgpu/tests/wgpu/pooling.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->