### PR TITLE
MS-192: add MaxPool2d benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,12 @@
   `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
   local run medians: Burn 981.71–994.77 µs, Coeus Sequential 2.2688–2.3151 ms,
   Coeus Moirai 2.2786–2.3658 ms. ([patch])
+- **NN benchmark matrix expansion (MaxPool2d forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a MaxPool2d forward row
+  (`[8,16,32,32]`, `k=2`, `s=2`), comparing Burn NdArray against Coeus
+  `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
+  local run medians: Burn 241.66–265.41 µs, Coeus Sequential 239.66–280.71 µs,
+  Coeus Moirai 116.22–133.93 µs. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -20,7 +20,7 @@ use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
     BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
-    LayerNorm, Linear, Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
+    LayerNorm, Linear, MaxPool2d, Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -294,6 +294,57 @@ fn bench_groupnorm_forward(c: &mut Criterion) {
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| black_box(gn_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_maxpool2d_forward(c: &mut Criterion) {
+    // MaxPool2d forward on [N=8, C=16, H=32, W=32] with k=2, s=2.
+    const MP_N: usize = 8;
+    const MP_C: usize = 16;
+    const MP_H: usize = 32;
+    const MP_W: usize = 32;
+    const MP_K: usize = 2;
+    const MP_S: usize = 2;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(MP_N * MP_C * MP_H * MP_W))
+        .map(|i| (i as f32 * 0.0025).sin())
+        .collect();
+
+    let x_burn: BurnTensor<BurnB, 4> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [MP_N, MP_C, MP_H, MP_W]),
+        &device,
+    );
+
+    let pool_seq = MaxPool2d::<f32, SequentialBackend>::with_params(MP_K, MP_S, 0, 1);
+    let pool_moirai = MaxPool2d::<f32, MoiraiBackend>::with_params(MP_K, MP_S, 0, 1);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![MP_N, MP_C, MP_H, MP_W], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![MP_N, MP_C, MP_H, MP_W], &input_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — MaxPool2d forward (8x16x32x32, k2 s2)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn::tensor::module::max_pool2d(
+                black_box(x_burn.clone()),
+                [MP_K, MP_K],
+                [MP_S, MP_S],
+                [0, 0],
+                [1, 1],
+            ))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(pool_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(pool_moirai.forward(black_box(&x_moirai))))
     });
     group.finish();
 }
@@ -655,6 +706,7 @@ criterion_group!(
     bench_batchnorm2d_eval_forward,
     bench_batchnorm3d_eval_forward,
     bench_groupnorm_forward,
+    bench_maxpool2d_forward,
     bench_conv1d_forward,
     bench_conv2d_forward,
     bench_conv3d_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,22 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-192: MaxPool2d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for MaxPool2d in
+  `coeus-nn/benches/nn_bench.rs` on `[8,16,32,32]` with `k=2`, `s=2`,
+  comparing Burn NdArray, Coeus `SequentialBackend`, and Coeus
+  `MoiraiBackend`.
+- [x] [patch] Registered the MaxPool2d row in the Criterion benchmark group so
+  it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- MaxPool2d --warm-up-time 1 --measurement-time 2
+  --sample-size 10`.
+
 ## Sprint MS-191: BatchNorm3d benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for BatchNorm3d eval

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-191 - BatchNorm3d benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-192 - MaxPool2d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a MaxPool2d
+forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_maxpool2d_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[8,16,32,32]` with `k=2`, `s=2`.
+- [x] [patch] Benchmarks Burn NdArray MaxPool2d forward vs Coeus
+  `MaxPool2d::<_, SequentialBackend>` and
+  `MaxPool2d::<_, MoiraiBackend>` and registers the row in
+  `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- MaxPool2d
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-191 - BatchNorm3d benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a BatchNorm3d
 eval-forward row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -10,8 +10,9 @@ module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
 layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
-BatchNorm3d eval forward, Conv1d forward, GroupNorm forward), not the full NN
-family set needed to claim Burn-level performance parity.
+BatchNorm3d eval forward, Conv1d forward, GroupNorm forward, MaxPool2d
+forward), not the full NN family set needed to claim Burn-level performance
+parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add a Burn-vs-Coeus MaxPool2d forward benchmark row in coeus-nn/benches/nn_bench.rs for [8,16,32,32] with k=2,s=2, register it in the criterion group, and update G-043 tracking docs/changelog for MS-192. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- MaxPool2d --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a benchmark comparison row for `MaxPool2d` forward operations with input shape `[8,16,32,32]` (kernel size 2, stride 2) across Burn NdArray, Coeus Sequential, and Coeus Moirai backends. The benchmark is integrated into the existing `nn_bench.rs` criterion group and tracking documentation is updated across changelog, backlog, checklist, and gap audit files to reflect completion of sprint MS-192.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->