### PR TITLE
MS-194: add RMSNorm benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,12 @@
   `SequentialBackend` and `MoiraiBackend` in the same Criterion group. Short
   local run medians: Burn 241.66–265.41 µs, Coeus Sequential 239.66–280.71 µs,
   Coeus Moirai 116.22–133.93 µs. ([patch])
+- **NN benchmark matrix expansion (RMSNorm forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with an RMSNorm forward row
+  (`[128,256]`), comparing Burn NdArray against Coeus `SequentialBackend`
+  and `MoiraiBackend` in the same Criterion group. Short local run medians:
+  Burn 25.54–30.29 µs, Coeus Sequential 39.55–42.01 µs,
+  Coeus Moirai 36.57–39.07 µs. ([patch])
 - **NN benchmark matrix expansion (AvgPool2d forward)** — extended
   `coeus-nn/benches/nn_bench.rs` with an AvgPool2d forward row
   (`[8,16,32,32]`, `k=2`, `s=2`), comparing Burn NdArray against Coeus

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,8 +19,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding,
-    GroupNorm, LayerNorm, Linear, MaxPool2d, Module, MultiHeadAttention, NullMask,
+    AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
+    LayerNorm, Linear, MaxPool2d, Module, MultiHeadAttention, NullMask, RMSNorm,
     TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
@@ -32,8 +32,8 @@ use burn::nn::conv::Conv2dConfig;
 use burn::nn::conv::Conv3dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
 use burn::nn::{
-    BatchNormConfig, GroupNormConfig, LayerNormConfig, LinearConfig, PaddingConfig1d, PaddingConfig2d,
-    PaddingConfig3d,
+    BatchNormConfig, GroupNormConfig, LayerNormConfig, LinearConfig, PaddingConfig1d,
+    PaddingConfig2d, PaddingConfig3d, RmsNormConfig,
 };
 use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
 type BurnB = NdArray<f32>;
@@ -108,6 +108,44 @@ fn bench_layernorm_forward(c: &mut Criterion) {
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| black_box(ln_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_rmsnorm_forward(c: &mut Criterion) {
+    // RMSNorm forward on [BATCH=128, FEATURES=256] — same shape as LayerNorm row for direct
+    // normalization-family comparison.
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0031).sin())
+        .collect();
+
+    let burn_rn = RmsNormConfig::new(FEATURES).init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
+
+    let rn_seq = RMSNorm::<f32, SequentialBackend>::new(FEATURES, 1e-5);
+    let rn_moirai = RMSNorm::<f32, MoiraiBackend>::new(FEATURES, 1e-5);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — RMSNorm forward (128x256)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_rn.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(rn_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(rn_moirai.forward(black_box(&x_moirai))))
     });
     group.finish();
 }
@@ -754,6 +792,7 @@ criterion_group!(
     benches,
     bench_linear_forward,
     bench_layernorm_forward,
+    bench_rmsnorm_forward,
     bench_batchnorm1d_eval_forward,
     bench_batchnorm2d_eval_forward,
     bench_batchnorm3d_eval_forward,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,21 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-194: RMSNorm benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for RMSNorm in
+  `coeus-nn/benches/nn_bench.rs` on `[128,256]`, comparing Burn NdArray,
+  Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the RMSNorm row in the Criterion benchmark group so
+  it executes with the existing NN benchmark matrix.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- RMSNorm --warm-up-time 1 --measurement-time 2
+  --sample-size 10`.
+
 ## Sprint MS-193: AvgPool2d benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for AvgPool2d in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-193 - AvgPool2d benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-194 - RMSNorm benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an RMSNorm
+forward row so one additional implemented NN family is measured across Burn
+NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_rmsnorm_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[128,256]`.
+- [x] [patch] Benchmarks Burn NdArray RMSNorm forward vs Coeus
+  `RMSNorm::<_, SequentialBackend>` and `RMSNorm::<_, MoiraiBackend>` and
+  registers the row in `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- RMSNorm
+  --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-193 - AvgPool2d benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an AvgPool2d
 forward row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.
@@ -11,9 +28,8 @@ NdArray and both Coeus CPU backends.
 - [x] [patch] Added `bench_avgpool2d_forward` in
   `coeus-nn/benches/nn_bench.rs` for `[8,16,32,32]` with `k=2`, `s=2`.
 - [x] [patch] Benchmarks Burn NdArray AvgPool2d forward vs Coeus
-  `AvgPool2d::<_, SequentialBackend>` and
-  `AvgPool2d::<_, MoiraiBackend>` and registers the row in
-  `criterion_group!`.
+  `AvgPool2d::<_, SequentialBackend>` and `AvgPool2d::<_, MoiraiBackend>` and
+  registers the row in `criterion_group!`.
 - [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
 - [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
   coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,7 +8,7 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
+(Linear, LayerNorm, RMSNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
 layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
 BatchNorm3d eval forward, Conv1d forward, GroupNorm forward, MaxPool2d forward,
 AvgPool2d forward), not the full NN family set needed to claim Burn-level


### PR DESCRIPTION
Expand the G-043 benchmark matrix with an RMSNorm forward row [128x256] in coeus-nn/benches/nn_bench.rs, register it in the criterion group, and update G-043 tracking docs/changelog for MS-194.

Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- RMSNorm --warm-up-time 1 --measurement-time 2 --sample-size 10.

Medians: Burn 25.54-30.29 us, Coeus Sequential 39.55-42.01 us, Coeus Moirai 36.57-39.07 us.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR expands the NN benchmark matrix by adding a new `RMSNorm` forward pass benchmark row with shape `[128x256]`, comparing Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend`. The change includes adding the benchmark function to `coeus-nn/benches/nn_bench.rs`, registering it in the Criterion group, and updating tracking documentation (changelog, gap audit, checklist, and backlog) to reflect the completion of sprint MS-194.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `docs/checklist.md` |
| 5 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->