### PR TITLE
test(dist): Stabilize TCP collective tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **TCP distributed test determinism** — `coeus-dist` TCP tests now use a
+  file-backed cross-process port allocator lock plus deterministic localhost
+  port reservation, and TCP mesh debug builds bound connect/accept/rank-read/
+  send/recv waits with peer/rank panic diagnostics. Connect retry backoff
+  remains async through `moirai_async::sleep`. Evidence tier:
+  empirical/value-semantic `coeus-dist` package gate. ([patch])
 - **Conv2d CPU AXPY kernel** — canonical contiguous CPU Conv2d forward now uses
   an output-stationary row kernel with `Scalar::axpy_slice` routed through
   Hermes SIMD for native floats, and coarser row-block partitioning for Moirai

--- a/coeus-dist/src/tcp/mesh.rs
+++ b/coeus-dist/src/tcp/mesh.rs
@@ -11,6 +11,11 @@ pub struct TcpMesh {
 }
 
 impl TcpMesh {
+    #[inline]
+    fn debug_timeout() -> Option<Duration> {
+        cfg!(debug_assertions).then_some(Duration::from_secs(5))
+    }
+
     /// Create a new TCP mesh connecting all ranks.
     pub fn new(rank: usize, size: usize, addresses: &[SocketAddr]) -> Self {
         assert!(size > 0, "world size must be > 0");
@@ -32,23 +37,36 @@ impl TcpMesh {
             for other in (rank + 1)..size {
                 let other_addr = addresses[other].to_string();
                 let mut delay = Duration::from_millis(5);
-                let stream = loop {
-                    match TcpStream::connect(&other_addr).await {
-                        Ok(s) => {
-                            s.set_nodelay(true).unwrap();
-                            let rank_bytes = (rank as u64).to_le_bytes();
-                            let mut s_mut = s;
-                            if s_mut.write_all(&rank_bytes).await.is_ok() {
-                                break s_mut;
+                let connect_future = async {
+                    loop {
+                        match TcpStream::connect(&other_addr).await {
+                            Ok(s) => {
+                                s.set_nodelay(true).unwrap();
+                                let rank_bytes = (rank as u64).to_le_bytes();
+                                let mut s_mut = s;
+                                if s_mut.write_all(&rank_bytes).await.is_ok() {
+                                    break s_mut;
+                                }
                             }
-                        }
-                        Err(_) => {
-                            moirai_async::sleep(delay).await;
-                            if delay < Duration::from_millis(500) {
-                                delay *= 2;
+                            Err(_) => {
+                                moirai_async::sleep(delay).await;
+                                if delay < Duration::from_millis(500) {
+                                    delay *= 2;
+                                }
                             }
                         }
                     }
+                };
+                let stream = if let Some(timeout) = Self::debug_timeout() {
+                    moirai_async::timeout(timeout, connect_future)
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "rank {rank} timed out connecting to peer {other} at {other_addr}"
+                            )
+                        })
+                } else {
+                    connect_future.await
                 };
                 assert!(
                     streams[other].is_none(),
@@ -59,17 +77,35 @@ impl TcpMesh {
 
             // Accept connections from lower ranks
             for _ in 0..rank {
-                let (s, _) = listener
-                    .accept()
-                    .await
-                    .expect("failed to accept connection");
+                let (s, _) = if let Some(timeout) = Self::debug_timeout() {
+                    moirai_async::timeout(timeout, listener.accept())
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!("rank {rank} timed out accepting lower-rank peer connection")
+                        })
+                        .expect("failed to accept connection")
+                } else {
+                    listener
+                        .accept()
+                        .await
+                        .expect("failed to accept connection")
+                };
                 s.set_nodelay(true).unwrap();
                 let mut rank_bytes = [0u8; 8];
                 let mut s_mut = s;
-                s_mut
-                    .read_exact(&mut rank_bytes)
-                    .await
-                    .expect("failed to read rank from incoming connection");
+                if let Some(timeout) = Self::debug_timeout() {
+                    moirai_async::timeout(timeout, s_mut.read_exact(&mut rank_bytes))
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!("rank {rank} timed out reading incoming peer rank during accept")
+                        })
+                        .expect("failed to read rank from incoming connection");
+                } else {
+                    s_mut
+                        .read_exact(&mut rank_bytes)
+                        .await
+                        .expect("failed to read rank from incoming connection");
+                }
                 let incoming_rank = u64::from_le_bytes(rank_bytes) as usize;
                 assert!(
                     incoming_rank < rank,
@@ -117,10 +153,17 @@ impl TcpMesh {
         let stream_mutex = self.stream_for_peer(target, "send");
         let mut stream = stream_mutex.lock().unwrap();
         moirai::global().block_on(async {
-            stream
-                .write_all(bytes)
-                .await
-                .expect("failed to send bytes over TCP");
+            if let Some(timeout) = Self::debug_timeout() {
+                moirai_async::timeout(timeout, stream.write_all(bytes))
+                    .await
+                    .unwrap_or_else(|_| panic!("send to peer {target} timed out"))
+                    .expect("failed to send bytes over TCP");
+            } else {
+                stream
+                    .write_all(bytes)
+                    .await
+                    .expect("failed to send bytes over TCP");
+            }
         });
     }
 
@@ -130,10 +173,17 @@ impl TcpMesh {
         let stream_mutex = self.stream_for_peer(source, "recv");
         let mut stream = stream_mutex.lock().unwrap();
         moirai::global().block_on(async {
-            stream
-                .read_exact(bytes)
-                .await
-                .expect("failed to receive bytes over TCP");
+            if let Some(timeout) = Self::debug_timeout() {
+                moirai_async::timeout(timeout, stream.read_exact(bytes))
+                    .await
+                    .unwrap_or_else(|_| panic!("recv from peer {source} timed out"))
+                    .expect("failed to receive bytes over TCP");
+            } else {
+                stream
+                    .read_exact(bytes)
+                    .await
+                    .expect("failed to receive bytes over TCP");
+            }
         });
     }
 }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -5,14 +5,45 @@ use coeus_dist::{
     TcpCommunicator, TcpMesh,
 };
 use coeus_tensor::Tensor;
+use std::fs::{self, OpenOptions};
+use std::path::PathBuf;
+use std::sync::mpsc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 fn assert_any_thread_panicked(handles: Vec<thread::JoinHandle<()>>, message: &str) {
-    let panicked = handles
-        .into_iter()
-        .map(|h| h.join().is_err())
-        .collect::<Vec<_>>();
-    assert!(panicked.iter().any(|&p| p), "{}", message);
+    let total = handles.len();
+    let (tx, rx) = mpsc::channel();
+    for handle in handles {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let _ = tx.send(handle.join().is_err());
+        });
+    }
+    drop(tx);
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut completed = 0usize;
+    let mut panicked = false;
+    while completed < total {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match rx.recv_timeout(remaining) {
+            Ok(did_panic) => {
+                completed += 1;
+                panicked |= did_panic;
+                if panicked {
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => break,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    assert!(panicked, "{}", message);
 }
 
 #[test]
@@ -428,18 +459,105 @@ fn test_local_broadcast_sliced() {
     }
 }
 
-fn get_free_ports(count: usize) -> Vec<std::net::SocketAddr> {
-    use std::net::TcpListener;
-    let mut addrs = Vec::new();
-    let mut listeners = Vec::new();
-    for _ in 0..count {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind dynamic port");
-        let addr = listener.local_addr().expect("failed to get local address");
-        addrs.push(addr);
-        listeners.push(listener);
+struct PortAllocatorLock {
+    path: PathBuf,
+}
+
+impl Drop for PortAllocatorLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
     }
-    drop(listeners);
-    addrs
+}
+
+fn port_allocator_lock() -> PortAllocatorLock {
+    let path = std::env::temp_dir().join("coeus-dist-tcp-port-counter.lock");
+    let start = Instant::now();
+
+    loop {
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(_) => return PortAllocatorLock { path },
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if start.elapsed() > Duration::from_secs(20) {
+                    let metadata = fs::metadata(&path)
+                        .expect("TCP port allocator lock exists but metadata could not be read");
+                    let modified = metadata
+                        .modified()
+                        .expect("TCP port allocator lock modified time could not be read");
+                    if modified.elapsed().unwrap_or(Duration::ZERO) > Duration::from_secs(120) {
+                        let _ = fs::remove_file(&path);
+                        continue;
+                    }
+                    panic!(
+                        "timed out waiting for TCP port allocator lock at {}",
+                        path.display()
+                    );
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!(
+                "failed to acquire TCP port allocator lock at {}: {error}",
+                path.display()
+            ),
+        }
+    }
+}
+
+fn get_free_ports(count: usize) -> Vec<std::net::SocketAddr> {
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener};
+
+    assert!(count > 0, "port count must be positive");
+
+    let _lock = port_allocator_lock();
+    let counter_path = std::env::temp_dir().join("coeus-dist-tcp-port-counter.txt");
+    let mut start = fs::read_to_string(&counter_path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(30_000);
+
+    for _ in 0..4096 {
+        if start < 30_000 || start + count >= u16::MAX as usize {
+            start = 30_000;
+            continue;
+        }
+
+        let mut addrs = Vec::with_capacity(count);
+        let mut listeners = Vec::with_capacity(count);
+        let mut all_bound = true;
+
+        for offset in 0..count {
+            let port = (start + offset) as u16;
+            let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+            match TcpListener::bind(addr) {
+                Ok(listener) => {
+                    addrs.push(addr);
+                    listeners.push(listener);
+                }
+                Err(_) => {
+                    all_bound = false;
+                    break;
+                }
+            }
+        }
+
+        if all_bound {
+            let next = start + count + 1;
+            fs::write(
+                &counter_path,
+                if next + count < u16::MAX as usize {
+                    next.to_string()
+                } else {
+                    "30000".to_string()
+                },
+            )
+            .expect("failed to persist TCP test port counter");
+            drop(listeners);
+            return addrs;
+        }
+
+        start += count + 1;
+    }
+
+    panic!("failed to reserve {count} local TCP test ports after multiple attempts");
 }
 
 #[test]
@@ -659,13 +777,9 @@ fn test_tcp_all_gather_mismatched_peer_numel_panics() {
         }));
     }
 
-    let panicked = handles
-        .into_iter()
-        .map(|h| h.join().is_err())
-        .collect::<Vec<_>>();
-    assert!(
-        panicked.iter().any(|&p| p),
-        "TCP all_gather with mismatched peer tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP all_gather with mismatched peer tensor numel should panic on at least one rank",
     );
 }
 
@@ -703,12 +817,8 @@ fn test_tcp_all_gather_zero_numel_mismatched_peer_numel_panics() {
         }));
     }
 
-    let panicked = handles
-        .into_iter()
-        .map(|h| h.join().is_err())
-        .collect::<Vec<_>>();
-    assert!(
-        panicked.iter().any(|&p| p),
+    assert_any_thread_panicked(
+        handles,
         "TCP all_gather zero-numel with mismatched peer tensor numel should panic on at least one rank"
     );
 }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -7,6 +7,14 @@ use coeus_dist::{
 use coeus_tensor::Tensor;
 use std::thread;
 
+fn assert_any_thread_panicked(handles: Vec<thread::JoinHandle<()>>, message: &str) {
+    let panicked = handles
+        .into_iter()
+        .map(|h| h.join().is_err())
+        .collect::<Vec<_>>();
+    assert!(panicked.iter().any(|&p| p), "{}", message);
+}
+
 #[test]
 fn test_local_all_reduce() {
     let world_size = 3;
@@ -486,9 +494,9 @@ fn test_tcp_all_reduce_mismatched_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP all_reduce with mismatched tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP all_reduce with mismatched tensor numel should panic on at least one rank",
     );
 }
 
@@ -514,9 +522,9 @@ fn test_tcp_all_reduce_zero_numel_mismatched_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP all_reduce zero-numel with mismatched tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP all_reduce zero-numel with mismatched tensor numel should panic on at least one rank",
     );
 }
 
@@ -578,9 +586,9 @@ fn test_tcp_broadcast_mismatched_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP broadcast with mismatched tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP broadcast with mismatched tensor numel should panic on at least one rank",
     );
 }
 
@@ -784,9 +792,9 @@ fn test_tcp_reduce_mismatched_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP reduce with mismatched tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP reduce with mismatched tensor numel should panic on at least one rank",
     );
 }
 
@@ -859,9 +867,9 @@ fn test_tcp_gather_mismatched_peer_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP gather with mismatched peer tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP gather with mismatched peer tensor numel should panic on at least one rank",
     );
 }
 
@@ -895,9 +903,9 @@ fn test_tcp_gather_zero_numel_mismatched_peer_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP gather zero-numel with mismatched peer tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP gather zero-numel with mismatched peer tensor numel should panic on at least one rank",
     );
 }
 
@@ -968,9 +976,9 @@ fn test_tcp_scatter_mismatched_target_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP scatter with mismatched target tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP scatter with mismatched target tensor numel should panic on at least one rank",
     );
 }
 
@@ -1005,9 +1013,9 @@ fn test_tcp_scatter_zero_numel_mismatched_target_numel_panics() {
         }));
     }
 
-    assert!(
-        handles.into_iter().any(|h| h.join().is_err()),
-        "TCP scatter zero-numel with mismatched target tensor numel should panic on at least one rank"
+    assert_any_thread_panicked(
+        handles,
+        "TCP scatter zero-numel with mismatched target tensor numel should panic on at least one rank",
     );
 }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,18 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-145: Bilinear backward PyTorch differential parity [COMPLETE]
+
+- [x] [patch] Added
+  `coeus-python/tests/test_pytorch_parity.py::test_bilinear_backward_matches_pytorch`
+  asserting `pycoeus.Bilinear(3,4,2, bias=True)` differentiated via
+  `out.sum().backward()` against `torch.nn.Bilinear.double()` at f64, atol=1e-10.
+  Covers the flat `[out, in1, in2]` weight gradient, `[out]` bias gradient, and
+  `[batch, in1]` / `[batch, in2]` input gradients — exercising the autograd
+  composition chain (matmul → mul → sum_axis → cat → add).
+- [x] Evidence tier: differential/empirical against PyTorch's autograd at f64.
+  Full Python parity suite passes 55 passed, 2 MLX-skipped; isolated bilinear
+  backward test passes 1/1.
+
 ## Sprint MS-176: ConvTranspose backward GPU coverage [COMPLETE]
 
 - [x] [patch] Added WGPU backend-autograd `conv_transpose1d` and

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,18 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-177: TCP distributed test determinism [COMPLETE]
+
+- [x] [patch] Added a file-backed cross-process TCP port allocator lock and
+  deterministic localhost port reservation to prevent nextest process-parallel
+  TCP tests from racing on ephemeral port reuse.
+- [x] [patch] Added debug-only TCP mesh timeouts for connect, accept, peer-rank
+  read, send, and recv paths so failures surface with peer/rank context instead
+  of reaching the nextest 60s termination threshold.
+- [x] [patch] Kept connect backoff async via `moirai_async::sleep`; no blocking
+  sleep is introduced in the async mesh construction path.
+- [x] Evidence tier: empirical/value-semantic through the `coeus-dist` package
+  gate.
+
 ## Sprint MS-145: Bilinear backward PyTorch differential parity [COMPLETE]
 
 - [x] [patch] Added

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,26 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-145 - Bilinear backward PyTorch parity [COMPLETE]
+### Current Sprint: MS-177 - TCP distributed test determinism [COMPLETE]
+**Objective**: Make `coeus-dist` TCP collective tests deterministic under
+nextest process parallelism and bound debug-mode TCP mesh waits so failures
+surface as explicit panic diagnostics instead of 60s hangs.
+**Target version**: 0.5.4 (test/runtime diagnostics [patch]).
+
+- [x] [patch] Added a file-backed cross-process TCP port allocator lock and
+  deterministic local port reservation for `coeus-dist/tests/dist_tests.rs`,
+  covering multi-rank and single-rank TCP panic-contract tests.
+- [x] [patch] Added debug-only timeout diagnostics around TCP mesh connect,
+  accept, peer-rank read, send, and recv paths while preserving async backoff
+  through `moirai_async::sleep`.
+- [x] [patch] Consolidated remaining TCP panic-thread assertions through
+  `assert_any_thread_panicked`.
+- [x] Evidence: `rustup run nightly cargo fmt -p coeus-dist --check`; `rustup
+  run nightly cargo check -p coeus-dist --all-targets`; `rustup run nightly
+  cargo clippy -p coeus-dist --all-targets -- -D warnings`; `rustup run nightly
+  cargo nextest run -p coeus-dist`; `git diff --check`.
+
+### Previous Sprint: MS-145 - Bilinear backward PyTorch parity [COMPLETE]
 **Objective**: Close the deferred backward gap for `pycoeus.Bilinear` from
 MS-140 forward parity; extend the differential harness to the bilinear
 interaction layer's autograd-tracked composition.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,22 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-176 - ConvTranspose backward GPU coverage [COMPLETE]
+### Current Sprint: MS-145 - Bilinear backward PyTorch parity [COMPLETE]
+**Objective**: Close the deferred backward gap for `pycoeus.Bilinear` from
+MS-140 forward parity; extend the differential harness to the bilinear
+interaction layer's autograd-tracked composition.
+**Target version**: 0.5.4 (test-only [patch]).
+
+- [x] [patch] Added
+  `coeus-python/tests/test_pytorch_parity.py::test_bilinear_backward_matches_pytorch`
+  asserting `pycoeus.Bilinear(3,4,2, bias=True)` differentiated via
+  `out.sum().backward()` against `torch.nn.Bilinear.double()` at f64, atol=1e-10.
+  Covers dweight (`[out, in1, in2]` flat), dbias, dx1, dx2.
+- [x] Evidence: `JAX_ENABLE_X64=1 JAX_PLATFORMS=cpu D:\miniforge3\python.exe -m
+  pytest coeus-python/tests/test_pytorch_parity.py::test_bilinear_backward_matches_pytorch
+  -v` (1/1 PASS); full Python parity suite 55 passed + 2 MLX-skipped.
+
+### Previous Sprint: MS-176 - ConvTranspose backward GPU coverage [COMPLETE]
 **Objective**: Close the deferred ConvTranspose backward coverage gap for the
 WGPU and CUDA backend-autograd paths without adding a duplicate backend backward
 API before there is a dedicated kernel seam.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -2,6 +2,16 @@
 
 ## Known Gaps & Residual Risks
 
+### ~~G-032: TCP collectives could hang past nextest timeout~~ **CLOSED**
+**Location**: `coeus-dist/src/tcp/mesh.rs`,
+`coeus-dist/tests/dist_tests.rs`
+**Closed by**: MS-177 — Added deterministic TCP test port reservation through a
+file-backed cross-process port allocator lock, and debug-mode mesh timeouts around
+connect, accept, peer-rank read, send, and recv paths. Connect retry backoff
+remains async through `moirai_async::sleep`, so the debug diagnostics do not
+introduce executor-blocking sleep. Evidence tier: empirical/value-semantic
+through the `coeus-dist` package gate.
+
 ### ~~G-031: JAX harness lacked regression/binary loss parity~~ **CLOSED**
 **Location**: `coeus-python/tests/test_jax_parity.py`
 **Closed by**: MS-175 — Added `test_{mse_loss,binary_cross_entropy,huber_loss}_matches_jax`,


### PR DESCRIPTION
## Summary
- add a file-backed cross-process TCP port allocator for coeus-dist tests
- bound debug-mode TcpMesh connect/accept/rank-read/send/recv waits with rank/peer diagnostics
- keep TCP connect retry backoff async through moirai_async::sleep
- sync checklist, backlog, gap audit, and changelog for MS-177

## Evidence
- rustup run nightly cargo fmt -p coeus-dist --check
- rustup run nightly cargo check -p coeus-dist --all-targets
- rustup run nightly cargo clippy -p coeus-dist --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-dist (64/64)
- rustup run nightly cargo test --doc -p coeus-dist (8/8)
- rustup run nightly cargo doc -p coeus-dist --no-deps
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR stabilizes TCP collective tests in `coeus-dist` by introducing a file-backed cross-process port allocator to prevent port conflicts during parallel test execution, and adds debug-mode timeouts with diagnostic panic messages for TCP mesh operations (connect, accept, rank-read, send, recv) to surface failures before hitting the 60-second test timeout. The connect retry backoff remains async through `moirai_async::sleep` to avoid blocking the executor. Documentation updates include the checklist, backlog, gap audit, and changelog to reflect the completion of sprint MS-177.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `CHANGELOG.md` |
| 5 | `coeus-dist/tests/dist_tests.rs` |
| 6 | `coeus-dist/src/tcp/mesh.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP distributed test reliability by making localhost port reservation deterministic and reducing test race conditions.
  * Added debug-only timeouts and clearer panic messages for TCP connect, accept, send, and receive operations to help surface hangs faster.

* **Documentation**
  * Updated release tracking notes and backlog status to reflect the completed TCP test determinism work and closed related risk item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->