### PR TITLE
MS-191: add BatchNorm3d benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,12 @@
   `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
   local run medians: Burn 1.4071–1.4791 ms, Coeus Sequential 4.2591–4.3470 ms,
   Coeus Moirai 4.1116–4.2598 ms. ([patch])
+- **NN benchmark matrix expansion (BatchNorm3d eval forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a BatchNorm3d eval forward row
+  (`[2,32,16,16,16]`), comparing Burn NdArray against Coeus
+  `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
+  local run medians: Burn 981.71–994.77 µs, Coeus Sequential 2.2688–2.3151 ms,
+  Coeus Moirai 2.2786–2.3658 ms. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,8 +19,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    BatchNorm1d, BatchNorm2d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm, LayerNorm, Linear,
-    Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
+    BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
+    LayerNorm, Linear, Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -190,6 +190,59 @@ fn bench_batchnorm1d_eval_forward(c: &mut Criterion) {
     );
 
     let mut group = c.benchmark_group("Burn vs Coeus — BatchNorm1d eval forward (16x128x256)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_bn.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(bn_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(bn_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_batchnorm3d_eval_forward(c: &mut Criterion) {
+    // BatchNorm3d eval-mode forward on [N=2, C=32, D=16, H=16, W=16].
+    // Burn NdArray BatchNorm runs in eval mode; Coeus is explicitly set to eval.
+    const BN3_N: usize = 2;
+    const BN3_C: usize = 32;
+    const BN3_D: usize = 16;
+    const BN3_H: usize = 16;
+    const BN3_W: usize = 16;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(BN3_N * BN3_C * BN3_D * BN3_H * BN3_W))
+        .map(|i| (i % 23) as f32 * 0.01 - 0.11)
+        .collect();
+
+    let burn_bn: burn::nn::BatchNorm<BurnB, 3> =
+        BatchNormConfig::new(BN3_C).init::<BurnB, 3>(&device);
+    let x_burn: BurnTensor<BurnB, 5> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BN3_N, BN3_C, BN3_D, BN3_H, BN3_W]),
+        &device,
+    );
+
+    let mut bn_seq = BatchNorm3d::<f32, SequentialBackend>::new(BN3_C, 1e-5, 0.1);
+    let mut bn_moirai = BatchNorm3d::<f32, MoiraiBackend>::new(BN3_C, 1e-5, 0.1);
+    bn_seq.set_training(false);
+    bn_moirai.set_training(false);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(
+            vec![BN3_N, BN3_C, BN3_D, BN3_H, BN3_W],
+            &input_data,
+        ),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(
+            vec![BN3_N, BN3_C, BN3_D, BN3_H, BN3_W],
+            &input_data,
+        ),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — BatchNorm3d eval forward (2x32x16x16x16)");
     group.bench_function("Burn NdArray", |b| {
         b.iter(|| black_box(burn_bn.forward(black_box(x_burn.clone()))))
     });
@@ -600,6 +653,7 @@ criterion_group!(
     bench_layernorm_forward,
     bench_batchnorm1d_eval_forward,
     bench_batchnorm2d_eval_forward,
+    bench_batchnorm3d_eval_forward,
     bench_groupnorm_forward,
     bench_conv1d_forward,
     bench_conv2d_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,21 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-191: BatchNorm3d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for BatchNorm3d eval
+  mode in `coeus-nn/benches/nn_bench.rs` on `[2,32,16,16,16]`, comparing Burn
+  NdArray, Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the BatchNorm3d row in the Criterion benchmark group
+  so it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- BatchNorm3d --warm-up-time 1 --measurement-time
+  2 --sample-size 10`.
+
 ## Sprint MS-190: BatchNorm1d benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for BatchNorm1d eval

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-190 - BatchNorm1d benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-191 - BatchNorm3d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a BatchNorm3d
+eval-forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_batchnorm3d_eval_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[2,32,16,16,16]`.
+- [x] [patch] Benchmarks Burn NdArray BatchNorm3d eval forward vs Coeus
+  `BatchNorm3d::<_, SequentialBackend>` and
+  `BatchNorm3d::<_, MoiraiBackend>` and registers the row in
+  `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- BatchNorm3d
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-190 - BatchNorm1d benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a BatchNorm1d
 eval-forward row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -10,8 +10,8 @@ module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
 layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
-Conv1d forward, GroupNorm forward), not the full NN family set needed to claim
-Burn-level performance parity.
+BatchNorm3d eval forward, Conv1d forward, GroupNorm forward), not the full NN
+family set needed to claim Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add a Burn-vs-Coeus BatchNorm3d eval forward benchmark row in coeus-nn/benches/nn_bench.rs for [2,32,16,16,16], register it in the criterion group, and update G-043 tracking docs/changelog for MS-191. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- BatchNorm3d --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a **BatchNorm3d** evaluation forward benchmark to the existing neural network benchmark suite, comparing Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend` on a `[2,32,16,16,16]` input shape. The implementation follows the established pattern from previous benchmark additions (BatchNorm1d, BatchNorm2d) and updates the relevant tracking documentation and changelog with performance results.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `docs/backlog.md` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
| 4 | `docs/gap_audit.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->