### PR TITLE
test(dist): Harden TCP lock contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   send/recv waits with peer/rank panic diagnostics. Connect retry backoff
   remains async through `moirai_async::sleep`. Evidence tier:
   empirical/value-semantic `coeus-dist` package gate. ([patch])
+- **TCP port allocator lock robustness** — the test-only TCP port allocator now
+  treats Windows `PermissionDenied` during lock-file creation as an already-held
+  lock, preserving the same stale-lock timeout and diagnostics instead of
+  failing spuriously while another process owns the lock handle. ([patch])
 - **Conv2d CPU AXPY kernel** — canonical contiguous CPU Conv2d forward now uses
   an output-stationary row kernel with `Scalar::axpy_slice` routed through
   Hermes SIMD for native floats, and coarser row-block partitioning for Moirai

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -476,7 +476,12 @@ fn port_allocator_lock() -> PortAllocatorLock {
     loop {
         match OpenOptions::new().write(true).create_new(true).open(&path) {
             Ok(_) => return PortAllocatorLock { path },
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::PermissionDenied
+                ) =>
+            {
                 if start.elapsed() > Duration::from_secs(20) {
                     let metadata = fs::metadata(&path)
                         .expect("TCP port allocator lock exists but metadata could not be read");

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -5,6 +5,9 @@
 - [x] [patch] Added a file-backed cross-process TCP port allocator lock and
   deterministic localhost port reservation to prevent nextest process-parallel
   TCP tests from racing on ephemeral port reuse.
+- [x] [patch] Treated Windows `PermissionDenied` from lock-file creation as
+  lock contention rather than a fatal allocator setup error, preserving the
+  existing stale-lock timeout path.
 - [x] [patch] Added debug-only TCP mesh timeouts for connect, accept, peer-rank
   read, send, and recv paths so failures surface with peer/rank context instead
   of reaching the nextest 60s termination threshold.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -11,6 +11,9 @@ surface as explicit panic diagnostics instead of 60s hangs.
 - [x] [patch] Added a file-backed cross-process TCP port allocator lock and
   deterministic local port reservation for `coeus-dist/tests/dist_tests.rs`,
   covering multi-rank and single-rank TCP panic-contract tests.
+- [x] [patch] Treated Windows `PermissionDenied` during TCP lock-file creation
+  as an already-held lock, preserving stale-lock diagnostics for nextest
+  process contention.
 - [x] [patch] Added debug-only timeout diagnostics around TCP mesh connect,
   accept, peer-rank read, send, and recv paths while preserving async backoff
   through `moirai_async::sleep`.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,8 +9,10 @@
 file-backed cross-process port allocator lock, and debug-mode mesh timeouts around
 connect, accept, peer-rank read, send, and recv paths. Connect retry backoff
 remains async through `moirai_async::sleep`, so the debug diagnostics do not
-introduce executor-blocking sleep. Evidence tier: empirical/value-semantic
-through the `coeus-dist` package gate.
+introduce executor-blocking sleep. The lock creation path also treats Windows
+`PermissionDenied` as lock contention rather than a distinct fatal failure,
+preserving the stale-lock timeout diagnostic under nextest process contention.
+Evidence tier: empirical/value-semantic through the `coeus-dist` package gate.
 
 ### ~~G-031: JAX harness lacked regression/binary loss parity~~ **CLOSED**
 **Location**: `coeus-python/tests/test_jax_parity.py`


### PR DESCRIPTION
## Summary
- Treat Windows PermissionDenied during test TCP port lock-file creation as lock contention.
- Preserve the existing stale-lock timeout and diagnostics.
- Sync Coeus PM artifacts for the dist test robustness slice.

## Verification
- rustup run nightly cargo fmt -p coeus-dist --check
- rustup run nightly cargo check -p coeus-dist --all-targets
- rustup run nightly cargo clippy -p coeus-dist --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-dist
- rustup run nightly cargo test --doc -p coeus-dist
- rustup run nightly cargo doc -p coeus-dist --no-deps
- git diff --check --cached

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the test-only TCP port allocator lock by treating Windows `PermissionDenied` errors during lock-file creation as lock contention rather than fatal failures. Previously, when another process held the lock, Windows could return `PermissionDenied` instead of `AlreadyExists`, causing spurious test failures. The fix now handles both error kinds consistently, preserving the existing 20-second stale-lock timeout and diagnostic behavior. Documentation across CHANGELOG, backlog, checklist, and gap audit files is updated to reflect this robustness improvement.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/checklist.md` |
| 5 | `docs/gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP port locking reliability on Windows, reducing spurious failures when another process already holds the lock.
  * Preserved existing timeout and diagnostic behavior when the lock can’t be acquired right away.

* **Documentation**
  * Updated release notes, sprint tracking, and audit docs to reflect the improved lock-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->