### PR TITLE
feat(nn): Add BCEWithLogits loss for G-038

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -45,6 +45,7 @@ pub use ops::{
     batchnorm1d,
     batchnorm2d,
     batchnorm3d,
+    bce_with_logits,
     binary_cross_entropy,
     // Shape ops
     broadcast_to,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -31,8 +31,9 @@ pub use reduction::{log_sum_exp, max_axis, min_axis, norm, norm_p, norm_p_axis};
 pub use arithmetic::VarScalarExt;
 pub use linalg::{matmul, sparse_matmul, sparse_matmul_coo, transpose_2d};
 pub use nn::{
-    avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, binary_cross_entropy, conv1d,
-    conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_transpose3d, cosine_embedding_loss,
+    avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, bce_with_logits,
+    binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
+    conv_transpose3d, cosine_embedding_loss,
     cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
     margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, rmsnorm, sdp_attention, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,

--- a/coeus-autograd/src/ops/nn/loss/bce_with_logits.rs
+++ b/coeus-autograd/src/ops/nn/loss/bce_with_logits.rs
@@ -1,0 +1,181 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Numerically stable sigmoid `1 / (1 + exp(-z))` without intermediate overflow.
+#[inline]
+fn stable_sigmoid<T: Float>(z: T) -> T {
+    let one = T::one();
+    if z >= T::zero() {
+        one / (one + (T::zero() - z).exp_op())
+    } else {
+        let ez = z.exp_op();
+        ez / (one + ez)
+    }
+}
+
+/// Autograd node for binary cross-entropy computed from logits.
+pub struct BceWithLogitsNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Per-element `sigmoid(logit) - target`, the `d/d_logit` factor before scaling.
+    pub sig_minus_target: Vec<T>,
+    /// Per-element logits, the `-d/d_target` factor before scaling.
+    pub logits: Vec<T>,
+    /// Number of elements in the mean reduction.
+    pub n: usize,
+    /// Original tensor shape for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for BceWithLogitsNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "bce_with_logits"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let mut host_grad = [T::zero()];
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+        let g_out = host_grad[0];
+        let n_t = T::from_f64(self.n as f64);
+        let scale = g_out / n_t;
+
+        // d/d_logit = (sigmoid(z) - y) / n.
+        if let Some(Some(ref g)) = input_grads.first() {
+            let mut d_logit = vec![T::zero(); self.n];
+            for (i, grad) in d_logit.iter_mut().enumerate() {
+                *grad = self.sig_minus_target[i] * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_logit, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+
+        // d/d_target = -z / n.
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut d_target = vec![T::zero(); self.n];
+            for (i, grad) in d_target.iter_mut().enumerate() {
+                *grad = (T::zero() - self.logits[i]) * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked binary cross-entropy with logits: the numerically stable composition
+/// of a sigmoid and binary cross-entropy. `logits` and `target` must share shape.
+///
+/// Per element with `z = logit`, `y = target`:
+/// `loss = max(z, 0) - z*y + log(1 + exp(-|z|))`, averaged over all elements.
+/// This is the `reduction="mean"` form of PyTorch `BCEWithLogitsLoss`.
+pub fn bce_with_logits<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    logits: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        logits.tensor.shape(),
+        target.tensor.shape(),
+        "bce_with_logits requires logits and target to have identical shapes"
+    );
+    let n = logits.tensor.numel();
+    assert!(n > 0, "bce_with_logits requires at least one element");
+    let shape = logits.tensor.shape_cloned();
+
+    let z_cont;
+    let z_raw = if logits.tensor.is_contiguous() && logits.tensor.layout().offset() == 0 {
+        &logits.tensor
+    } else {
+        z_cont = logits.tensor.to_contiguous_on(&backend);
+        &z_cont
+    };
+    let t_cont;
+    let t_raw = if target.tensor.is_contiguous() && target.tensor.layout().offset() == 0 {
+        &target.tensor
+    } else {
+        t_cont = target.tensor.to_contiguous_on(&backend);
+        &t_cont
+    };
+
+    let z_host: std::borrow::Cow<[T]> = if let Some(s) = z_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(z_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let t_host: std::borrow::Cow<[T]> = if let Some(s) = t_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(t_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let one = T::one();
+    let mut sig_minus_target = vec![T::zero(); n];
+    let mut logits_v = vec![T::zero(); n];
+    let mut loss_val = T::zero();
+    for i in 0..n {
+        let z = z_host[i];
+        let y = t_host[i];
+        logits_v[i] = z;
+        // Stable: max(z,0) - z*y + log(1 + exp(-|z|)).
+        let max_z0 = if z > T::zero() { z } else { T::zero() };
+        let elem = max_z0 - z * y + (one + (T::zero() - z.abs()).exp_op()).log_op();
+        loss_val = loss_val + elem;
+        sig_minus_target[i] = stable_sigmoid(z) - y;
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad = crate::grad_mode::should_track_var(logits)
+        || crate::grad_mode::should_track_var(target);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = BceWithLogitsNode {
+            output_grad,
+            inputs: vec![logits.clone(), target.clone()],
+            sig_minus_target,
+            logits: logits_v,
+            n,
+            shape,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -1,5 +1,7 @@
 /// Binary cross-entropy loss.
 pub mod bce;
+/// Binary cross-entropy from logits (numerically stable).
+pub mod bce_with_logits;
 /// Cosine embedding loss.
 pub mod cosine;
 /// Cross-entropy loss.
@@ -16,6 +18,7 @@ pub mod margin_ranking;
 pub mod nll;
 
 pub use bce::{binary_cross_entropy, BinaryCrossEntropyNode};
+pub use bce_with_logits::{bce_with_logits, BceWithLogitsNode};
 pub use cosine::{cosine_embedding_loss, CosineEmbeddingLossNode};
 pub use cross_entropy::{cross_entropy_loss, CrossEntropyLossNode};
 pub use huber::{huber_loss, HuberLossNode};

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -22,8 +22,8 @@ pub use conv::{conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_
 pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
-    binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, nll_loss,
+    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
+    kl_divergence, l1_loss, margin_ranking_loss, nll_loss,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -84,8 +84,8 @@ pub use init::{kaiming_uniform, xavier_uniform};
 pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
-    binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, mse_loss, nll_loss,
+    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
+    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -110,6 +110,17 @@ pub fn binary_cross_entropy<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::binary_cross_entropy(pred, target, eps)
 }
 
+/// Binary Cross-Entropy with logits (numerically stable sigmoid + BCE).
+/// logits and target share shape; reduces with `mean`. Mirrors PyTorch
+/// `BCEWithLogitsLoss(reduction="mean")`.
+#[inline]
+pub fn bce_with_logits<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    logits: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    coeus_autograd::bce_with_logits(logits, target)
+}
+
 /// Negative Log-Likelihood Loss.
 /// log_probs: `[N, C]` log-probabilities, targets: `[N]` class indices.
 #[inline]

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -1,8 +1,8 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
-    binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence, l1_loss,
-    margin_ranking_loss, nll_loss,
+    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
+    l1_loss, margin_ranking_loss, nll_loss,
 };
 use coeus_tensor::Tensor;
 
@@ -182,6 +182,76 @@ fn test_l1_loss() {
             -e
         );
     }
+}
+
+#[test]
+fn test_bce_with_logits() {
+    // Oracle: BCEWithLogits(z, y) == BCE(sigmoid(z), y), computed independently in f64.
+    // logits z=[0, 2, -1], target y=[1, 0, 1].
+    let zs = [0.0_f64, 2.0, -1.0];
+    let ys = [1.0_f64, 0.0, 1.0];
+    let n = zs.len() as f64;
+
+    let logits = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([3], &zs), true);
+    let target = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([3], &ys), true);
+
+    let loss = bce_with_logits(&logits, &target);
+    assert_eq!(loss.tensor.shape(), &[1]);
+
+    // Reference forward via sigmoid + BCE.
+    let sigmoid = |z: f64| 1.0 / (1.0 + (-z).exp());
+    let mut expected = 0.0;
+    for (&z, &y) in zs.iter().zip(ys.iter()) {
+        let s = sigmoid(z);
+        expected -= y * s.ln() + (1.0 - y) * (1.0 - s).ln();
+    }
+    expected /= n;
+    let loss_val = loss.tensor.as_slice()[0];
+    assert!(
+        (loss_val - expected).abs() <= 1e-12,
+        "bce_with_logits forward: got {loss_val:.17}, expected {expected:.17}"
+    );
+
+    loss.backward();
+    // d/d_logit = (sigmoid(z) - y) / n; d/d_target = -z / n.
+    let logit_grad = logits.grad().expect("logits must receive a gradient");
+    let target_grad = target.grad().expect("target must receive a gradient");
+    for (i, ((&z, &y), (&gz, &gt))) in zs
+        .iter()
+        .zip(ys.iter())
+        .zip(logit_grad.as_slice().iter().zip(target_grad.as_slice().iter()))
+        .enumerate()
+    {
+        let exp_gz = (sigmoid(z) - y) / n;
+        let exp_gt = -z / n;
+        assert!(
+            (gz - exp_gz).abs() <= 1e-12,
+            "bce_with_logits d/d_logit[{i}]: got {gz:.17}, expected {exp_gz:.17}"
+        );
+        assert!(
+            (gt - exp_gt).abs() <= 1e-12,
+            "bce_with_logits d/d_target[{i}]: got {gt:.17}, expected {exp_gt:.17}"
+        );
+    }
+}
+
+#[test]
+fn test_bce_with_logits_matches_bce_of_sigmoid() {
+    // Numerically equal to applying sigmoid then binary_cross_entropy (eps→0 regime,
+    // well inside (0,1) so clamping is inert).
+    let zs = [0.5_f64, -0.7, 1.3, -2.0];
+    let ys = [1.0_f64, 0.0, 1.0, 0.0];
+    let logits = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([4], &zs), false);
+    let target = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([4], &ys), false);
+    let stable = bce_with_logits(&logits, &target).tensor.as_slice()[0];
+
+    let probs: Vec<f64> = zs.iter().map(|z| 1.0 / (1.0 + (-z).exp())).collect();
+    let pv = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([4], &probs), false);
+    let composed = binary_cross_entropy(&pv, &target, 1e-12).tensor.as_slice()[0];
+    assert!(
+        (stable - composed).abs() <= 1e-12,
+        "bce_with_logits {stable:.17} != bce(sigmoid) {composed:.17}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Implements BCEWithLogits from the G-038 loss/distance parity gap.

## Change
- Generic autograd node `bce_with_logits` = stable `mean_i[max(z,0) - z*y + log(1+exp(-|z|))]` (PyTorch `BCEWithLogitsLoss(reduction="mean")`), differentiable w.r.t. both inputs (`d/d_logit = (σ(z)-y)/n`, `d/d_target = -z/n`), shape-preserving N-d, overflow-free sigmoid.
- Wired through the autograd re-export chain + thin coeus-nn delegate, mirroring `l1_loss`/`huber_loss`.

## Verification
Value-semantic tests: forward + dual-gradient vs an independent f64 sigmoid+BCE oracle, and exact equivalence with `bce(σ(z))`. `cargo nextest run -p coeus-nn` bce tests: 2/2 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a numerically stable `BCEWithLogitsLoss` function that combines sigmoid activation and binary cross-entropy in a single operation to prevent numerical overflow. The implementation adds a new autograd node `bce_with_logits` that computes the loss using the stable formula `max(z,0) - z*y + log(1+exp(-|z|))` with proper gradients for both logit and target inputs. The function is wired through the autograd and nn layers following the same pattern as existing loss functions like `l1_loss` and `huber_loss`, and includes comprehensive tests verifying correctness against an independent sigmoid+BCE oracle and exact equivalence with the composed `bce(sigmoid(z))` approach.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/bce_with_logits.rs` |
| 2 | `coeus-nn/tests/nn_loss_tests.rs` |
| 3 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 4 | `coeus-autograd/src/ops/nn/mod.rs` |
| 5 | `coeus-autograd/src/ops/mod.rs` |
| 6 | `coeus-autograd/src/lib.rs` |
| 7 | `coeus-nn/src/loss.rs` |
| 8 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new binary cross-entropy-with-logits loss function for use in model training.
  * Made the new loss available through the main neural-network and autograd APIs.
  * Added test coverage to verify output values, gradients, and consistency with existing loss behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->