### PR TITLE
test(coeus-nn): harden linear loss gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- **Linear/loss gradient test hardening** — `coeus-nn` Linear, MSE, and
+  CrossEntropy focused tests now assert analytical gradient values instead of
+  only checking that gradient buffers exist. CrossEntropy uses a stable
+  softmax-minus-onehot mean-reduction oracle. Evidence tier:
+  analytical/value-semantic Rust tests. ([patch])
 - **Conv1d/Conv2d/Conv3d gradient test hardening** — `coeus-nn` Conv module
   tests now assert exact analytical input, weight, and bias gradients
   instead of only checking that gradient buffers exist. Evidence tier:

--- a/coeus-nn/tests/nn/linear_activation_loss.rs
+++ b/coeus-nn/tests/nn/linear_activation_loss.rs
@@ -2,6 +2,60 @@ use coeus_autograd::Var;
 use coeus_nn::{cross_entropy_loss, gelu, init, mse_loss, relu, sigmoid, tanh, Linear, Module};
 use coeus_tensor::Tensor;
 
+fn assert_slice_close(label: &str, actual: &[f64], expected: &[f64], tolerance: f64) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label}: length mismatch: actual {}, expected {}",
+        actual.len(),
+        expected.len()
+    );
+
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        let diff = (actual - expected).abs();
+        assert!(
+            diff <= tolerance,
+            "{label}[{index}]: actual {actual}, expected {expected}, diff {diff}, tolerance {tolerance}"
+        );
+    }
+}
+
+fn expected_cross_entropy_gradients(
+    logits: &[f64],
+    rows: usize,
+    cols: usize,
+    targets: &[usize],
+) -> Vec<f64> {
+    assert_eq!(logits.len(), rows * cols);
+    assert_eq!(targets.len(), rows);
+
+    let batch_scale = 1.0 / rows as f64;
+    let mut expected = Vec::with_capacity(logits.len());
+    for (row, &target) in targets.iter().enumerate() {
+        assert!(
+            target < cols,
+            "target class {target} must be less than {cols}"
+        );
+        let row_start = row * cols;
+        let row_logits = &logits[row_start..row_start + cols];
+        let max_logit = row_logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let exp_sum: f64 = row_logits
+            .iter()
+            .map(|logit| (*logit - max_logit).exp())
+            .sum();
+
+        for (class, &logit) in row_logits.iter().enumerate() {
+            let mut grad = ((logit - max_logit).exp() / exp_sum) * batch_scale;
+            if class == target {
+                grad -= batch_scale;
+            }
+            expected.push(grad);
+        }
+    }
+
+    expected
+}
+
 #[test]
 fn test_linear_layer() {
     let mut layer = Linear::<f64>::new(3, 2, true);
@@ -17,10 +71,28 @@ fn test_linear_layer() {
     assert_eq!(output.tensor.as_slice(), &[6.5, 6.5]);
 
     output.backward();
-    assert!(input.grad().is_some());
-    assert!(layer.weight.grad().is_some());
+    assert_eq!(
+        input
+            .grad()
+            .expect("linear input gradient must be populated")
+            .as_slice(),
+        &[2.0, 2.0, 2.0]
+    );
+    assert_eq!(
+        layer
+            .weight
+            .grad()
+            .expect("linear weight gradient must be populated")
+            .as_slice(),
+        &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
+    );
     if let Some(ref b) = layer.bias {
-        assert!(b.grad().is_some());
+        assert_eq!(
+            b.grad()
+                .expect("linear bias gradient must be populated")
+                .as_slice(),
+            &[1.0, 1.0]
+        );
     }
 }
 
@@ -62,18 +134,30 @@ fn test_losses() {
     let loss_mse = mse_loss(&pred, &target);
     assert_eq!(loss_mse.tensor.as_slice(), &[0.25]);
     loss_mse.backward();
-    assert!(pred.grad().is_some());
+    assert_eq!(
+        pred.grad()
+            .expect("mse prediction gradient must be populated")
+            .as_slice(),
+        &[-0.5, 0.5]
+    );
 
     // Cross entropy
-    let logits: Var<f64> = Var::new(
-        Tensor::from_slice(vec![2, 3], &[1.0f64, 2.0, 0.0, 0.0, 2.0, 1.0]),
-        true,
-    );
+    let logits_values = &[1.0f64, 2.0, 0.0, 0.0, 2.0, 1.0];
+    let logits: Var<f64> = Var::new(Tensor::from_slice(vec![2, 3], logits_values), true);
     let targets = vec![1, 2];
     let loss_ce = cross_entropy_loss(&logits, &targets);
     assert_eq!(loss_ce.tensor.shape(), &[1]);
     loss_ce.backward();
-    assert!(logits.grad().is_some());
+    let expected_ce_gradients = expected_cross_entropy_gradients(logits_values, 2, 3, &targets);
+    assert_slice_close(
+        "cross_entropy_logits_grad",
+        logits
+            .grad()
+            .expect("cross-entropy logit gradient must be populated")
+            .as_slice(),
+        &expected_ce_gradients,
+        1e-12,
+    );
 }
 
 #[test]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,12 @@
 # Coeus Project Backlog & Historical Archives
 
+## Sprint MS-179: Linear/loss gradient value assertions [COMPLETE]
+
+- [x] [patch] Replaced Linear, MSE, and CrossEntropy focused test
+  gradient-existence assertions with analytical value checks for input,
+  parameter, and loss gradients.
+- [x] Evidence tier: analytical/value-semantic Rust tests.
+
 ## Sprint MS-178: Conv gradient value assertions [COMPLETE]
 
 - [x] [patch] Replaced Conv1d/Conv2d/Conv3d module backward existence-only assertions

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,26 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-178 - Conv gradient value assertions [COMPLETE]
+### Current Sprint: MS-179 - Linear/loss gradient value assertions [COMPLETE]
+**Objective**: Remove existence-only Linear/MSE/CrossEntropy focused gradient
+checks and replace them with analytical value-semantic assertions.
+**Target version**: 0.5.4 (test-only [patch]).
+
+- [x] [patch] Replaced Linear module gradient-existence checks with exact
+  analytical assertions for input, weight, and bias gradients under a
+  deterministic all-ones layer and unit output seed.
+- [x] [patch] Replaced MSE loss gradient-existence checks with the analytical
+  mean-reduction derivative `2 * (prediction - target) / n`.
+- [x] [patch] Replaced CrossEntropy loss gradient-existence checks with a
+  stable softmax-minus-onehot mean-reduction oracle for the logits gradient.
+- [x] Evidence: `rustup run nightly cargo fmt -p coeus-nn --check`; `rustup
+  run nightly cargo check -p coeus-nn --all-targets`; `rustup run nightly cargo
+  clippy -p coeus-nn --all-targets -- -D warnings`; `rustup run nightly cargo
+  nextest run -p coeus-nn --test nn_tests`; `rustup run nightly cargo nextest
+  run -p coeus-nn`; `rustup run nightly cargo test --doc -p coeus-nn`; `rustup run
+  nightly cargo doc -p coeus-nn --no-deps`; `git diff --check`.
+
+### Previous Sprint: MS-178 - Conv gradient value assertions [COMPLETE]
 **Objective**: Remove existence-only Conv1d/Conv2d/Conv3d module gradient checks and
 replace them with analytical value-semantic assertions for small deterministic
 kernels.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -2,6 +2,15 @@
 
 ## Known Gaps & Residual Risks
 
+### ~~G-034: Linear/loss tests only checked gradient existence~~ **CLOSED**
+**Location**: `coeus-nn/tests/nn/linear_activation_loss.rs`
+**Closed by**: MS-179 — Replaced Linear, MSE, and CrossEntropy
+gradient-existence checks with value-semantic assertions. Linear now pins
+input, weight, and bias gradients for a deterministic all-ones layer; MSE pins
+the mean-reduction derivative; CrossEntropy pins the stable
+softmax-minus-onehot mean-reduction gradient. Evidence tier:
+analytical/value-semantic Rust tests.
+
 ### ~~G-033: Conv module tests only checked gradient existence~~ **CLOSED**
 **Location**: `coeus-nn/tests/nn/conv1d.rs`,
 `coeus-nn/tests/nn/conv2d.rs`,


### PR DESCRIPTION
## Summary
- replace Linear gradient existence checks with exact input/weight/bias gradient assertions
- replace MSE and CrossEntropy smoke checks with analytical gradient oracles
- sync MS-179 tracking in changelog, checklist, backlog, and gap audit

## Verification
- rustup run nightly cargo fmt -p coeus-nn --check
- rustup run nightly cargo check -p coeus-nn --all-targets
- rustup run nightly cargo clippy -p coeus-nn --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p coeus-nn --test nn_tests
- rustup run nightly cargo nextest run -p coeus-nn
- rustup run nightly cargo test --doc -p coeus-nn
- rustup run nightly cargo doc -p coeus-nn --no-deps
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens gradient testing in the `coeus-nn` package by replacing basic existence checks with precise analytical gradient assertions. The changes upgrade tests for the Linear layer, MSE loss, and CrossEntropy loss to verify exact gradient values using mathematical oracles. For Linear, the test now validates input, weight, and bias gradients against deterministic expectations. For MSE, the mean-reduction derivative is verified. For CrossEntropy, a stable softmax-minus-onehot mean-reduction oracle is implemented. The changes are tracked across project documentation (backlog, checklist, gap audit, and changelog) as milestone MS-179.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/nn/linear_activation_loss.rs` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/checklist.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->