### PR TITLE
MS-190: add BatchNorm1d benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,12 @@
   `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
   local run medians: Burn 166.88–183.00 µs, Coeus Sequential 442.42–482.49 µs,
   Coeus Moirai 496.87–513.85 µs. ([patch])
+- **NN benchmark matrix expansion (BatchNorm1d eval forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a BatchNorm1d eval forward row
+  (`[16,128,256]`), comparing Burn NdArray against Coeus
+  `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
+  local run medians: Burn 1.4071–1.4791 ms, Coeus Sequential 4.2591–4.3470 ms,
+  Coeus Moirai 4.1116–4.2598 ms. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,8 +19,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    BatchNorm2d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm, LayerNorm, Linear, Module,
-    MultiHeadAttention, NullMask, TransformerEncoderLayer,
+    BatchNorm1d, BatchNorm2d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm, LayerNorm, Linear,
+    Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -145,6 +145,51 @@ fn bench_batchnorm2d_eval_forward(c: &mut Criterion) {
     );
 
     let mut group = c.benchmark_group("Burn vs Coeus — BatchNorm2d eval forward (2x64x32x32)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_bn.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(bn_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(bn_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_batchnorm1d_eval_forward(c: &mut Criterion) {
+    // BatchNorm1d eval-mode forward on [N=16, C=128, L=256].
+    // Burn NdArray BatchNorm runs in eval mode; Coeus is explicitly set to eval.
+    const BN1_N: usize = 16;
+    const BN1_C: usize = 128;
+    const BN1_L: usize = 256;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(BN1_N * BN1_C * BN1_L))
+        .map(|i| (i % 29) as f32 * 0.01 - 0.14)
+        .collect();
+
+    let burn_bn: burn::nn::BatchNorm<BurnB, 1> =
+        BatchNormConfig::new(BN1_C).init::<BurnB, 1>(&device);
+    let x_burn: BurnTensor<BurnB, 3> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BN1_N, BN1_C, BN1_L]),
+        &device,
+    );
+
+    let mut bn_seq = BatchNorm1d::<f32, SequentialBackend>::new(BN1_C, 1e-5, 0.1);
+    let mut bn_moirai = BatchNorm1d::<f32, MoiraiBackend>::new(BN1_C, 1e-5, 0.1);
+    bn_seq.set_training(false);
+    bn_moirai.set_training(false);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BN1_N, BN1_C, BN1_L], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BN1_N, BN1_C, BN1_L], &input_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — BatchNorm1d eval forward (16x128x256)");
     group.bench_function("Burn NdArray", |b| {
         b.iter(|| black_box(burn_bn.forward(black_box(x_burn.clone()))))
     });
@@ -553,6 +598,7 @@ criterion_group!(
     benches,
     bench_linear_forward,
     bench_layernorm_forward,
+    bench_batchnorm1d_eval_forward,
     bench_batchnorm2d_eval_forward,
     bench_groupnorm_forward,
     bench_conv1d_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,21 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-190: BatchNorm1d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for BatchNorm1d eval
+  mode in `coeus-nn/benches/nn_bench.rs` on `[16,128,256]`, comparing Burn
+  NdArray, Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the BatchNorm1d row in the Criterion benchmark group
+  so it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- BatchNorm1d --warm-up-time 1 --measurement-time
+  2 --sample-size 10`.
+
 ## Sprint MS-189: GroupNorm benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for GroupNorm in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-189 - GroupNorm benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-190 - BatchNorm1d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a BatchNorm1d
+eval-forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_batchnorm1d_eval_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[16,128,256]`.
+- [x] [patch] Benchmarks Burn NdArray BatchNorm1d eval forward vs Coeus
+  `BatchNorm1d::<_, SequentialBackend>` and
+  `BatchNorm1d::<_, MoiraiBackend>` and registers the row in
+  `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- BatchNorm1d
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-189 - GroupNorm benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a GroupNorm
 forward row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,9 +9,9 @@
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
-layer, Embedding lookup, BatchNorm2d eval forward, Conv1d forward, GroupNorm
-forward), not the full NN family set needed to claim Burn-level performance
-parity.
+layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
+Conv1d forward, GroupNorm forward), not the full NN family set needed to claim
+Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add a Burn-vs-Coeus BatchNorm1d eval forward benchmark row in coeus-nn/benches/nn_bench.rs for [16,128,256], register it in the criterion group, and update G-043 tracking docs/changelog for MS-190. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- BatchNorm1d --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a `BatchNorm1d` benchmark row to the neural network benchmark suite, comparing Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend` implementations. The benchmark tests eval-mode forward passes with input shape `[16,128,256]`. Documentation updates include tracking this work in the changelog, gap audit, checklist, and backlog files.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->