### PR TITLE
MS-193: add AvgPool2d benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,12 @@
   `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
   local run medians: Burn 241.66–265.41 µs, Coeus Sequential 239.66–280.71 µs,
   Coeus Moirai 116.22–133.93 µs. ([patch])
+- **NN benchmark matrix expansion (AvgPool2d forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with an AvgPool2d forward row
+  (`[8,16,32,32]`, `k=2`, `s=2`), comparing Burn NdArray against Coeus
+  `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
+  local run medians: Burn 279.92–336.67 µs, Coeus Sequential 293.67–299.49 µs,
+  Coeus Moirai 235.34–303.26 µs. ([patch])
 - **KL divergence / MarginRanking loss coverage** — added tracked
   `coeus_autograd` and `coeus_nn` entry points for KL divergence and margin
   ranking losses, plus analytical forward/backward tests and sequential/Moirai

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,8 +19,9 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
-    LayerNorm, Linear, MaxPool2d, Module, MultiHeadAttention, NullMask, TransformerEncoderLayer,
+    AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding,
+    GroupNorm, LayerNorm, Linear, MaxPool2d, Module, MultiHeadAttention, NullMask,
+    TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -337,6 +338,57 @@ fn bench_maxpool2d_forward(c: &mut Criterion) {
                 [MP_S, MP_S],
                 [0, 0],
                 [1, 1],
+            ))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(pool_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(pool_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_avgpool2d_forward(c: &mut Criterion) {
+    // AvgPool2d forward on [N=8, C=16, H=32, W=32] with k=2, s=2.
+    const AP_N: usize = 8;
+    const AP_C: usize = 16;
+    const AP_H: usize = 32;
+    const AP_W: usize = 32;
+    const AP_K: usize = 2;
+    const AP_S: usize = 2;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(AP_N * AP_C * AP_H * AP_W))
+        .map(|i| (i as f32 * 0.0018).cos())
+        .collect();
+
+    let x_burn: BurnTensor<BurnB, 4> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [AP_N, AP_C, AP_H, AP_W]),
+        &device,
+    );
+
+    let pool_seq = AvgPool2d::<f32, SequentialBackend>::with_params(AP_K, AP_S, 0, 1);
+    let pool_moirai = AvgPool2d::<f32, MoiraiBackend>::with_params(AP_K, AP_S, 0, 1);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![AP_N, AP_C, AP_H, AP_W], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![AP_N, AP_C, AP_H, AP_W], &input_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — AvgPool2d forward (8x16x32x32, k2 s2)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn::tensor::module::avg_pool2d(
+                black_box(x_burn.clone()),
+                [AP_K, AP_K],
+                [AP_S, AP_S],
+                [0, 0],
+                false,
             ))
         })
     });
@@ -707,6 +759,7 @@ criterion_group!(
     bench_batchnorm3d_eval_forward,
     bench_groupnorm_forward,
     bench_maxpool2d_forward,
+    bench_avgpool2d_forward,
     bench_conv1d_forward,
     bench_conv2d_forward,
     bench_conv3d_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,22 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-193: AvgPool2d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for AvgPool2d in
+  `coeus-nn/benches/nn_bench.rs` on `[8,16,32,32]` with `k=2`, `s=2`,
+  comparing Burn NdArray, Coeus `SequentialBackend`, and Coeus
+  `MoiraiBackend`.
+- [x] [patch] Registered the AvgPool2d row in the Criterion benchmark group so
+  it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- AvgPool2d --warm-up-time 1 --measurement-time 2
+  --sample-size 10`.
+
 ## Sprint MS-192: MaxPool2d benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for MaxPool2d in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,25 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-192 - MaxPool2d benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-193 - AvgPool2d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an AvgPool2d
+forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_avgpool2d_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[8,16,32,32]` with `k=2`, `s=2`.
+- [x] [patch] Benchmarks Burn NdArray AvgPool2d forward vs Coeus
+  `AvgPool2d::<_, SequentialBackend>` and
+  `AvgPool2d::<_, MoiraiBackend>` and registers the row in
+  `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- AvgPool2d
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-192 - MaxPool2d benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a MaxPool2d
 forward row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -10,9 +10,9 @@ module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
 layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
-BatchNorm3d eval forward, Conv1d forward, GroupNorm forward, MaxPool2d
-forward), not the full NN family set needed to claim Burn-level performance
-parity.
+BatchNorm3d eval forward, Conv1d forward, GroupNorm forward, MaxPool2d forward,
+AvgPool2d forward), not the full NN family set needed to claim Burn-level
+performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Summary: add a Burn-vs-Coeus AvgPool2d forward benchmark row in coeus-nn/benches/nn_bench.rs for [8,16,32,32] with k=2,s=2, register it in the criterion group, and update G-043 tracking docs/changelog for MS-193. Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- AvgPool2d --warm-up-time 1 --measurement-time 2 --sample-size 10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new benchmark row for `AvgPool2d` forward operations to the neural network benchmark suite. The benchmark compares Burn's NdArray backend against Coeus' `SequentialBackend` and `MoiraiBackend` using an 8×16×32×32 input tensor with kernel size 2 and stride 2. The implementation includes the benchmark function in `nn_bench.rs`, registration with the Criterion benchmark group, and updates to tracking documentation (changelog, gap audit, backlog, and checklist) to reflect the completion of sprint MS-193.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `docs/backlog.md` |
| 5 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->