### PR TITLE
test(dist): stabilize TCP collective suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   send/recv waits with peer/rank panic diagnostics. Connect retry backoff
   remains async through `moirai_async::sleep`. Evidence tier:
   empirical/value-semantic `coeus-dist` package gate. ([patch])
+- **TCP port allocator lock robustness** — the test-only TCP port allocator now
+  treats Windows `PermissionDenied` during lock-file creation as an already-held
+  lock, preserving the same stale-lock timeout and diagnostics instead of
+  failing spuriously while another process owns the lock handle. ([patch])
 - **Conv2d CPU AXPY kernel** — canonical contiguous CPU Conv2d forward now uses
   an output-stationary row kernel with `Scalar::axpy_slice` routed through
   Hermes SIMD for native floats, and coarser row-block partitioning for Moirai

--- a/coeus-dist/src/tcp/mesh.rs
+++ b/coeus-dist/src/tcp/mesh.rs
@@ -1,3 +1,4 @@
+use moirai::Moirai;
 use moirai_async::{AsyncReadExt, AsyncWriteExt, TcpListener, TcpStream};
 use std::net::SocketAddr;
 use std::sync::Mutex;
@@ -8,12 +9,13 @@ pub struct TcpMesh {
     rank: usize,
     size: usize,
     streams: Vec<Option<Mutex<TcpStream>>>,
+    runtime: Moirai,
 }
 
 impl TcpMesh {
     #[inline]
     fn debug_timeout() -> Option<Duration> {
-        cfg!(debug_assertions).then_some(Duration::from_secs(5))
+        cfg!(debug_assertions).then_some(Duration::from_secs(45))
     }
 
     /// Create a new TCP mesh connecting all ranks.
@@ -26,8 +28,9 @@ impl TcpMesh {
             "addresses list length must match world size"
         );
         let mut streams = (0..size).map(|_| None).collect::<Vec<_>>();
+        let runtime = Moirai::new().expect("failed to initialize dedicated TCP mesh runtime");
 
-        moirai::global().block_on(async {
+        runtime.block_on(async {
             let local_addr = addresses[rank].to_string();
             let listener = TcpListener::bind(&local_addr)
                 .await
@@ -123,6 +126,7 @@ impl TcpMesh {
             rank,
             size,
             streams,
+            runtime,
         }
     }
 
@@ -152,7 +156,7 @@ impl TcpMesh {
     pub fn send(&self, target: usize, bytes: &[u8]) {
         let stream_mutex = self.stream_for_peer(target, "send");
         let mut stream = stream_mutex.lock().unwrap();
-        moirai::global().block_on(async {
+        self.runtime.block_on(async {
             if let Some(timeout) = Self::debug_timeout() {
                 moirai_async::timeout(timeout, stream.write_all(bytes))
                     .await
@@ -172,7 +176,7 @@ impl TcpMesh {
     pub fn recv(&self, source: usize, bytes: &mut [u8]) {
         let stream_mutex = self.stream_for_peer(source, "recv");
         let mut stream = stream_mutex.lock().unwrap();
-        moirai::global().block_on(async {
+        self.runtime.block_on(async {
             if let Some(timeout) = Self::debug_timeout() {
                 moirai_async::timeout(timeout, stream.read_exact(bytes))
                     .await
@@ -185,5 +189,11 @@ impl TcpMesh {
                     .expect("failed to receive bytes over TCP");
             }
         });
+    }
+}
+
+impl Drop for TcpMesh {
+    fn drop(&mut self) {
+        self.runtime.shutdown();
     }
 }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -6,44 +6,34 @@ use coeus_dist::{
 };
 use coeus_tensor::Tensor;
 use std::fs::{self, OpenOptions};
+use std::panic::{self, AssertUnwindSafe};
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-fn assert_any_thread_panicked(handles: Vec<thread::JoinHandle<()>>, message: &str) {
-    let total = handles.len();
-    let (tx, rx) = mpsc::channel();
-    for handle in handles {
-        let tx = tx.clone();
-        thread::spawn(move || {
-            let _ = tx.send(handle.join().is_err());
-        });
-    }
-    drop(tx);
+fn assert_any_thread_panicked(handles: Vec<thread::JoinHandle<bool>>, message: &str) {
+    let panicked = handles
+        .into_iter()
+        .map(|h| h.join().unwrap_or(true))
+        .collect::<Vec<_>>();
+    assert!(panicked.iter().any(|&p| p), "{}", message);
+}
 
-    let deadline = Instant::now() + Duration::from_secs(20);
-    let mut completed = 0usize;
-    let mut panicked = false;
-    while completed < total {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        match rx.recv_timeout(remaining) {
-            Ok(did_panic) => {
-                completed += 1;
-                panicked |= did_panic;
-                if panicked {
-                    break;
-                }
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => break,
-            Err(mpsc::RecvTimeoutError::Disconnected) => break,
-        }
-    }
+static TCP_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
-    assert!(panicked, "{}", message);
+fn tcp_test_lock() -> MutexGuard<'static, ()> {
+    TCP_TEST_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn spawn_maybe_panicking<F>(f: F) -> thread::JoinHandle<bool>
+where
+    F: FnOnce() + Send + 'static,
+{
+    thread::spawn(move || panic::catch_unwind(AssertUnwindSafe(f)).is_err())
 }
 
 #[test]
@@ -567,6 +557,7 @@ fn get_free_ports(count: usize) -> Vec<std::net::SocketAddr> {
 
 #[test]
 fn test_tcp_all_reduce() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -597,13 +588,14 @@ fn test_tcp_all_reduce() {
 
 #[test]
 fn test_tcp_all_reduce_mismatched_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -625,13 +617,14 @@ fn test_tcp_all_reduce_mismatched_numel_panics() {
 
 #[test]
 fn test_tcp_all_reduce_zero_numel_mismatched_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -653,6 +646,7 @@ fn test_tcp_all_reduce_zero_numel_mismatched_numel_panics() {
 
 #[test]
 fn test_tcp_broadcast() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -687,6 +681,7 @@ fn test_tcp_broadcast() {
 
 #[test]
 fn test_tcp_broadcast_mismatched_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -694,7 +689,7 @@ fn test_tcp_broadcast_mismatched_numel_panics() {
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -717,6 +712,7 @@ fn test_tcp_broadcast_mismatched_numel_panics() {
 
 #[test]
 fn test_tcp_all_gather() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -750,13 +746,14 @@ fn test_tcp_all_gather() {
 
 #[test]
 fn test_tcp_all_gather_mismatched_peer_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -790,13 +787,14 @@ fn test_tcp_all_gather_mismatched_peer_numel_panics() {
 
 #[test]
 fn test_tcp_all_gather_zero_numel_mismatched_peer_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -830,6 +828,7 @@ fn test_tcp_all_gather_zero_numel_mismatched_peer_numel_panics() {
 
 #[test]
 fn test_tcp_barrier() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -853,6 +852,7 @@ fn test_tcp_barrier() {
 
 #[test]
 fn test_tcp_reduce() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -885,6 +885,7 @@ fn test_tcp_reduce() {
 
 #[test]
 fn test_tcp_reduce_mismatched_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -892,7 +893,7 @@ fn test_tcp_reduce_mismatched_numel_panics() {
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -915,6 +916,7 @@ fn test_tcp_reduce_mismatched_numel_panics() {
 
 #[test]
 fn test_tcp_gather() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -954,13 +956,14 @@ fn test_tcp_gather() {
 
 #[test]
 fn test_tcp_gather_mismatched_peer_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -990,13 +993,14 @@ fn test_tcp_gather_mismatched_peer_numel_panics() {
 
 #[test]
 fn test_tcp_gather_zero_numel_mismatched_peer_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -1026,6 +1030,7 @@ fn test_tcp_gather_zero_numel_mismatched_peer_numel_panics() {
 
 #[test]
 fn test_tcp_scatter() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
 
@@ -1062,13 +1067,14 @@ fn test_tcp_scatter() {
 
 #[test]
 fn test_tcp_scatter_mismatched_target_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -1099,13 +1105,14 @@ fn test_tcp_scatter_mismatched_target_numel_panics() {
 
 #[test]
 fn test_tcp_scatter_zero_numel_mismatched_target_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let world_size = 2;
     let addresses = get_free_ports(world_size);
     let mut handles = vec![];
 
     for rank in 0..world_size {
         let addrs = addresses.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_maybe_panicking(move || {
             let mesh = TcpMesh::new(rank, world_size, &addrs);
             let comm = TcpCommunicator::new(mesh);
             let backend = SequentialBackend::new();
@@ -1137,6 +1144,7 @@ fn test_tcp_scatter_zero_numel_mismatched_target_numel_panics() {
 #[test]
 #[should_panic(expected = "all_gather output numel mismatch")]
 fn test_tcp_all_gather_mismatched_output_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1150,6 +1158,7 @@ fn test_tcp_all_gather_mismatched_output_numel_panics() {
 #[test]
 #[should_panic(expected = "all_gather output length mismatch")]
 fn test_tcp_all_gather_zero_numel_output_len_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1163,6 +1172,7 @@ fn test_tcp_all_gather_zero_numel_output_len_mismatch_panics() {
 #[test]
 #[should_panic(expected = "all_gather output numel mismatch")]
 fn test_tcp_all_gather_zero_numel_output_numel_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1176,6 +1186,7 @@ fn test_tcp_all_gather_zero_numel_output_numel_mismatch_panics() {
 #[test]
 #[should_panic(expected = "scatter input numel mismatch")]
 fn test_tcp_scatter_mismatched_input_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1189,6 +1200,7 @@ fn test_tcp_scatter_mismatched_input_numel_panics() {
 #[test]
 #[should_panic(expected = "collective root out of bounds")]
 fn test_tcp_broadcast_root_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1200,6 +1212,7 @@ fn test_tcp_broadcast_root_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "collective root out of bounds")]
 fn test_tcp_reduce_root_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1211,6 +1224,7 @@ fn test_tcp_reduce_root_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "collective root out of bounds")]
 fn test_tcp_gather_root_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1223,6 +1237,7 @@ fn test_tcp_gather_root_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "collective root out of bounds")]
 fn test_tcp_scatter_root_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1235,6 +1250,7 @@ fn test_tcp_scatter_root_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "gather output length mismatch on root")]
 fn test_tcp_gather_zero_numel_output_len_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1247,6 +1263,7 @@ fn test_tcp_gather_zero_numel_output_len_mismatch_panics() {
 #[test]
 #[should_panic(expected = "gather output numel mismatch")]
 fn test_tcp_gather_mismatched_output_numel_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1259,6 +1276,7 @@ fn test_tcp_gather_mismatched_output_numel_panics() {
 #[test]
 #[should_panic(expected = "gather output numel mismatch")]
 fn test_tcp_gather_zero_numel_output_numel_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1271,6 +1289,7 @@ fn test_tcp_gather_zero_numel_output_numel_mismatch_panics() {
 #[test]
 #[should_panic(expected = "scatter input length mismatch on root")]
 fn test_tcp_scatter_zero_numel_input_len_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1283,6 +1302,7 @@ fn test_tcp_scatter_zero_numel_input_len_mismatch_panics() {
 #[test]
 #[should_panic(expected = "scatter input numel mismatch")]
 fn test_tcp_scatter_zero_numel_input_numel_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let comm = TcpCommunicator::new(mesh);
@@ -1295,6 +1315,7 @@ fn test_tcp_scatter_zero_numel_input_numel_mismatch_panics() {
 #[test]
 #[should_panic(expected = "send peer must differ from local rank")]
 fn test_tcp_mesh_send_self_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     mesh.send(0, &[1u8]);
@@ -1303,6 +1324,7 @@ fn test_tcp_mesh_send_self_panics() {
 #[test]
 #[should_panic(expected = "recv peer must differ from local rank")]
 fn test_tcp_mesh_recv_self_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let mut byte = [0u8; 1];
@@ -1312,6 +1334,7 @@ fn test_tcp_mesh_recv_self_panics() {
 #[test]
 #[should_panic(expected = "send peer out of bounds")]
 fn test_tcp_mesh_send_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     mesh.send(1, &[1u8]);
@@ -1320,6 +1343,7 @@ fn test_tcp_mesh_send_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "recv peer out of bounds")]
 fn test_tcp_mesh_recv_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let mesh = TcpMesh::new(0, 1, &addresses);
     let mut byte = [0u8; 1];
@@ -1329,6 +1353,7 @@ fn test_tcp_mesh_recv_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "rank must be less than world size")]
 fn test_tcp_mesh_new_rank_out_of_bounds_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let _mesh = TcpMesh::new(1, 1, &addresses);
 }
@@ -1336,6 +1361,7 @@ fn test_tcp_mesh_new_rank_out_of_bounds_panics() {
 #[test]
 #[should_panic(expected = "world size must be > 0")]
 fn test_tcp_mesh_new_zero_world_size_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses: Vec<std::net::SocketAddr> = vec![];
     let _mesh = TcpMesh::new(0, 0, &addresses);
 }
@@ -1343,6 +1369,7 @@ fn test_tcp_mesh_new_zero_world_size_panics() {
 #[test]
 #[should_panic(expected = "addresses list length must match world size")]
 fn test_tcp_mesh_new_addresses_len_mismatch_panics() {
+    let _tcp_lock = tcp_test_lock();
     let addresses = get_free_ports(1);
     let _mesh = TcpMesh::new(0, 2, &addresses);
 }

--- a/coeus-dist/tests/dist_tests.rs
+++ b/coeus-dist/tests/dist_tests.rs
@@ -476,7 +476,12 @@ fn port_allocator_lock() -> PortAllocatorLock {
     loop {
         match OpenOptions::new().write(true).create_new(true).open(&path) {
             Ok(_) => return PortAllocatorLock { path },
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::PermissionDenied
+                ) =>
+            {
                 if start.elapsed() > Duration::from_secs(20) {
                     let metadata = fs::metadata(&path)
                         .expect("TCP port allocator lock exists but metadata could not be read");

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -5,6 +5,9 @@
 - [x] [patch] Added a file-backed cross-process TCP port allocator lock and
   deterministic localhost port reservation to prevent nextest process-parallel
   TCP tests from racing on ephemeral port reuse.
+- [x] [patch] Treated Windows `PermissionDenied` from lock-file creation as
+  lock contention rather than a fatal allocator setup error, preserving the
+  existing stale-lock timeout path.
 - [x] [patch] Added debug-only TCP mesh timeouts for connect, accept, peer-rank
   read, send, and recv paths so failures surface with peer/rank context instead
   of reaching the nextest 60s termination threshold.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -11,6 +11,9 @@ surface as explicit panic diagnostics instead of 60s hangs.
 - [x] [patch] Added a file-backed cross-process TCP port allocator lock and
   deterministic local port reservation for `coeus-dist/tests/dist_tests.rs`,
   covering multi-rank and single-rank TCP panic-contract tests.
+- [x] [patch] Treated Windows `PermissionDenied` during TCP lock-file creation
+  as an already-held lock, preserving stale-lock diagnostics for nextest
+  process contention.
 - [x] [patch] Added debug-only timeout diagnostics around TCP mesh connect,
   accept, peer-rank read, send, and recv paths while preserving async backoff
   through `moirai_async::sleep`.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,8 +9,10 @@
 file-backed cross-process port allocator lock, and debug-mode mesh timeouts around
 connect, accept, peer-rank read, send, and recv paths. Connect retry backoff
 remains async through `moirai_async::sleep`, so the debug diagnostics do not
-introduce executor-blocking sleep. Evidence tier: empirical/value-semantic
-through the `coeus-dist` package gate.
+introduce executor-blocking sleep. The lock creation path also treats Windows
+`PermissionDenied` as lock contention rather than a distinct fatal failure,
+preserving the stale-lock timeout diagnostic under nextest process contention.
+Evidence tier: empirical/value-semantic through the `coeus-dist` package gate.
 
 ### ~~G-031: JAX harness lacked regression/binary loss parity~~ **CLOSED**
 **Location**: `coeus-python/tests/test_jax_parity.py`


### PR DESCRIPTION
TCP suite stabilization.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR stabilizes the TCP distributed collective test suite by introducing three key improvements: (1) adding a global mutex to serialize TCP tests and prevent port allocation races under parallel test execution, (2) switching `TcpMesh` from the global Moirai runtime to a dedicated per-instance runtime with explicit shutdown to avoid interference between concurrent tests, and (3) enhancing the TCP port allocator lock to treat Windows `PermissionDenied` errors as lock contention rather than fatal failures. Additionally, the debug timeout for TCP operations is increased from 5 to 45 seconds, and panic-detecting tests now use `spawn_maybe_panicking` helper with proper unwind catching instead of channel-based detection.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-dist/tests/dist_tests.rs` |
| 2 | `coeus-dist/src/tcp/mesh.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `docs/checklist.md` |
| 6 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->