### PR TITLE
test(backend): Add ConvTranspose GPU backward parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@
 
 ### Added
 
+- **ConvTranspose backward GPU coverage** — added WGPU and CUDA
+  backend-autograd parity tests for `conv_transpose1d` and `conv_transpose2d`,
+  seeding non-uniform output gradients and comparing input/weight gradients
+  against the CPU autograd reference. Evidence tier: empirical differential;
+  backend nextest 87/87, CUDA feature nextest 71/71, CUDA feature check, and
+  touched-backend clippy all pass. ([patch])
 - **MSE / BinaryCrossEntropy / Huber loss JAX parity** — added
   `test_{mse_loss,binary_cross_entropy,huber_loss}_matches_jax` to
   `coeus-python/tests/test_jax_parity.py`, asserting forward loss and prediction

--- a/coeus-cuda/Cargo.toml
+++ b/coeus-cuda/Cargo.toml
@@ -24,6 +24,7 @@ cuda-async   = { git = "https://github.com/NVlabs/cutile-rs", package = "cuda-as
 cuda = ["dep:cutile", "dep:cuda-core", "dep:cuda-async", "dep:themis", "hephaestus-cuda/cuda"]
 
 [dev-dependencies]
+coeus-autograd = { workspace = true, default-features = false }
 criterion = "0.5"
 
 [[bench]]

--- a/coeus-cuda/tests/cuda/parity.rs
+++ b/coeus-cuda/tests/cuda/parity.rs
@@ -11,6 +11,7 @@
 // must match the CPU reference. Every test is skipped unless a live CUDA
 // device, driver, and context are all present.
 
+use coeus_autograd::Var;
 use coeus_core::SequentialBackend;
 use coeus_cuda::CudaBackend;
 use coeus_ops::{ConvOps, OptimizerOps, PoolOps};
@@ -1372,6 +1373,124 @@ fn test_cuda_parity_conv_transpose2d() {
         "conv_transpose2d",
         out_s.as_slice(),
         to_cpu(&out_g, &c, &s).as_slice(),
+        CUDA_ACC_TOL,
+    );
+}
+
+#[test]
+fn test_cuda_parity_conv_transpose1d_backward() {
+    let Some((s, c)) = backends() else {
+        return;
+    };
+
+    let input = [0.5f32, -0.25, 0.75];
+    let weight = [0.7f32, -0.4];
+    let seed = [1.0f32, -0.5, 0.25, 2.0];
+
+    let input_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 3], &input),
+        true,
+    );
+    let weight_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 2], &weight),
+        true,
+    );
+    let out_cpu =
+        coeus_ops::conv_transpose1d(&input_cpu.tensor, &weight_cpu.tensor, None, 1, 0, 0, 1, &s);
+    let tracked_cpu =
+        coeus_autograd::conv_transpose1d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
+    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+        [1, 1, 4],
+        &seed,
+    ));
+
+    let input_gpu = Var::new(
+        Tensor::<f32, CudaBackend>::from_slice_on([1, 1, 3], &input, &c),
+        true,
+    );
+    let weight_gpu = Var::new(
+        Tensor::<f32, CudaBackend>::from_slice_on([1, 1, 2], &weight, &c),
+        true,
+    );
+    let out_gpu =
+        coeus_ops::conv_transpose1d(&input_gpu.tensor, &weight_gpu.tensor, None, 1, 0, 0, 1, &c);
+    let tracked_gpu =
+        coeus_autograd::conv_transpose1d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
+    tracked_gpu.backward_with_seed(Tensor::<f32, CudaBackend>::from_slice_on(
+        [1, 1, 4],
+        &seed,
+        &c,
+    ));
+
+    assert_parity_tol(
+        "conv_transpose1d_backward_input",
+        input_cpu.grad().unwrap().as_slice(),
+        to_cpu(&input_gpu.grad().unwrap(), &c, &s).as_slice(),
+        CUDA_ACC_TOL,
+    );
+    assert_parity_tol(
+        "conv_transpose1d_backward_weight",
+        weight_cpu.grad().unwrap().as_slice(),
+        to_cpu(&weight_gpu.grad().unwrap(), &c, &s).as_slice(),
+        CUDA_ACC_TOL,
+    );
+}
+
+#[test]
+fn test_cuda_parity_conv_transpose2d_backward() {
+    let Some((s, c)) = backends() else {
+        return;
+    };
+
+    let input = [0.5f32, -0.25, 0.75, 1.25];
+    let weight = [0.6f32, -0.2, 0.3, -0.5];
+    let seed: Vec<f32> = (0..9).map(|x| x as f32 * 0.2 - 0.7).collect();
+
+    let input_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 2, 2], &input),
+        true,
+    );
+    let weight_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 2, 2], &weight),
+        true,
+    );
+    let out_cpu =
+        coeus_ops::conv_transpose2d(&input_cpu.tensor, &weight_cpu.tensor, None, 1, 0, 0, 1, &s);
+    let tracked_cpu =
+        coeus_autograd::conv_transpose2d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
+    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+        [1, 1, 3, 3],
+        &seed,
+    ));
+
+    let input_gpu = Var::new(
+        Tensor::<f32, CudaBackend>::from_slice_on([1, 1, 2, 2], &input, &c),
+        true,
+    );
+    let weight_gpu = Var::new(
+        Tensor::<f32, CudaBackend>::from_slice_on([1, 1, 2, 2], &weight, &c),
+        true,
+    );
+    let out_gpu =
+        coeus_ops::conv_transpose2d(&input_gpu.tensor, &weight_gpu.tensor, None, 1, 0, 0, 1, &c);
+    let tracked_gpu =
+        coeus_autograd::conv_transpose2d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
+    tracked_gpu.backward_with_seed(Tensor::<f32, CudaBackend>::from_slice_on(
+        [1, 1, 3, 3],
+        &seed,
+        &c,
+    ));
+
+    assert_parity_tol(
+        "conv_transpose2d_backward_input",
+        input_cpu.grad().unwrap().as_slice(),
+        to_cpu(&input_gpu.grad().unwrap(), &c, &s).as_slice(),
+        CUDA_ACC_TOL,
+    );
+    assert_parity_tol(
+        "conv_transpose2d_backward_weight",
+        weight_cpu.grad().unwrap().as_slice(),
+        to_cpu(&weight_gpu.grad().unwrap(), &c, &s).as_slice(),
         CUDA_ACC_TOL,
     );
 }

--- a/coeus-wgpu/tests/wgpu/conv_transpose.rs
+++ b/coeus-wgpu/tests/wgpu/conv_transpose.rs
@@ -4,6 +4,7 @@
 // (`BackendOps::conv_transpose1d`/`2d`) element-wise within an accumulation
 // tolerance (f32 sum-order differs between gather and scatter).
 
+use coeus_autograd::Var;
 use coeus_core::SequentialBackend;
 use coeus_ops::ConvOps;
 use coeus_tensor::Tensor;
@@ -142,5 +143,153 @@ fn test_wgpu_conv_transpose2d() {
         "conv_transpose2d",
         out_g.to_backend_on(&wgpu, &seq).as_slice(),
         out_c.as_slice(),
+    );
+}
+
+#[test]
+fn test_wgpu_conv_transpose1d_backward_matches_cpu_autograd() {
+    let seq = SequentialBackend::new();
+    let wgpu = WgpuBackend::new();
+
+    let input = [0.5f32, -0.25, 0.75];
+    let weight = [0.7f32, -0.4];
+    let seed = [1.0f32, -0.5, 0.25, 2.0];
+
+    let input_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 3], &input),
+        true,
+    );
+    let weight_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 2], &weight),
+        true,
+    );
+    let out_cpu = coeus_ops::conv_transpose1d(
+        &input_cpu.tensor,
+        &weight_cpu.tensor,
+        None,
+        1,
+        0,
+        0,
+        1,
+        &seq,
+    );
+    let tracked_cpu =
+        coeus_autograd::conv_transpose1d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
+    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+        [1, 1, 4],
+        &seed,
+    ));
+
+    let input_gpu = Var::new(
+        Tensor::<f32, WgpuBackend>::from_slice_on([1, 1, 3], &input, &wgpu),
+        true,
+    );
+    let weight_gpu = Var::new(
+        Tensor::<f32, WgpuBackend>::from_slice_on([1, 1, 2], &weight, &wgpu),
+        true,
+    );
+    let out_gpu = coeus_ops::conv_transpose1d(
+        &input_gpu.tensor,
+        &weight_gpu.tensor,
+        None,
+        1,
+        0,
+        0,
+        1,
+        &wgpu,
+    );
+    let tracked_gpu =
+        coeus_autograd::conv_transpose1d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
+    tracked_gpu.backward_with_seed(Tensor::<f32, WgpuBackend>::from_slice_on(
+        [1, 1, 4],
+        &seed,
+        &wgpu,
+    ));
+
+    let input_grad_gpu = input_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
+    let weight_grad_gpu = weight_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
+    assert_close(
+        "conv_transpose1d_backward_input",
+        input_grad_gpu.as_slice(),
+        input_cpu.grad().unwrap().as_slice(),
+    );
+    assert_close(
+        "conv_transpose1d_backward_weight",
+        weight_grad_gpu.as_slice(),
+        weight_cpu.grad().unwrap().as_slice(),
+    );
+}
+
+#[test]
+fn test_wgpu_conv_transpose2d_backward_matches_cpu_autograd() {
+    let seq = SequentialBackend::new();
+    let wgpu = WgpuBackend::new();
+
+    let input = [0.5f32, -0.25, 0.75, 1.25];
+    let weight = [0.6f32, -0.2, 0.3, -0.5];
+    let seed: Vec<f32> = (0..9).map(|x| x as f32 * 0.2 - 0.7).collect();
+
+    let input_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 2, 2], &input),
+        true,
+    );
+    let weight_cpu = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice([1, 1, 2, 2], &weight),
+        true,
+    );
+    let out_cpu = coeus_ops::conv_transpose2d(
+        &input_cpu.tensor,
+        &weight_cpu.tensor,
+        None,
+        1,
+        0,
+        0,
+        1,
+        &seq,
+    );
+    let tracked_cpu =
+        coeus_autograd::conv_transpose2d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
+    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+        [1, 1, 3, 3],
+        &seed,
+    ));
+
+    let input_gpu = Var::new(
+        Tensor::<f32, WgpuBackend>::from_slice_on([1, 1, 2, 2], &input, &wgpu),
+        true,
+    );
+    let weight_gpu = Var::new(
+        Tensor::<f32, WgpuBackend>::from_slice_on([1, 1, 2, 2], &weight, &wgpu),
+        true,
+    );
+    let out_gpu = coeus_ops::conv_transpose2d(
+        &input_gpu.tensor,
+        &weight_gpu.tensor,
+        None,
+        1,
+        0,
+        0,
+        1,
+        &wgpu,
+    );
+    let tracked_gpu =
+        coeus_autograd::conv_transpose2d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
+    tracked_gpu.backward_with_seed(Tensor::<f32, WgpuBackend>::from_slice_on(
+        [1, 1, 3, 3],
+        &seed,
+        &wgpu,
+    ));
+
+    let input_grad_gpu = input_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
+    let weight_grad_gpu = weight_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
+    assert_close(
+        "conv_transpose2d_backward_input",
+        input_grad_gpu.as_slice(),
+        input_cpu.grad().unwrap().as_slice(),
+    );
+    assert_close(
+        "conv_transpose2d_backward_weight",
+        weight_grad_gpu.as_slice(),
+        weight_cpu.grad().unwrap().as_slice(),
     );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,19 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-176: ConvTranspose backward GPU coverage [COMPLETE]
+
+- [x] [patch] Added WGPU backend-autograd `conv_transpose1d` and
+  `conv_transpose2d` backward tests that seed non-uniform output gradients and
+  compare input/weight gradients against the existing CPU autograd reference.
+- [x] [patch] Added CUDA feature-gated backend-autograd `conv_transpose1d` and
+  `conv_transpose2d` backward parity tests using the same CPU-autograd oracle.
+- [x] Evidence tier: empirical differential; `rustup run nightly cargo nextest
+  run -p coeus-wgpu -p coeus-cuda` passes 87/87; `rustup run nightly cargo
+  check -p coeus-cuda --all-targets --features cuda` passes; `rustup run
+  nightly cargo nextest run -p coeus-cuda --features cuda` passes 71/71;
+  `rustup run nightly cargo clippy -p coeus-wgpu -p coeus-cuda --all-targets
+  -- -D warnings` passes.
+
 ## Sprint MS-175: TCP rooted handshake fail-status propagation [COMPLETE]
 
 - [x] [patch] Upgraded `TcpCommunicator::rooted_numel_handshake` to propagate a

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-175 - MSE/BCE/Huber loss JAX parity [COMPLETE]
+### Current Sprint: MS-176 - ConvTranspose backward GPU coverage [COMPLETE]
+**Objective**: Close the deferred ConvTranspose backward coverage gap for the
+WGPU and CUDA backend-autograd paths without adding a duplicate backend backward
+API before there is a dedicated kernel seam.
+**Target version**: 0.5.4 (test-only [patch]).
+
+- [x] [patch] Added WGPU `conv_transpose1d` and `conv_transpose2d` backward
+  tests that run tracked backend tensors, seed non-uniform gradients, and compare
+  input/weight gradients against the existing CPU autograd reference.
+- [x] [patch] Added CUDA feature-gated `conv_transpose1d` and
+  `conv_transpose2d` backward parity tests with the same CPU-autograd oracle.
+- [x] Evidence: `rustup run nightly cargo nextest run -p coeus-wgpu -p
+  coeus-cuda` (87/87); `rustup run nightly cargo check -p coeus-cuda
+  --all-targets --features cuda`; `rustup run nightly cargo nextest run -p
+  coeus-cuda --features cuda` (71/71); `rustup run nightly cargo clippy -p
+  coeus-wgpu -p coeus-cuda --all-targets -- -D warnings`.
+
+### Previous Sprint: MS-175 - MSE/BCE/Huber loss JAX parity [COMPLETE]
 **Objective**: Extend the JAX parity harness to the regression/binary losses
 (mse_loss, binary_cross_entropy, huber_loss), mirroring the PyTorch loss parity.
 **Target version**: 0.5.4 (test-only [patch]).

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -301,5 +301,5 @@ Evidence tier: differential/empirical (PyTorch f64).
 | G-029 JAX harness lacked softmax/log-softmax/cross-entropy parity | differential | **closed MS-173** |
 | G-030 JAX harness lacked LayerNorm/RMSNorm parity | differential | **closed MS-174** |
 | G-031 JAX harness lacked regression/binary loss parity | differential | **closed MS-175** |
-| ConvTranspose backward WGPU/CUDA coverage | empirical (forward-only) | deferred |
+| ConvTranspose backward WGPU/CUDA coverage | empirical GPU/CPU autograd differential | **closed MS-176** |
 | mnemosyne-backend lib.rs docstring stale | documentation | **closed 87da068** |


### PR DESCRIPTION
## Summary
- add WGPU backend-autograd ConvTranspose1d/2d backward parity against CPU autograd gradients
- add CUDA feature-gated ConvTranspose1d/2d backward parity against CPU autograd gradients
- close the deferred ConvTranspose backward WGPU/CUDA coverage row in PM artifacts

## Verification
- rustup run nightly cargo fmt -p coeus-wgpu -p coeus-cuda --check
- rustup run nightly cargo check -p coeus-cuda --all-targets --features cuda
- rustup run nightly cargo clippy -p coeus-wgpu -p coeus-cuda --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-wgpu -p coeus-cuda (87/87)
- rustup run nightly cargo nextest run -p coeus-cuda --features cuda (71/71)

Evidence tier: empirical differential GPU/CPU autograd parity plus compile/lint gates.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds backward pass testing coverage for `ConvTranspose1d` and `ConvTranspose2d` operations on GPU backends (WGPU and CUDA). The tests verify that GPU autograd gradients for both input and weight tensors match the CPU autograd reference implementation by seeding non-uniform output gradients and comparing the computed gradients within an acceptable tolerance. This closes a previously deferred testing gap in the project's GPU coverage matrix.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
| 5 | `coeus-cuda/Cargo.toml` |
| 6 | `coeus-wgpu/tests/wgpu/conv_transpose.rs` |
| 7 | `coeus-cuda/tests/cuda/parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU backward parity coverage for transposed convolution in both 1D and 2D.
  * Expanded testing to compare GPU and CPU gradients for inputs and weights using fixed gradient seeds.
* **Bug Fixes**
  * Improved confidence that transposed convolution autograd results match across CUDA and WGPU backends.
* **Documentation**
  * Updated release notes, sprint tracking, backlog, and audit status to reflect the completed coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->