### PR TITLE
bench/docs(nn): expand Burn parity benchmark matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- **Burn/PyTorch parity gap audit** — compared the current `coeus-nn` and
+  `coeus-python` public surfaces against Burn and PyTorch NN module families,
+  then filed open G-035..G-043 parity items in `docs/gap_audit.md` and mirrored
+  them in `docs/backlog.md`. Evidence tier: source-surface audit plus external
+  API documentation audit. ([patch])
 - **Linear/loss gradient test hardening** — `coeus-nn` Linear, MSE, and
   CrossEntropy focused tests now assert analytical gradient values instead of
   only checking that gradient buffers exist. CrossEntropy uses a stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,12 @@
   no bias/padding) across the same three backends. Short local Criterion run:
   Burn NdArray 2.19 ms, Coeus Sequential 32.83 ms, Coeus Moirai 126.56 ms
   median; no Conv2d speedup is claimed. ([patch])
+- **NN benchmark matrix expansion (Transformer encoder layer)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a Transformer encoder layer forward row
+  (`[8,64,256]`, `d_ff=1024`, 8 heads, dropout disabled), comparing Burn
+  NdArray against Coeus `SequentialBackend` and `MoiraiBackend` in the same
+  Criterion group. Short local run medians: Burn 233.47–239.80 ms, Coeus
+  Sequential 19.73–20.54 ms, Coeus Moirai 17.18–17.54 ms. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -18,12 +18,15 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
-use coeus_nn::{Conv2d, LayerNorm, Linear, Module, MultiHeadAttention, NullMask};
+use coeus_nn::{
+    Conv2d, LayerNorm, Linear, Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
+};
 use coeus_tensor::Tensor;
 
 use burn::backend::ndarray::{NdArray, NdArrayDevice};
 use burn::nn::attention::{MhaInput, MultiHeadAttentionConfig};
 use burn::nn::conv::Conv2dConfig;
+use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
 use burn::nn::{LayerNormConfig, LinearConfig, PaddingConfig2d};
 use burn::tensor::{Tensor as BurnTensor, TensorData};
 type BurnB = NdArray<f32>;
@@ -202,11 +205,55 @@ fn bench_mha_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_transformer_encoder_forward(c: &mut Criterion) {
+    // One Pre-LN transformer encoder layer (self-attn + FFN + 2 LayerNorms +
+    // residuals) on [batch=8, seq=64, d_model=256], d_ff=1024, 8 heads. Burn uses
+    // a single-layer encoder with norm-first and dropout disabled to match.
+    const B: usize = 8;
+    const SEQ: usize = 64;
+    const D: usize = 256;
+    const D_FF: usize = 1024;
+    const H: usize = 8;
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = vec![0.02f32; B * SEQ * D];
+
+    let burn_enc = TransformerEncoderConfig::new(D, D_FF, 1, H)
+        .with_norm_first(true)
+        .with_dropout(0.0)
+        .init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 3> =
+        BurnTensor::from_data(TensorData::new(input_data.clone(), [B, SEQ, D]), &device);
+
+    let enc_seq = TransformerEncoderLayer::<f32, SequentialBackend, H, NullMask>::new(D, D_FF, 0.0);
+    let enc_moirai = TransformerEncoderLayer::<f32, MoiraiBackend, H, NullMask>::new(D, D_FF, 0.0);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::ones(vec![B, SEQ, D]),
+        false,
+    );
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::ones(vec![B, SEQ, D]), false);
+
+    let mut group = c
+        .benchmark_group("Burn vs Coeus — Transformer encoder layer forward (8x64x256, d_ff=1024)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn_enc.forward(TransformerEncoderInput::new(black_box(x_burn.clone()))))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(enc_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(enc_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
     bench_layernorm_forward,
     bench_conv2d_forward,
-    bench_mha_forward
+    bench_mha_forward,
+    bench_transformer_encoder_forward
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,39 @@
 # Coeus Project Backlog & Historical Archives
 
+## Open Burn/PyTorch Parity Backlog
+
+- [ ] [minor] G-035: Implement ConvTranspose3d across Rust, backend-autograd,
+  PyO3, and PyTorch differential parity surfaces.
+- [ ] [minor] G-036: Fill 1D pooling, adaptive pooling, and unfold/fold family
+  gaps through canonical shared pooling/window kernels.
+- [ ] [minor] G-037: Extend activation parity for PReLU, CELU, hard/shrink,
+  softsign, threshold, GLU, and SwiGLU families.
+- [ ] [minor] G-038: Extend loss and distance parity for L1/SmoothL1,
+  BCEWithLogits, CTC, NLL variants, multilabel/multimargin, triplet, pairwise,
+  and cosine similarity surfaces.
+- [ ] [patch] G-039: Expose existing Rust KL divergence and margin ranking
+  losses through thin PyO3 wrappers with PyTorch differential tests.
+- [ ] [minor] G-040: Add vanilla and bidirectional recurrent module parity
+  without duplicating GRU/LSTM cell math.
+- [ ] [minor] G-041: Add regularization, sparse, and local-response modules:
+  AlphaDropout, FeatureAlphaDropout, EmbeddingBag, GaussianNoise, and
+  LocalResponseNorm.
+- [ ] [minor] G-042: Define and implement or explicitly scope Coeus parity for
+  quantized and lazy module families.
+- [ ] [patch] G-043: Expand the Coeus-vs-Burn/PyTorch benchmark/parity manifest
+  so every implemented NN family has an explicit measurement or differential
+  row.
+
+## Sprint MS-180: Burn/PyTorch parity gap audit [COMPLETE]
+
+- [x] [patch] Compared `coeus-nn` and `coeus-python` public NN/loss surfaces
+  against Burn and PyTorch NN module families, using current source exports as
+  the Coeus SSOT.
+- [x] [patch] Filed G-035..G-043 with acceptance criteria in
+  `docs/gap_audit.md` and mirrored them in the open parity backlog.
+- [x] Evidence tier: source-surface audit plus external API documentation audit;
+  no Rust or Python implementation changed.
+
 ## Sprint MS-179: Linear/loss gradient value assertions [COMPLETE]
 
 - [x] [patch] Replaced Linear, MSE, and CrossEntropy focused test

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,6 +24,19 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-181: Transformer encoder benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for
+  `TransformerEncoderLayer` in `coeus-nn/benches/nn_bench.rs` on
+  `[batch=8, seq=64, d_model=256]` with `d_ff=1024`, `heads=8`, and dropout
+  disabled, comparing Burn NdArray, Coeus `SequentialBackend`, and Coeus
+  `MoiraiBackend`.
+- [x] [patch] Registered the Transformer encoder row in the Criterion group so
+  it runs with the existing NN benchmark matrix.
+- [x] Evidence tier: empirical benchmark harness; `cargo bench -p coeus-nn
+  --bench nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench --
+  Transformer --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
 ## Sprint MS-180: Burn/PyTorch parity gap audit [COMPLETE]
 
 - [x] [patch] Compared `coeus-nn` and `coeus-python` public NN/loss surfaces

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-179 - Linear/loss gradient value assertions [COMPLETE]
+### Current Sprint: MS-180 - Burn/PyTorch parity gap audit [COMPLETE]
+**Objective**: Compare Coeus NN and Python public surfaces against Burn and
+PyTorch module families, then file remaining parity work as concrete backlog
+items.
+**Target version**: 0.5.4 (audit/docs-only [patch]).
+
+- [x] [patch] Audited `coeus-nn/src/lib.rs`, `coeus-nn/src/loss.rs`,
+  `coeus-python/src/lib.rs`, and `coeus-python/src/losses.rs` public surfaces
+  against Burn/PyTorch NN categories and the current parity harness scope.
+- [x] [patch] Added G-035..G-043 to `docs/gap_audit.md`, covering
+  ConvTranspose3d, pooling/adaptive/unfold/fold, activations, losses/distances,
+  Python loss wrapper lag, recurrent variants, regularization/sparse/local
+  response modules, quantized/lazy policy, and benchmark matrix coverage.
+- [x] [patch] Mirrored the open parity queue in `docs/backlog.md`.
+- [x] Evidence: source-surface audit plus Burn/PyTorch documentation audit; no
+  Rust or Python implementation changed.
+
+### Previous Sprint: MS-179 - Linear/loss gradient value assertions [COMPLETE]
 **Objective**: Remove existence-only Linear/MSE/CrossEntropy focused gradient
 checks and replace them with analytical value-semantic assertions.
 **Target version**: 0.5.4 (test-only [patch]).

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,23 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-180 - Burn/PyTorch parity gap audit [COMPLETE]
+### Current Sprint: MS-181 - Transformer encoder benchmark matrix expansion [COMPLETE]
+**Objective**: Extend the Burn-vs-Coeus NN benchmark matrix with a
+TransformerEncoder-layer forward row so one additional implemented NN family is
+measured across Burn NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_transformer_encoder_forward` in
+  `coeus-nn/benches/nn_bench.rs` using shape `[8,64,256]`, `d_ff=1024`,
+  `heads=8`, and dropout disabled.
+- [x] [patch] Benchmarks Burn NdArray vs Coeus `SequentialBackend` vs Coeus
+  `MoiraiBackend` for the same encoder-layer forward contract and registers the
+  row in `criterion_group!`.
+- [x] Evidence: `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo
+  bench -p coeus-nn --bench nn_bench -- Transformer --warm-up-time 1
+  --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-180 - Burn/PyTorch parity gap audit [COMPLETE]
 **Objective**: Compare Coeus NN and Python public surfaces against Burn and
 PyTorch module families, then file remaining parity work as concrete backlog
 items.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -2,6 +2,127 @@
 
 ## Known Gaps & Residual Risks
 
+### G-043: Burn/PyTorch NN benchmark matrix remains partial
+**Location**: `coeus-nn/benches/nn_bench.rs`,
+`coeus-python/tests/test_pytorch_parity.py`
+**Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
+module families.
+**Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows, not the
+full NN family set needed to claim Burn-level performance parity. PyTorch
+differential coverage similarly remains module-family selective.
+**Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
+rows for every newly implemented G-035..G-042 family with Coeus sequential,
+Moirai, WGPU/CUDA where applicable, Burn NdArray where comparable, and PyTorch
+Python differential tests at f64. Report median/confidence intervals for
+benchmarks and analytical tolerance derivations for numerical comparisons.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-042: Quantized and lazy module parity policy missing
+**Location**: `coeus-nn/src/lib.rs`, `coeus-python/src/lib.rs`
+**Compared against**: PyTorch quantized/lazy NN module families.
+**Gap**: Coeus has no documented implementation policy or public surface for
+PyTorch-style quantized and lazy NN modules. The current scalar/backend design
+may support the underlying representation through typed scalar/backend contracts,
+but the parity scope is not recorded.
+**Acceptance**: Define the Coeus parity policy for quantized and lazy modules in
+the NN design notes, then either implement typed Coeus module surfaces and PyO3
+wrappers with PyTorch differential tests, or record a precise non-goal with the
+replacement Coeus contract and explicit user-facing migration path.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-041: Regularization, sparse, and local-response modules incomplete
+**Location**: `coeus-nn/src/dropout.rs`, `coeus-nn/src/embedding.rs`,
+`coeus-nn/src/normalization/`, `coeus-python/src/nn/`
+**Compared against**: Burn `GaussianNoise`/`LocalResponseNorm` and PyTorch
+`AlphaDropout`, `FeatureAlphaDropout`, `EmbeddingBag`, and
+`LocalResponseNorm`.
+**Gap**: Coeus exposes `Dropout` and `Embedding`, but lacks AlphaDropout,
+FeatureAlphaDropout, EmbeddingBag, GaussianNoise, and LocalResponseNorm module
+surfaces and PyO3 wrappers.
+**Acceptance**: Implement each family once in Rust with value-semantic forward
+and backward tests; add PyO3 wrappers that only delegate to Rust; add PyTorch
+differential tests where PyTorch has a direct oracle and Burn parity tests where
+Burn exposes the module.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-040: Recurrent parity lacks vanilla and bidirectional sequence variants
+**Location**: `coeus-nn/src/rnn/`, `coeus-python/src/nn/rnn.rs`
+**Compared against**: Burn recurrent modules and PyTorch
+`RNN`/`RNNCell`/bidirectional recurrent configurations.
+**Gap**: Coeus exposes LSTM/GRU cells and sequence modules, but no vanilla
+RNN/RNNCell and no explicit bidirectional RNN/LSTM/GRU module surfaces.
+**Acceptance**: Add a generic recurrent core that shares step logic across
+vanilla, GRU, and LSTM families; implement bidirectional composition without
+duplicating cell math; expose thin PyO3 wrappers; verify forward/backward
+against PyTorch and Burn where direct APIs exist.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-039: Python loss wrappers lag existing Rust loss surface
+**Location**: `coeus-nn/src/loss.rs`, `coeus-python/src/losses.rs`,
+`coeus-python/src/lib.rs`
+**Compared against**: Coeus Rust surface and PyTorch functional losses.
+**Gap**: Rust `coeus-nn` exports `kl_divergence` and `margin_ranking_loss`, but
+`coeus-python` does not expose corresponding thin PyO3 functions. This violates
+the wrapper-only parity direction because existing Rust functionality is not
+reachable from Python.
+**Acceptance**: Add PyO3 wrappers for Rust KL divergence and margin ranking
+loss without Python-side math; add PyTorch differential tests for forward value
+and prediction/input gradients at f64.
+**Evidence tier**: source-surface audit.
+
+### G-038: Loss and distance surface remains below PyTorch coverage
+**Location**: `coeus-nn/src/loss.rs`, `coeus-python/src/losses.rs`
+**Compared against**: PyTorch loss and distance families.
+**Gap**: Coeus lacks direct L1, SmoothL1, BCEWithLogits, CTC, PoissonNLL,
+GaussianNLL, MultiMargin, MultiLabel margin/soft-margin, TripletMargin,
+PairwiseDistance, and CosineSimilarity public surfaces. Some behavior may be
+expressible by existing primitives, but there is no authoritative module/API
+parity, no wrapper, and no differential harness coverage.
+**Acceptance**: Implement missing losses/distances as Rust canonical functions
+or modules with typed reduction policy where applicable; expose PyO3 wrappers
+only as delegates; add analytical tests for formulae and PyTorch differential
+tests for forward/backward where PyTorch provides gradients.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-037: Activation surface remains incomplete versus Burn/PyTorch
+**Location**: `coeus-nn/src/activation.rs`, `coeus-python/src/activation.rs`
+**Compared against**: Burn activations and PyTorch activation modules/functions.
+**Gap**: Coeus covers common activations, but lacks Rust module/API parity for
+PReLU, CELU, Hardshrink, Hardsigmoid, Hardtanh, Hardswish, Softshrink,
+Softsign, Threshold, and a Rust `nn` GLU/SwiGLU family surface matching
+framework module expectations.
+**Acceptance**: Add one generic Rust activation implementation per operation
+family with analytical derivative tests; expose PyO3 wrappers as delegation
+only; add PyTorch/Burn differential tests at f64, with kink/subgradient points
+handled by documented analytical contracts.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-036: Pooling, adaptive pooling, and unfold/fold coverage incomplete
+**Location**: `coeus-nn/src/pool.rs`, `coeus-python/src/nn/pool.rs`
+**Compared against**: Burn `Unfold4d` and PyTorch pooling/unfold/fold module
+families.
+**Gap**: Coeus exposes 2D/3D average and max pooling plus selected global
+pooling wrappers, but lacks 1D pooling modules, adaptive pooling surfaces beyond
+global wrappers, and Unfold/Fold/Unfold4d parity surfaces.
+**Acceptance**: Add canonical N-dimensional pooling kernels with shape policy
+types or const-generic rank routing, then expose 1D/adaptive/unfold/fold module
+surfaces without duplicating math. Verify forward/backward against PyTorch and
+Burn where direct APIs exist.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
+### G-035: ConvTranspose3d parity missing
+**Location**: `coeus-nn/src/conv/`, `coeus-python/src/nn/conv.rs`
+**Compared against**: PyTorch `ConvTranspose3d` and the existing Coeus
+ConvTranspose1d/2d family.
+**Gap**: Coeus exports ConvTranspose1d and ConvTranspose2d, but has no
+ConvTranspose3d Rust module, backend route, autograd coverage, PyO3 wrapper, or
+PyTorch differential test.
+**Acceptance**: Implement ConvTranspose3d through the existing convolution
+family architecture, add value-semantic forward/backward Rust tests, add
+WGPU/CUDA backend-autograd parity where supported, and expose a thin PyO3
+wrapper with PyTorch f64 differential coverage.
+**Evidence tier**: source-surface audit plus external API documentation audit.
+
 ### ~~G-034: Linear/loss tests only checked gradient existence~~ **CLOSED**
 **Location**: `coeus-nn/tests/nn/linear_activation_loss.rs`
 **Closed by**: MS-179 — Replaced Linear, MSE, and CrossEntropy
@@ -307,6 +428,15 @@ Evidence tier: differential/empirical (PyTorch f64).
 
 | Risk | Evidence Tier | Status |
 |------|--------------|--------|
+| G-035 ConvTranspose3d parity missing | source-surface + external docs audit | **open** |
+| G-036 pooling/adaptive/unfold/fold coverage incomplete | source-surface + external docs audit | **open** |
+| G-037 activation surface incomplete versus Burn/PyTorch | source-surface + external docs audit | **open** |
+| G-038 loss and distance surface remains below PyTorch coverage | source-surface + external docs audit | **open** |
+| G-039 Python loss wrappers lag existing Rust loss surface | source-surface audit | **open** |
+| G-040 recurrent parity lacks vanilla and bidirectional variants | source-surface + external docs audit | **open** |
+| G-041 regularization/sparse/local-response modules incomplete | source-surface + external docs audit | **open** |
+| G-042 quantized and lazy module parity policy missing | source-surface + external docs audit | **open** |
+| G-043 Burn/PyTorch NN benchmark matrix remains partial | source-surface + external docs audit | **open** |
 | G-001 stateless PyTransformerEncoderLayer binding | structural | **closed MS-127** |
 | G-002 stateless PyTransformerEncoder binding | structural | **closed MS-128** |
 | G-003 stateless PyTransformerDecoderLayer binding | structural | **closed MS-129** |

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -7,9 +7,10 @@
 `coeus-python/tests/test_pytorch_parity.py`
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
-**Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows, not the
-full NN family set needed to claim Burn-level performance parity. PyTorch
-differential coverage similarly remains module-family selective.
+**Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
+(Linear, LayerNorm, Conv2d, MHA self-attention, Transformer encoder layer),
+not the full NN family set needed to claim Burn-level performance parity.
+PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,
 Moirai, WGPU/CUDA where applicable, Burn NdArray where comparable, and PyTorch


### PR DESCRIPTION
## Summary
- add a Transformer encoder layer forward row to coeus-nn/benches/nn_bench.rs for Burn NdArray vs Coeus Sequential/Moirai
- record MS-181 benchmark-matrix progress in docs/backlog.md and docs/checklist.md
- update docs/gap_audit.md G-043 partial-coverage detail and changelog entry

## Validation
- cargo check -p coeus-nn --all-targets
- cargo clippy -p coeus-nn --all-targets -- -D warnings
- cargo bench -p coeus-nn --bench nn_bench --no-run
- cargo bench -p coeus-nn --bench nn_bench -- Transformer --warm-up-time 1 --measurement-time 2 --sample-size 10

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR expands the Burn-versus-Coeus neural network benchmark matrix by adding a `TransformerEncoderLayer` forward pass benchmark comparing Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend`. It also documents the completion of milestone MS-181 (benchmark matrix expansion) and MS-180 (Burn/PyTorch parity gap audit) by updating the project backlog, checklist, and gap audit documentation with new parity items G-035 through G-043, which cover missing module families like ConvTranspose3d, pooling variants, activations, losses, and recurrent modules.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `docs/checklist.md` |
| 5 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new transformer encoder benchmark to compare forward performance across implementations.

* **Bug Fixes**
  * Noted a fix for stale build artifacts that could interfere with test runs.

* **Documentation**
  * Updated release notes, parity audit tracking, backlog items, and sprint checklists.
  * Added new parity gap entries and acceptance criteria for remaining coverage work.

* **Chores**
  * Bumped workspace metadata to version 0.5.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->