### PR TITLE
MS-195: add LSTM benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,12 @@
   and `MoiraiBackend` in the same Criterion group. Short local run medians:
   Burn 25.54–30.29 µs, Coeus Sequential 39.55–42.01 µs,
   Coeus Moirai 36.57–39.07 µs. ([patch])
+- **NN benchmark matrix expansion (LSTM forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with an LSTM forward row
+  (`batch=4, seq=32, input=64, hidden=128`), comparing Burn NdArray against
+  Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion group.
+  Short local run medians: Burn 3.44–4.17 ms, Coeus Sequential 3.39–4.14 ms,
+  Coeus Moirai 2.99–3.68 ms. ([patch])
 - **NN benchmark matrix expansion (AvgPool2d forward)** — extended
   `coeus-nn/benches/nn_bench.rs` with an AvgPool2d forward row
   (`[8,16,32,32]`, `k=2`, `s=2`), comparing Burn NdArray against Coeus

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -20,7 +20,7 @@ use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
     AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
-    LayerNorm, Linear, MaxPool2d, Module, MultiHeadAttention, NullMask, RMSNorm,
+    LayerNorm, Linear, Lstm, MaxPool2d, Module, MultiHeadAttention, NullMask, RMSNorm,
     TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
@@ -32,7 +32,7 @@ use burn::nn::conv::Conv2dConfig;
 use burn::nn::conv::Conv3dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
 use burn::nn::{
-    BatchNormConfig, GroupNormConfig, LayerNormConfig, LinearConfig, PaddingConfig1d,
+    BatchNormConfig, GroupNormConfig, LayerNormConfig, LinearConfig, LstmConfig, PaddingConfig1d,
     PaddingConfig2d, PaddingConfig3d, RmsNormConfig,
 };
 use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
@@ -788,6 +788,58 @@ fn bench_linear_forward_backward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_lstm_forward(c: &mut Criterion) {
+    // LSTM sequence forward on [batch=4, seq=32, input=64] → hidden=128.
+    // Modest size keeps the run tractable while exercising the full unroll path.
+    const LSTM_BATCH: usize = 4;
+    const LSTM_SEQ: usize = 32;
+    const LSTM_IN: usize = 64;
+    const LSTM_H: usize = 128;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(LSTM_BATCH * LSTM_SEQ * LSTM_IN))
+        .map(|i| (i as f32 * 0.0017).cos())
+        .collect();
+
+    // Burn: LstmConfig(d_input, d_hidden, bias=true).
+    let burn_lstm = LstmConfig::new(LSTM_IN, LSTM_H, true).init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 3> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [LSTM_BATCH, LSTM_SEQ, LSTM_IN]),
+        &device,
+    );
+
+    // Coeus: Lstm::new(input_size, hidden_size).
+    let lstm_seq = Lstm::<f32, SequentialBackend>::new(LSTM_IN, LSTM_H);
+    let lstm_moirai = Lstm::<f32, MoiraiBackend>::new(LSTM_IN, LSTM_H);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(
+            vec![LSTM_BATCH, LSTM_SEQ, LSTM_IN],
+            &input_data,
+        ),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(
+            vec![LSTM_BATCH, LSTM_SEQ, LSTM_IN],
+            &input_data,
+        ),
+        false,
+    );
+
+    let mut group =
+        c.benchmark_group("Burn vs Coeus — LSTM forward (4x32 seq, in=64 hidden=128)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_lstm.forward(black_box(x_burn.clone()), None)))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(lstm_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(lstm_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -805,6 +857,7 @@ criterion_group!(
     bench_mha_forward,
     bench_transformer_encoder_forward,
     bench_embedding_forward,
-    bench_linear_forward_backward
+    bench_linear_forward_backward,
+    bench_lstm_forward
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,20 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-195: LSTM benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for LSTM in
+  `coeus-nn/benches/nn_bench.rs` with `batch=4, seq=32, input=64, hidden=128`,
+  comparing Burn NdArray, Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the LSTM row in the Criterion benchmark group.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence tier: empirical benchmark harness; `cargo check -p coeus-nn
+  --all-targets`; `cargo clippy -p coeus-nn --all-targets -- -D warnings`;
+  `cargo bench -p coeus-nn --bench nn_bench --no-run`; `cargo bench -p
+  coeus-nn --bench nn_bench -- LSTM --warm-up-time 1 --measurement-time 3
+  --sample-size 10`.
+
 ## Sprint MS-194: RMSNorm benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for RMSNorm in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-194 - RMSNorm benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-195 - LSTM benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an LSTM forward
+row so one additional implemented NN family is measured across Burn NdArray and
+both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_lstm_forward` in `coeus-nn/benches/nn_bench.rs`
+  with `batch=4, seq=32, input=64, hidden=128`.
+- [x] [patch] Benchmarks Burn NdArray LSTM forward vs Coeus
+  `Lstm::<_, SequentialBackend>` and `Lstm::<_, MoiraiBackend>` and
+  registers the row in `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench -- LSTM
+  --warm-up-time 1 --measurement-time 3 --sample-size 10`.
+
+### Previous Sprint: MS-194 - RMSNorm benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an RMSNorm
 forward row so one additional implemented NN family is measured across Burn
 NdArray and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,7 +8,7 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, RMSNorm, Conv2d, Conv3d, MHA self-attention, Transformer encoder
+(Linear, LayerNorm, RMSNorm, LSTM, Conv2d, Conv3d, MHA self-attention, Transformer encoder
 layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
 BatchNorm3d eval forward, Conv1d forward, GroupNorm forward, MaxPool2d forward,
 AvgPool2d forward), not the full NN family set needed to claim Burn-level


### PR DESCRIPTION
Expand the G-043 benchmark matrix with an LSTM forward row [batch=4,seq=32,in=64,hidden=128] in coeus-nn/benches/nn_bench.rs, register it in the criterion group, and update G-043 tracking docs/changelog for MS-195.

Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- LSTM --warm-up-time 1 --measurement-time 3 --sample-size 10.

Medians: Burn 3.44-4.17 ms, Coeus Sequential 3.39-4.14 ms, Coeus Moirai 2.99-3.68 ms.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds an LSTM forward benchmark to the existing neural network benchmark matrix in `coeus-nn`, comparing Burn NdArray performance against Coeus `SequentialBackend` and `MoiraiBackend` implementations using a modest workload configuration of `batch=4, seq=32, input=64, hidden=128`. The benchmark is properly integrated into the Criterion benchmark group, and corresponding documentation is updated across the changelog, backlog tracking, checklist, and gap audit to reflect the expanded benchmark coverage for MS-195.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->