### PR TITLE
MS-189: add GroupNorm benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,12 @@
   `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
   local run medians: Burn 5.1786–6.1684 ms, Coeus Sequential 13.295–13.784 ms,
   Coeus Moirai 10.192–10.648 ms. ([patch])
+- **NN benchmark matrix expansion (GroupNorm forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a GroupNorm forward row
+  (`[8,32,16,16]`, `g=8`), comparing Burn NdArray against Coeus
+  `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
+  local run medians: Burn 166.88–183.00 µs, Coeus Sequential 442.42–482.49 µs,
+  Coeus Moirai 496.87–513.85 µs. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,8 +19,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    BatchNorm2d, Conv1d, Conv2d, Conv3d, Embedding, LayerNorm, Linear, Module, MultiHeadAttention,
-    NullMask, TransformerEncoderLayer,
+    BatchNorm2d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm, LayerNorm, Linear, Module,
+    MultiHeadAttention, NullMask, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -31,7 +31,7 @@ use burn::nn::conv::Conv2dConfig;
 use burn::nn::conv::Conv3dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
 use burn::nn::{
-    BatchNormConfig, LayerNormConfig, LinearConfig, PaddingConfig1d, PaddingConfig2d,
+    BatchNormConfig, GroupNormConfig, LayerNormConfig, LinearConfig, PaddingConfig1d, PaddingConfig2d,
     PaddingConfig3d,
 };
 use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
@@ -153,6 +153,49 @@ fn bench_batchnorm2d_eval_forward(c: &mut Criterion) {
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| black_box(bn_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_groupnorm_forward(c: &mut Criterion) {
+    // GroupNorm forward on [N=8, C=32, H=16, W=16] with 8 groups.
+    const GN_N: usize = 8;
+    const GN_C: usize = 32;
+    const GN_H: usize = 16;
+    const GN_W: usize = 16;
+    const GN_G: usize = 8;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(GN_N * GN_C * GN_H * GN_W))
+        .map(|i| (i % 37) as f32 * 0.02 - 0.36)
+        .collect();
+
+    let burn_gn = GroupNormConfig::new(GN_G, GN_C).init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 4> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [GN_N, GN_C, GN_H, GN_W]),
+        &device,
+    );
+
+    let gn_seq = GroupNorm::<f32, SequentialBackend, GN_G>::new(GN_C, 1e-5);
+    let gn_moirai = GroupNorm::<f32, MoiraiBackend, GN_G>::new(GN_C, 1e-5);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![GN_N, GN_C, GN_H, GN_W], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![GN_N, GN_C, GN_H, GN_W], &input_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — GroupNorm forward (8x32x16x16, g8)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_gn.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(gn_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(gn_moirai.forward(black_box(&x_moirai))))
     });
     group.finish();
 }
@@ -511,6 +554,7 @@ criterion_group!(
     bench_linear_forward,
     bench_layernorm_forward,
     bench_batchnorm2d_eval_forward,
+    bench_groupnorm_forward,
     bench_conv1d_forward,
     bench_conv2d_forward,
     bench_conv3d_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,21 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-189: GroupNorm benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for GroupNorm in
+  `coeus-nn/benches/nn_bench.rs` on `[8,32,16,16]` with `g=8`, comparing Burn
+  NdArray, Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the GroupNorm row in the Criterion benchmark group so
+  it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- GroupNorm --warm-up-time 1 --measurement-time 2
+  --sample-size 10`.
+
 ## Sprint MS-188: Embedding and GroupNorm JAX parity [COMPLETE]
 
 - [x] [patch] Added `test_embedding_matches_jax` for `pycoeus.Embedding`

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-188 - Embedding and GroupNorm JAX parity [COMPLETE]
+### Current Sprint: MS-189 - GroupNorm benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a GroupNorm
+forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_groupnorm_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[8,32,16,16]` with `g=8`.
+- [x] [patch] Benchmarks Burn NdArray GroupNorm forward vs Coeus
+  `GroupNorm::<_, SequentialBackend, 8>` and
+  `GroupNorm::<_, MoiraiBackend, 8>` and registers the row in
+  `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- GroupNorm
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-188 - Embedding and GroupNorm JAX parity [COMPLETE]
 **Objective**: Extend the Python JAX differential suite for existing Rust-owned
 module surfaces without adding Python-side domain logic.
 **Target version**: 0.5.4 (python parity/test/docs [patch]).

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,8 +9,9 @@
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
-layer, Embedding lookup, BatchNorm2d eval forward, Conv1d forward), not the
-full NN family set needed to claim Burn-level performance parity.
+layer, Embedding lookup, BatchNorm2d eval forward, Conv1d forward, GroupNorm
+forward), not the full NN family set needed to claim Burn-level performance
+parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add a Burn-vs-Coeus GroupNorm forward benchmark row in coeus-nn/benches/nn_bench.rs for [8,32,16,16] with g=8, register it in the criterion group, and update G-043 tracking docs/changelog for MS-189. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- GroupNorm --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a GroupNorm forward pass benchmark to the existing NN benchmark suite, comparing performance between Burn's NdArray backend and Coeus's `SequentialBackend` and `MoiraiBackend` implementations. The benchmark uses an input shape of `[8,32,16,16]` with 8 groups. The change also updates the project's tracking documentation (gap audit, backlog, and checklist) to reflect the completion of sprint MS-189 and includes CHANGELOG entries with the local run medians showing Burn at 166.88–183.00 µs, Coeus Sequential at 442.42–482.49 µs, and Coeus Moirai at 496.87–513.85 µs.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/backlog.md` |
| 2 | `docs/checklist.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `coeus-nn/benches/nn_bench.rs` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GroupNorm forward benchmark to the performance matrix.
  * Expanded benchmark coverage to compare multiple backend implementations on a fixed tensor shape.

* **Documentation**
  * Updated release notes and sprint tracking to reflect the completed benchmark expansion.
  * Refreshed the gap audit to show broader benchmark coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->