### PR TITLE
MS-186: add Conv1d benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,12 @@
   and `MoiraiBackend` in the same Criterion group. Short local run medians:
   Burn 294.37–360.28 µs, Coeus Sequential 704.28–789.10 µs, Coeus Moirai
   638.68–678.64 µs. ([patch])
+- **NN benchmark matrix expansion (Conv1d forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a Conv1d forward row
+  (`[8,32,256]`, `k=3`), comparing Burn NdArray against Coeus
+  `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
+  local run medians: Burn 5.1786–6.1684 ms, Coeus Sequential 13.295–13.784 ms,
+  Coeus Moirai 10.192–10.648 ms. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,16 +19,17 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    BatchNorm2d, Conv2d, Embedding, LayerNorm, Linear, Module, MultiHeadAttention, NullMask,
-    TransformerEncoderLayer,
+    BatchNorm2d, Conv1d, Conv2d, Embedding, LayerNorm, Linear, Module, MultiHeadAttention,
+    NullMask, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
 use burn::backend::ndarray::{NdArray, NdArrayDevice};
 use burn::nn::attention::{MhaInput, MultiHeadAttentionConfig};
+use burn::nn::conv::Conv1dConfig;
 use burn::nn::conv::Conv2dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
-use burn::nn::{BatchNormConfig, LayerNormConfig, LinearConfig, PaddingConfig2d};
+use burn::nn::{BatchNormConfig, LayerNormConfig, LinearConfig, PaddingConfig1d, PaddingConfig2d};
 use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
 type BurnB = NdArray<f32>;
 
@@ -150,6 +151,43 @@ fn bench_batchnorm2d_eval_forward(c: &mut Criterion) {
         b.iter(|| black_box(bn_moirai.forward(black_box(&x_moirai))))
     });
     group.finish();
+}
+
+/// One Coeus-vs-Burn Conv1d forward comparison for `[n, ch, len]` input through
+/// `Conv1d(ch -> ch, k, stride 1, no pad, no bias)`.
+fn bench_conv1d_shape(c: &mut Criterion, label: &str, n: usize, ch: usize, len: usize, k: usize) {
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = vec![1.0f32; n * ch * len];
+
+    let burn_conv = Conv1dConfig::new(ch, ch, k)
+        .with_bias(false)
+        .with_padding(PaddingConfig1d::Valid)
+        .init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 3> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [n, ch, len]),
+        &device,
+    );
+
+    let conv_seq = Conv1d::<f32, SequentialBackend>::new(ch, ch, k, false);
+    let conv_moirai = Conv1d::<f32, MoiraiBackend>::new(ch, ch, k, false);
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::ones(vec![n, ch, len]), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::ones(vec![n, ch, len]), false);
+
+    let mut group = c.benchmark_group(label);
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_conv.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(conv_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(conv_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_conv1d_forward(c: &mut Criterion) {
+    bench_conv1d_shape(c, "Burn vs Coeus — Conv1d forward (8x32x256, k3)", 8, 32, 256, 3);
 }
 
 /// One Coeus-vs-Burn Conv2d forward comparison for a square `[n, ch, hw, hw]`
@@ -411,6 +449,7 @@ criterion_group!(
     bench_linear_forward,
     bench_layernorm_forward,
     bench_batchnorm2d_eval_forward,
+    bench_conv1d_forward,
     bench_conv2d_forward,
     bench_mha_forward,
     bench_transformer_encoder_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,21 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-186: Conv1d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for Conv1d in
+  `coeus-nn/benches/nn_bench.rs` on `[8,32,256]` with `k=3`, comparing Burn
+  NdArray, Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the Conv1d row in the Criterion benchmark group so it
+  executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- Conv1d --warm-up-time 1 --measurement-time 2
+  --sample-size 10`.
+
 ## Sprint MS-184: BatchNorm2d benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for BatchNorm2d eval

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-185 - ConvTranspose3d CPU/PyO3 parity [COMPLETE]
+### Current Sprint: MS-186 - Conv1d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a Conv1d
+forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_conv1d_forward` in `coeus-nn/benches/nn_bench.rs`
+  for `[8,32,256]`, `k=3`.
+- [x] [patch] Benchmarks Burn NdArray Conv1d forward vs Coeus
+  `Conv1d::<_, SequentialBackend>` and `Conv1d::<_, MoiraiBackend>` and
+  registers the row in `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- Conv1d
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-185 - ConvTranspose3d CPU/PyO3 parity [COMPLETE]
 **Objective**: Advance G-035 through the CPU/default backend, autograd,
 `coeus-nn`, and PyO3 parity surfaces while leaving WGPU/CUDA backend-specific
 coverage open.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,8 +9,8 @@
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, MHA self-attention, Transformer encoder layer,
-Embedding lookup, BatchNorm2d eval forward), not the full NN family set needed
-to claim Burn-level performance parity.
+Embedding lookup, BatchNorm2d eval forward, Conv1d forward), not the full NN
+family set needed to claim Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add a Burn-vs-Coeus Conv1d forward benchmark row in coeus-nn/benches/nn_bench.rs for [8,32,256] k=3, register it in the criterion group, and update G-043 tracking docs/changelog for MS-186. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- Conv1d --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new benchmark row for `Conv1d` forward pass to compare Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend`. The benchmark uses input shape `[8,32,256]` with kernel size 3, and the implementation includes registering the benchmark in the Criterion group and updating all tracking documentation (changelog, backlog, checklist, and gap audit) to reflect the completion of milestone MS-186.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `CHANGELOG.md` |
| 5 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Conv1d forward benchmarking to the neural-network benchmark suite, comparing multiple backends with the existing performance matrix.
  * Expanded the benchmark coverage shown in project tracking to include this new Conv1d row.

* **Documentation**
  * Updated the changelog, checklist, backlog, and gap audit notes to reflect the new benchmark coverage and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->