### PR TITLE
MS-184: add BatchNorm2d eval benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@
   against Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion
   group. Short local run medians: Burn 4.36–4.56 µs, Coeus Sequential
   4.45–4.77 µs, Coeus Moirai 5.11–5.67 µs. ([patch])
+- **NN benchmark matrix expansion (BatchNorm2d eval forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a BatchNorm2d eval forward row
+  (`[2,64,32,32]`), comparing Burn NdArray against Coeus `SequentialBackend`
+  and `MoiraiBackend` in the same Criterion group. Short local run medians:
+  Burn 294.37–360.28 µs, Coeus Sequential 704.28–789.10 µs, Coeus Moirai
+  638.68–678.64 µs. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,7 +19,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    Conv2d, Embedding, LayerNorm, Linear, Module, MultiHeadAttention, NullMask,
+    BatchNorm2d, Conv2d, Embedding, LayerNorm, Linear, Module, MultiHeadAttention, NullMask,
     TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
@@ -28,7 +28,7 @@ use burn::backend::ndarray::{NdArray, NdArrayDevice};
 use burn::nn::attention::{MhaInput, MultiHeadAttentionConfig};
 use burn::nn::conv::Conv2dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
-use burn::nn::{LayerNormConfig, LinearConfig, PaddingConfig2d};
+use burn::nn::{BatchNormConfig, LayerNormConfig, LinearConfig, PaddingConfig2d};
 use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
 type BurnB = NdArray<f32>;
 
@@ -102,6 +102,52 @@ fn bench_layernorm_forward(c: &mut Criterion) {
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| black_box(ln_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_batchnorm2d_eval_forward(c: &mut Criterion) {
+    // BatchNorm2d eval-mode forward on [N=2, C=64, H=32, W=32].
+    // Burn NdArray BatchNorm runs in eval mode; Coeus is explicitly set to eval.
+    const BN_N: usize = 2;
+    const BN_C: usize = 64;
+    const BN_H: usize = 32;
+    const BN_W: usize = 32;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(BN_N * BN_C * BN_H * BN_W))
+        .map(|i| (i % 31) as f32 * 0.01 - 0.15)
+        .collect();
+
+    let burn_bn: burn::nn::BatchNorm<BurnB, 2> =
+        BatchNormConfig::new(BN_C).init::<BurnB, 2>(&device);
+    let x_burn: BurnTensor<BurnB, 4> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BN_N, BN_C, BN_H, BN_W]),
+        &device,
+    );
+
+    let mut bn_seq = BatchNorm2d::<f32, SequentialBackend>::new(BN_C, 1e-5, 0.1);
+    let mut bn_moirai = BatchNorm2d::<f32, MoiraiBackend>::new(BN_C, 1e-5, 0.1);
+    bn_seq.set_training(false);
+    bn_moirai.set_training(false);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BN_N, BN_C, BN_H, BN_W], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BN_N, BN_C, BN_H, BN_W], &input_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — BatchNorm2d eval forward (2x64x32x32)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_bn.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(bn_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(bn_moirai.forward(black_box(&x_moirai))))
     });
     group.finish();
 }
@@ -364,6 +410,7 @@ criterion_group!(
     benches,
     bench_linear_forward,
     bench_layernorm_forward,
+    bench_batchnorm2d_eval_forward,
     bench_conv2d_forward,
     bench_mha_forward,
     bench_transformer_encoder_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,21 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-184: BatchNorm2d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for BatchNorm2d eval
+  mode in `coeus-nn/benches/nn_bench.rs` on `[2,64,32,32]`, comparing Burn
+  NdArray, Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the BatchNorm2d row in the Criterion benchmark group
+  so it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- BatchNorm2d --warm-up-time 1 --measurement-time
+  2 --sample-size 10`.
+
 ## Sprint MS-183: Embedding benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for embedding lookup

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-183 - Embedding benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-184 - BatchNorm2d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a BatchNorm2d
+eval-forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_batchnorm2d_eval_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[2,64,32,32]`.
+- [x] [patch] Benchmarks Burn NdArray BatchNorm2d eval forward vs Coeus
+  `BatchNorm2d::<_, SequentialBackend>` and
+  `BatchNorm2d::<_, MoiraiBackend>` and registers the row in
+  `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- BatchNorm2d
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-183 - Embedding benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an embedding
 lookup row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,8 +9,8 @@
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, MHA self-attention, Transformer encoder layer,
-Embedding lookup), not the full NN family set needed to claim Burn-level
-performance parity.
+Embedding lookup, BatchNorm2d eval forward), not the full NN family set needed
+to claim Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add bench_batchnorm2d_eval_forward in coeus-nn/benches/nn_bench.rs, compare Burn NdArray vs Coeus Sequential/Moirai on [2,64,32,32], register in criterion_group, and update G-043 docs/changelog. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- BatchNorm2d --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new benchmark comparing BatchNorm2d eval-mode forward performance across Burn NdArray and Coeus backends (Sequential and Moirai) on a `[2, 64, 32, 32]` input shape. The benchmark is integrated into the existing NN benchmark suite and shows baseline performance metrics: Burn at 294-360 µs, Coeus Sequential at 704-789 µs, and Coeus Moirai at 638-678 µs. Documentation is updated across the gap audit, checklist, and backlog to reflect the expanded benchmark matrix coverage.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/gap_audit.md` |
| 2 | `docs/checklist.md` |
| 3 | `docs/backlog.md` |
| 4 | `coeus-nn/benches/nn_bench.rs` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->