### PR TITLE
bench(nn): expand benchmark matrix with embedding row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@
   NdArray against Coeus `SequentialBackend` and `MoiraiBackend` in the same
   Criterion group. Short local run medians: Burn 233.47–239.80 ms, Coeus
   Sequential 19.73–20.54 ms, Coeus Moirai 17.18–17.54 ms. ([patch])
+- **NN benchmark matrix expansion (Embedding lookup)** — extended
+  `coeus-nn/benches/nn_bench.rs` with an embedding lookup forward row
+  (`[batch=2, seq=16]`, `vocab=4096`, `d_model=256`), comparing Burn NdArray
+  against Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion
+  group. Short local run medians: Burn 4.36–4.56 µs, Coeus Sequential
+  4.45–4.77 µs, Coeus Moirai 5.11–5.67 µs. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,7 +19,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    Conv2d, LayerNorm, Linear, Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
+    Conv2d, Embedding, LayerNorm, Linear, Module, MultiHeadAttention, NullMask,
+    TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -28,7 +29,7 @@ use burn::nn::attention::{MhaInput, MultiHeadAttentionConfig};
 use burn::nn::conv::Conv2dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
 use burn::nn::{LayerNormConfig, LinearConfig, PaddingConfig2d};
-use burn::tensor::{Tensor as BurnTensor, TensorData};
+use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
 type BurnB = NdArray<f32>;
 
 // Shared workload: batch of `BATCH` vectors of width `FEATURES`.
@@ -248,12 +249,63 @@ fn bench_transformer_encoder_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_embedding_forward(c: &mut Criterion) {
+    // Embedding lookup on [batch=2, seq=16] into [vocab=4096, d_model=256].
+    // Burn uses integer index tensors; Coeus routes through the same embedding
+    // forward path used by the module via `forward_indices`.
+    const EMB_BATCH: usize = 2;
+    const EMB_SEQ: usize = 16;
+    const EMB_VOCAB: usize = 4096;
+    const EMB_DIM: usize = 256;
+
+    let device = NdArrayDevice::default();
+    let indices: [[i32; EMB_SEQ]; EMB_BATCH] = [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+    ];
+    let idx_data: Vec<f32> = indices
+        .iter()
+        .flat_map(|row| row.iter())
+        .map(|&v| v as f32)
+        .collect();
+
+    let burn_weight: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(vec![1.0f32; EMB_VOCAB * EMB_DIM], [EMB_VOCAB, EMB_DIM]),
+        &device,
+    );
+    let burn_indices: BurnTensor<BurnB, 2, Int> = BurnTensor::from_ints(indices, &device);
+
+    let emb_seq = Embedding::<f32, SequentialBackend>::new(EMB_VOCAB, EMB_DIM);
+    let emb_moirai = Embedding::<f32, MoiraiBackend>::new(EMB_VOCAB, EMB_DIM);
+    let idx_seq = Tensor::<f32, SequentialBackend>::from_slice(vec![EMB_BATCH, EMB_SEQ], &idx_data);
+    let idx_moirai = Tensor::<f32, MoiraiBackend>::from_slice(vec![EMB_BATCH, EMB_SEQ], &idx_data);
+
+    let mut group =
+        c.benchmark_group("Burn vs Coeus — Embedding lookup forward (2x16, vocab=4096, d=256)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn::tensor::module::embedding(
+                black_box(burn_weight.clone()),
+                black_box(burn_indices.clone()),
+            ))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(emb_seq.forward_indices(black_box(&idx_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(emb_moirai.forward_indices(black_box(&idx_moirai))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
     bench_layernorm_forward,
     bench_conv2d_forward,
     bench_mha_forward,
-    bench_transformer_encoder_forward
+    bench_transformer_encoder_forward,
+    bench_embedding_forward
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,20 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-183: Embedding benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for embedding lookup
+  in `coeus-nn/benches/nn_bench.rs` on `[batch=2, seq=16]` over
+  `[vocab=4096, d_model=256]`, comparing Burn NdArray, Coeus
+  `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the embedding benchmark row in the Criterion benchmark
+  group so it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo bench -p coeus-nn
+  --bench nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench --
+  Embedding --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
 ## Sprint MS-182: Python KL/Margin wrapper parity [COMPLETE]
 
 - [x] [patch] Added thin PyO3 loss wrappers

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-182 - Python KL/Margin wrapper parity [COMPLETE]
+### Current Sprint: MS-183 - Embedding benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an embedding
+lookup row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_embedding_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[batch=2, seq=16]`,
+  `[vocab=4096, d_model=256]`.
+- [x] [patch] Benchmarks Burn NdArray embedding lookup vs Coeus
+  `Embedding::<_, SequentialBackend>` and `Embedding::<_, MoiraiBackend>` and
+  registers the row in `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- Embedding
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-182 - Python KL/Margin wrapper parity [COMPLETE]
 **Objective**: Close the wrapper-only parity gap for existing Rust loss APIs by
 exposing `kl_divergence` and `margin_ranking_loss` through thin PyO3 bindings
 and pinning forward/backward parity against PyTorch.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,8 +8,9 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, Conv2d, MHA self-attention, Transformer encoder layer),
-not the full NN family set needed to claim Burn-level performance parity.
+(Linear, LayerNorm, Conv2d, MHA self-attention, Transformer encoder layer,
+Embedding lookup), not the full NN family set needed to claim Burn-level
+performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
## Summary
- add `bench_embedding_forward` to `coeus-nn/benches/nn_bench.rs` for Burn NdArray vs Coeus Sequential/Moirai embedding lookup
- register the embedding row in the `criterion_group!` benchmark matrix
- update G-043 selected-row detail and sprint tracking docs/changelog for MS-183

## Validation
- cargo check -p coeus-nn --all-targets
- cargo clippy -p coeus-nn --all-targets -- -D warnings
- cargo bench -p coeus-nn --bench nn_bench --no-run
- cargo bench -p coeus-nn --bench nn_bench -- Embedding --warm-up-time 1 --measurement-time 2 --sample-size 10

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new benchmark row for embedding lookup operations to the existing NN benchmark suite. The benchmark compares Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend` implementations for embedding lookups on a `[batch=2, seq=16]` input with `vocab=4096` and `d_model=256`. The implementation adds the `bench_embedding_forward` function to `nn_bench.rs`, registers it in the Criterion benchmark group, and updates the corresponding documentation to reflect the expanded benchmark coverage and sprint tracking for milestone MS-183.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `docs/backlog.md` |
| 5 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new embedding benchmark comparing performance across multiple backend implementations.
  * Expanded the benchmark coverage with recorded median timing results.

* **Documentation**
  * Updated release notes and internal tracking docs to reflect the completed benchmark addition.
  * Refreshed the benchmark gap/audit notes for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->