### PR TITLE
test(nn): Assert conv gradient values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changed
 
-- **Conv1d/Conv2d gradient test hardening** — `coeus-nn` Conv1d and Conv2d
-  module tests now assert exact analytical input, weight, and bias gradients
+- **Conv1d/Conv2d/Conv3d gradient test hardening** — `coeus-nn` Conv module
+  tests now assert exact analytical input, weight, and bias gradients
   instead of only checking that gradient buffers exist. Evidence tier:
   analytical/value-semantic Rust tests. ([patch])
 - **TCP distributed test determinism** — `coeus-dist` TCP tests now use a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **Conv1d/Conv2d gradient test hardening** — `coeus-nn` Conv1d and Conv2d
+  module tests now assert exact analytical input, weight, and bias gradients
+  instead of only checking that gradient buffers exist. Evidence tier:
+  analytical/value-semantic Rust tests. ([patch])
 - **TCP distributed test determinism** — `coeus-dist` TCP tests now use a
   file-backed cross-process port allocator lock plus deterministic localhost
   port reservation, and TCP mesh debug builds bound connect/accept/rank-read/

--- a/coeus-nn/tests/nn/conv1d.rs
+++ b/coeus-nn/tests/nn/conv1d.rs
@@ -65,7 +65,7 @@ fn test_conv1d_forward_multi_channel() {
 }
 
 #[test]
-fn test_conv1d_backward_gradients_exist() {
+fn test_conv1d_backward_gradients_match_reference() {
     let mut conv = Conv1d::<f64>::new(1, 1, 2, true);
     init::constant(&mut conv.weight, 1.0);
     if let Some(ref mut b) = conv.bias {
@@ -80,10 +80,18 @@ fn test_conv1d_backward_gradients_exist() {
     let output = conv.forward(&input);
     output.backward();
 
-    assert!(input.grad().is_some());
-    assert!(conv.weight.grad().is_some());
+    let input_grad = input.grad().expect("input gradient must be set");
+    assert_eq!(input_grad.shape(), &[1, 1, 4]);
+    assert_eq!(input_grad.as_slice(), &[1.0, 2.0, 2.0, 1.0]);
+
+    let weight_grad = conv.weight.grad().expect("weight gradient must be set");
+    assert_eq!(weight_grad.shape(), &[1, 1, 2]);
+    assert_eq!(weight_grad.as_slice(), &[6.0, 9.0]);
+
     if let Some(ref b) = conv.bias {
-        assert!(b.grad().is_some());
+        let bias_grad = b.grad().expect("bias gradient must be set");
+        assert_eq!(bias_grad.shape(), &[1]);
+        assert_eq!(bias_grad.as_slice(), &[3.0]);
     }
 }
 

--- a/coeus-nn/tests/nn/conv2d.rs
+++ b/coeus-nn/tests/nn/conv2d.rs
@@ -49,7 +49,7 @@ fn test_conv2d_forward_computation() {
 }
 
 #[test]
-fn test_conv2d_backward_gradients_exist() {
+fn test_conv2d_backward_gradients_match_reference() {
     let mut conv = Conv2d::<f64>::new(1, 1, 2, true);
     init::constant(&mut conv.weight, 1.0);
     if let Some(ref mut b) = conv.bias {
@@ -67,10 +67,21 @@ fn test_conv2d_backward_gradients_exist() {
     let output = conv.forward(&input);
     output.backward();
 
-    assert!(input.grad().is_some());
-    assert!(conv.weight.grad().is_some());
+    let input_grad = input.grad().expect("input gradient must be set");
+    assert_eq!(input_grad.shape(), &[1, 1, 3, 3]);
+    assert_eq!(
+        input_grad.as_slice(),
+        &[1.0, 2.0, 1.0, 2.0, 4.0, 2.0, 1.0, 2.0, 1.0]
+    );
+
+    let weight_grad = conv.weight.grad().expect("weight gradient must be set");
+    assert_eq!(weight_grad.shape(), &[1, 1, 2, 2]);
+    assert_eq!(weight_grad.as_slice(), &[12.0, 16.0, 24.0, 28.0]);
+
     if let Some(ref b) = conv.bias {
-        assert!(b.grad().is_some());
+        let bias_grad = b.grad().expect("bias gradient must be set");
+        assert_eq!(bias_grad.shape(), &[1]);
+        assert_eq!(bias_grad.as_slice(), &[4.0]);
     }
 }
 

--- a/coeus-nn/tests/nn/conv3d_pool3d.rs
+++ b/coeus-nn/tests/nn/conv3d_pool3d.rs
@@ -38,7 +38,7 @@ fn test_conv3d_forward_computation() {
 }
 
 #[test]
-fn test_conv3d_backward_gradients_exist() {
+fn test_conv3d_backward_gradients_match_reference() {
     let mut conv = Conv3d::<f64>::new(1, 1, 2, true);
     init::constant(&mut conv.weight, 1.0);
     if let Some(ref mut b) = conv.bias {
@@ -56,10 +56,21 @@ fn test_conv3d_backward_gradients_exist() {
     let output = conv.forward(&input);
     output.backward();
 
-    assert!(input.grad().is_some());
-    assert!(conv.weight.grad().is_some());
+    let input_grad = input.grad().expect("input gradient must be set");
+    assert_eq!(input_grad.shape(), &[1, 1, 2, 2, 2]);
+    assert_eq!(input_grad.as_slice(), &[1.0; 8]);
+
+    let weight_grad = conv.weight.grad().expect("weight gradient must be set");
+    assert_eq!(weight_grad.shape(), &[1, 1, 2, 2, 2]);
+    assert_eq!(
+        weight_grad.as_slice(),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    );
+
     if let Some(ref b) = conv.bias {
-        assert!(b.grad().is_some());
+        let bias_grad = b.grad().expect("bias gradient must be set");
+        assert_eq!(bias_grad.shape(), &[1]);
+        assert_eq!(bias_grad.as_slice(), &[1.0]);
     }
 }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,7 +2,7 @@
 
 ## Sprint MS-178: Conv gradient value assertions [COMPLETE]
 
-- [x] [patch] Replaced Conv1d/Conv2d module backward existence-only assertions
+- [x] [patch] Replaced Conv1d/Conv2d/Conv3d module backward existence-only assertions
   with exact analytical checks for input, weight, and bias gradients.
 - [x] Evidence tier: analytical/value-semantic Rust tests.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,11 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-178: Conv gradient value assertions [COMPLETE]
+
+- [x] [patch] Replaced Conv1d/Conv2d module backward existence-only assertions
+  with exact analytical checks for input, weight, and bias gradients.
+- [x] Evidence tier: analytical/value-semantic Rust tests.
+
 ## Sprint MS-177: TCP distributed test determinism [COMPLETE]
 
 - [x] [patch] Added a file-backed cross-process TCP port allocator lock and

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,26 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-177 - TCP distributed test determinism [COMPLETE]
+### Current Sprint: MS-178 - Conv gradient value assertions [COMPLETE]
+**Objective**: Remove existence-only Conv1d/Conv2d module gradient checks and
+replace them with analytical value-semantic assertions for small deterministic
+kernels.
+**Target version**: 0.5.4 (test-only [patch]).
+
+- [x] [patch] Replaced `test_conv1d_backward_gradients_exist` with
+  `test_conv1d_backward_gradients_match_reference`, asserting exact input,
+  weight, and bias gradients for a `[1,1,4]` input and all-ones kernel.
+- [x] [patch] Replaced `test_conv2d_backward_gradients_exist` with
+  `test_conv2d_backward_gradients_match_reference`, asserting exact input,
+  weight, and bias gradients for a `[1,1,3,3]` input and all-ones `2x2` kernel.
+- [x] Evidence: `rustup run nightly cargo fmt -p coeus-nn --check`; `rustup
+  run nightly cargo check -p coeus-nn --all-targets`; `rustup run nightly cargo
+  clippy -p coeus-nn --all-targets -- -D warnings`; `rustup run nightly cargo
+  nextest run -p coeus-nn` (305/305); `rustup run nightly cargo test --doc -p
+  coeus-nn`; `rustup run nightly cargo doc -p coeus-nn --no-deps`; `git diff
+  --check`.
+
+### Previous Sprint: MS-177 - TCP distributed test determinism [COMPLETE]
 **Objective**: Make `coeus-dist` TCP collective tests deterministic under
 nextest process parallelism and bound debug-mode TCP mesh waits so failures
 surface as explicit panic diagnostics instead of 60s hangs.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -3,7 +3,7 @@
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
 ### Current Sprint: MS-178 - Conv gradient value assertions [COMPLETE]
-**Objective**: Remove existence-only Conv1d/Conv2d module gradient checks and
+**Objective**: Remove existence-only Conv1d/Conv2d/Conv3d module gradient checks and
 replace them with analytical value-semantic assertions for small deterministic
 kernels.
 **Target version**: 0.5.4 (test-only [patch]).
@@ -14,6 +14,10 @@ kernels.
 - [x] [patch] Replaced `test_conv2d_backward_gradients_exist` with
   `test_conv2d_backward_gradients_match_reference`, asserting exact input,
   weight, and bias gradients for a `[1,1,3,3]` input and all-ones `2x2` kernel.
+- [x] [patch] Replaced `test_conv3d_backward_gradients_exist` with
+  `test_conv3d_backward_gradients_match_reference`, asserting exact input,
+  weight, and bias gradients for a `[1,1,2,2,2]` input and all-ones `2x2x2`
+  kernel.
 - [x] Evidence: `rustup run nightly cargo fmt -p coeus-nn --check`; `rustup
   run nightly cargo check -p coeus-nn --all-targets`; `rustup run nightly cargo
   clippy -p coeus-nn --all-targets -- -D warnings`; `rustup run nightly cargo

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -2,6 +2,14 @@
 
 ## Known Gaps & Residual Risks
 
+### ~~G-033: Conv module tests only checked gradient existence~~ **CLOSED**
+**Location**: `coeus-nn/tests/nn/conv1d.rs`,
+`coeus-nn/tests/nn/conv2d.rs`
+**Closed by**: MS-178 — Replaced Conv1d/Conv2d module backward smoke checks with
+exact analytical assertions for input, weight, and bias gradients under
+deterministic all-ones kernels. Evidence tier: analytical/value-semantic Rust
+tests.
+
 ### ~~G-032: TCP collectives could hang past nextest timeout~~ **CLOSED**
 **Location**: `coeus-dist/src/tcp/mesh.rs`,
 `coeus-dist/tests/dist_tests.rs`

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -4,8 +4,9 @@
 
 ### ~~G-033: Conv module tests only checked gradient existence~~ **CLOSED**
 **Location**: `coeus-nn/tests/nn/conv1d.rs`,
-`coeus-nn/tests/nn/conv2d.rs`
-**Closed by**: MS-178 — Replaced Conv1d/Conv2d module backward smoke checks with
+`coeus-nn/tests/nn/conv2d.rs`,
+`coeus-nn/tests/nn/conv3d_pool3d.rs`
+**Closed by**: MS-178 — Replaced Conv1d/Conv2d/Conv3d module backward smoke checks with
 exact analytical assertions for input, weight, and bias gradients under
 deterministic all-ones kernels. Evidence tier: analytical/value-semantic Rust
 tests.


### PR DESCRIPTION
## Summary
- Replace Conv1d/Conv2d backward existence-only checks with analytical gradient value assertions.
- Pin input, weight, and bias gradients for deterministic all-ones kernels.
- Sync changelog, checklist, backlog, and gap audit for MS-178.

## Evidence tier
- Analytical/value-semantic Rust tests.

## Verification
- rustup run nightly cargo fmt -p coeus-nn --check
- rustup run nightly cargo check -p coeus-nn --all-targets
- rustup run nightly cargo clippy -p coeus-nn --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-nn test_conv1d_backward_gradients_match_reference test_conv2d_backward_gradients_match_reference
- rustup run nightly cargo nextest run -p coeus-nn
- rustup run nightly cargo test --doc -p coeus-nn
- rustup run nightly cargo doc -p coeus-nn --no-deps
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR strengthens the test coverage for Conv1d and Conv2d backward passes by replacing existence-only gradient checks with exact analytical value assertions. The tests now verify that computed gradients match expected values for deterministic all-ones kernels, using small input tensors (`[1,1,4]` for Conv1d and `[1,1,3,3]` for Conv2d). The change also updates project documentation (changelog, backlog, checklist, and gap audit) to track completion of MS-178 sprint.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/nn/conv1d.rs` |
| 2 | `coeus-nn/tests/nn/conv2d.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `docs/checklist.md` |
| 6 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved convolution gradient checks so they now verify exact gradient values, not just that gradients are present.
  * This increases confidence in backward-pass correctness for 1D, 2D, and 3D convolutions.

* **Documentation**
  * Updated release and project tracking notes to reflect the completed gradient test hardening work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->