### PR TITLE
feat(nn): Add L1 (mean absolute error) loss for G-038

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -89,6 +89,7 @@ pub use ops::{
     huber_loss,
     index_select,
     kl_divergence,
+    l1_loss,
     layernorm,
     leaky_relu,
     log,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -33,7 +33,7 @@ pub use linalg::{matmul, sparse_matmul, sparse_matmul_coo, transpose_2d};
 pub use nn::{
     avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, binary_cross_entropy, conv1d,
     conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_transpose3d, cosine_embedding_loss,
-    cross_entropy_loss, dropout, huber_loss, kl_divergence, layernorm, log_softmax,
+    cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
     margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, rmsnorm, sdp_attention, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };

--- a/coeus-autograd/src/ops/nn/loss/l1.rs
+++ b/coeus-autograd/src/ops/nn/loss/l1.rs
@@ -1,0 +1,168 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for L1 (mean absolute error) loss.
+pub struct L1LossNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Element-wise differences `pred[i] - target[i]`, stored for backward.
+    pub diffs: Vec<T>,
+    /// Number of elements in the mean reduction.
+    pub n: usize,
+    /// Original tensor shape for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for L1LossNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "l1_loss"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let mut host_grad = [T::zero()];
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+        let g_out = host_grad[0];
+        let n_t = T::from_f64(self.n as f64);
+        let scale = g_out / n_t;
+        // d/d_pred mean|pred - target| = sign(pred - target) / n.
+        // Subgradient at the kink is 0, matching torch.sign(0) == 0.
+        let neg_one = T::zero() - T::one();
+        let mut d_pred = vec![T::zero(); self.n];
+        for (i, grad) in d_pred.iter_mut().enumerate() {
+            let diff = self.diffs[i];
+            let sign = if diff > T::zero() {
+                T::one()
+            } else if diff < T::zero() {
+                neg_one
+            } else {
+                T::zero()
+            };
+            *grad = sign * scale;
+        }
+
+        if let Some(Some(ref g)) = input_grads.first() {
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_pred, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut d_target = d_pred;
+            for grad in &mut d_target {
+                *grad = T::zero() - *grad;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked L1 (mean absolute error) loss: `mean_i |pred[i] - target[i]|`.
+/// pred and target must have identical shape. The mean reduction covers every
+/// element, not only the leading dimension.
+pub fn l1_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    pred: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        pred.tensor.shape(),
+        target.tensor.shape(),
+        "l1_loss requires pred and target to have identical shapes"
+    );
+    let n = pred.tensor.numel();
+    assert!(n > 0, "l1_loss requires at least one element");
+    let shape = pred.tensor.shape_cloned();
+
+    let p_cont;
+    let p_raw = if pred.tensor.is_contiguous() && pred.tensor.layout().offset() == 0 {
+        &pred.tensor
+    } else {
+        p_cont = pred.tensor.to_contiguous_on(&backend);
+        &p_cont
+    };
+    let t_cont;
+    let t_raw = if target.tensor.is_contiguous() && target.tensor.layout().offset() == 0 {
+        &target.tensor
+    } else {
+        t_cont = target.tensor.to_contiguous_on(&backend);
+        &t_cont
+    };
+
+    let p_host: std::borrow::Cow<[T]> = if let Some(s) = p_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(p_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let t_host: std::borrow::Cow<[T]> = if let Some(s) = t_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(t_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let mut diffs = vec![T::zero(); n];
+    let mut loss_val = T::zero();
+    for i in 0..n {
+        let diff = p_host[i] - t_host[i];
+        diffs[i] = diff;
+        let abs_diff = if diff < T::zero() {
+            T::zero() - diff
+        } else {
+            diff
+        };
+        loss_val = loss_val + abs_diff;
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad =
+        crate::grad_mode::should_track_var(pred) || crate::grad_mode::should_track_var(target);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = L1LossNode {
+            output_grad,
+            inputs: vec![pred.clone(), target.clone()],
+            diffs,
+            n,
+            shape,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -8,6 +8,8 @@ pub mod cross_entropy;
 pub mod huber;
 /// KL divergence loss.
 pub mod kl_div;
+/// L1 (mean absolute error) loss.
+pub mod l1;
 /// Margin ranking loss.
 pub mod margin_ranking;
 /// Negative log-likelihood loss.
@@ -18,5 +20,6 @@ pub use cosine::{cosine_embedding_loss, CosineEmbeddingLossNode};
 pub use cross_entropy::{cross_entropy_loss, CrossEntropyLossNode};
 pub use huber::{huber_loss, HuberLossNode};
 pub use kl_div::{kl_divergence, KlDivLossNode};
+pub use l1::{l1_loss, L1LossNode};
 pub use margin_ranking::{margin_ranking_loss, MarginRankingLossNode};
 pub use nll::{nll_loss, NllLossNode};

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -23,7 +23,7 @@ pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
     binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, kl_divergence,
-    margin_ranking_loss, nll_loss,
+    l1_loss, margin_ranking_loss, nll_loss,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -85,7 +85,7 @@ pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
     binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, kl_divergence,
-    margin_ranking_loss, mse_loss, nll_loss,
+    l1_loss, margin_ranking_loss, mse_loss, nll_loss,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -131,6 +131,16 @@ pub fn huber_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::huber_loss(pred, target, delta)
 }
 
+/// L1 (mean absolute error) loss.
+/// pred: `[N]`, target: `[N]`. Computes `mean(|pred - target|)`.
+#[inline]
+pub fn l1_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    pred: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    coeus_autograd::l1_loss(pred, target)
+}
+
 /// KL divergence loss.
 ///
 /// `input` is log-probabilities and `target` is probabilities. Computes

--- a/coeus-nn/tests/loss_parity.rs
+++ b/coeus-nn/tests/loss_parity.rs
@@ -1,5 +1,5 @@
 //! Differential parity for loss functions:
-//!   `mse_loss`, `nll_loss`, `huber_loss`,
+//!   `mse_loss`, `nll_loss`, `huber_loss`, `l1_loss`,
 //!   `binary_cross_entropy`, `kl_divergence`, `margin_ranking_loss`,
 //!   `cosine_embedding_loss`.
 //!
@@ -22,8 +22,8 @@ use coeus_core::{
     CpuAddressableStorage, CpuAddressableStorageMut, MoiraiBackend, SequentialBackend,
 };
 use coeus_nn::{
-    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, margin_ranking_loss,
-    mse_loss, nll_loss,
+    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, l1_loss,
+    margin_ranking_loss, mse_loss, nll_loss,
 };
 use coeus_ops::BackendOps;
 use coeus_tensor::Tensor;
@@ -70,6 +70,22 @@ where
     let hzt = v(&[2], &[1.0, 2.0], backend);
     let hz = huber_loss(&hzp, &hzt, 1.0_f64);
     assert_eq!(hz.tensor.as_slice(), &[0.0_f64], "huber_loss(x,x)=0");
+
+    // L1: pred-target=[3,-1,0.5,0] over shape [2,2] → mean = 4.5/4 = 1.125.
+    let l1p = v(&[2, 2], &[3.0, -1.0, 0.5, 4.0], backend);
+    let l1t = v(&[2, 2], &[0.0, 0.0, 0.0, 4.0], backend);
+    let l1 = l1_loss(&l1p, &l1t);
+    assert_eq!(
+        l1.tensor.as_slice(),
+        &[1.125_f64],
+        "l1_loss mean abs error over all elements"
+    );
+
+    // L1 zero error → 0 exactly.
+    let l1zp = v(&[2], &[1.0, 2.0], backend);
+    let l1zt = v(&[2], &[1.0, 2.0], backend);
+    let l1z = l1_loss(&l1zp, &l1zt);
+    assert_eq!(l1z.tensor.as_slice(), &[0.0_f64], "l1_loss(x,x)=0");
 
     // BCE: pred=[0.5], target=[0.0], eps=0.
     // loss = -0*log(0.5) - 1*log(1-0.5) = -log(0.5) = log(2).

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -1,8 +1,8 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
-    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, margin_ranking_loss,
-    nll_loss,
+    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, l1_loss,
+    margin_ranking_loss, nll_loss,
 };
 use coeus_tensor::Tensor;
 
@@ -127,6 +127,76 @@ fn test_huber_loss() {
 
     loss.backward();
     assert!(pred.grad().is_some());
+}
+
+#[test]
+fn test_l1_loss() {
+    // pred-target over shape [2, 2] gives diffs [3,-1,0.5,0].
+    // forward: mean(|diff|) = (3 + 1 + 0.5 + 0) / 4 = 1.125 exactly.
+    // backward: d/d_pred = sign(diff)/n = [1/4, -1/4, 1/4, 0].
+    let pred = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2, 2], &[3.0, -1.0, 0.5, 4.0]),
+        true,
+    );
+    let target = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2, 2], &[0.0, 0.0, 0.0, 4.0]),
+        true,
+    );
+
+    let loss = l1_loss(&pred, &target);
+    assert_eq!(loss.tensor.shape(), &[1]);
+    let loss_val = loss.tensor.as_slice()[0];
+    let expected = (3.0 + 1.0 + 0.5) / 4.0;
+    assert!(
+        (loss_val - expected).abs() <= 4.0 * f64::EPSILON * expected,
+        "l1_loss forward: got {loss_val:.17}, expected {expected:.17}"
+    );
+
+    loss.backward();
+    let grad = pred.grad().expect("pred must receive a gradient");
+    assert_eq!(grad.shape(), &[2, 2], "pred grad preserves input shape");
+    let quarter = 1.0 / 4.0;
+    let expected_grad = [quarter, -quarter, quarter, 0.0];
+    for (i, (&g, &e)) in grad.as_slice().iter().zip(expected_grad.iter()).enumerate() {
+        assert!(
+            (g - e).abs() <= 4.0 * f64::EPSILON,
+            "l1_loss grad[{i}]: got {g:.17}, expected {e:.17} (sign(diff)/n)"
+        );
+    }
+
+    let target_grad = target.grad().expect("target must receive a gradient");
+    assert_eq!(
+        target_grad.shape(),
+        &[2, 2],
+        "target grad preserves input shape"
+    );
+    for (i, (&g, &e)) in target_grad
+        .as_slice()
+        .iter()
+        .zip(expected_grad.iter())
+        .enumerate()
+    {
+        assert!(
+            (g + e).abs() <= 4.0 * f64::EPSILON,
+            "l1_loss target grad[{i}]: got {g:.17}, expected {:.17}",
+            -e
+        );
+    }
+}
+
+#[test]
+fn test_l1_loss_zero_when_equal() {
+    // l1_loss(x, x) = 0 exactly (all diffs zero).
+    let pred = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]),
+        false,
+    );
+    let target = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]),
+        false,
+    );
+    let loss = l1_loss(&pred, &target);
+    assert_eq!(loss.tensor.as_slice(), &[0.0_f64], "l1_loss(x, x) = 0");
 }
 
 #[test]


### PR DESCRIPTION
Implements L1Loss from the G-038 loss/distance parity gap.

## Change
- Canonical generic autograd node `l1_loss` = `mean_i |pred - target|` over all elements, differentiable w.r.t. both inputs (`d/d_pred = sign(diff)/n`, `d/d_target = -sign(diff)/n`; kink subgradient 0, matching `torch.sign(0)`). Gradients reconstruct input shape (N-d correct).
- Wired through the autograd re-export chain + thin coeus-nn delegate, mirroring `huber_loss`.

## Verification
Value-semantic tests (forward + dual-gradient on an N-d operand, identity-zero case, Sequential-vs-Moirai bitwise-differential parity). `cargo nextest run -p coeus-nn` loss suite: 26/26 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the **L1 (mean absolute error) loss function** to address the G-038 gap in the loss/distance function coverage. The implementation adds a new autograd node `l1_loss` that computes `mean(|pred - target|)` over all elements with proper gradient propagation for both inputs. The change follows the existing pattern used by `huber_loss`, wiring the core autograd operation through the module re-export chain to the `coeus-nn` interface, and includes comprehensive tests verifying forward computation, dual-gradient behavior on N-dimensional tensors, zero-error edge cases, and bitwise parity between Sequential and Moirai backends.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/l1.rs` |
| 2 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 3 | `coeus-autograd/src/ops/nn/mod.rs` |
| 4 | `coeus-autograd/src/ops/mod.rs` |
| 5 | `coeus-autograd/src/lib.rs` |
| 6 | `coeus-nn/src/loss.rs` |
| 7 | `coeus-nn/src/lib.rs` |
| 8 | `coeus-nn/tests/nn_loss_tests.rs` |
| 9 | `coeus-nn/tests/loss_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->