### PR TITLE
feat(nn): Add Poisson NLL loss for G-038

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -111,6 +111,7 @@ pub use ops::{
     // New unary math ops
     neg,
     nll_loss,
+    poisson_nll,
     norm,
     norm_p,
     norm_p_axis,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -35,7 +35,7 @@ pub use nn::{
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
     conv_transpose3d, cosine_embedding_loss,
     cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
-    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, rmsnorm, sdp_attention, softmax,
+    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, poisson_nll, rmsnorm, sdp_attention, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -16,6 +16,8 @@ pub mod l1;
 pub mod margin_ranking;
 /// Negative log-likelihood loss.
 pub mod nll;
+/// Poisson negative-log-likelihood loss.
+pub mod poisson_nll;
 
 pub use bce::{binary_cross_entropy, BinaryCrossEntropyNode};
 pub use bce_with_logits::{bce_with_logits, BceWithLogitsNode};
@@ -26,3 +28,4 @@ pub use kl_div::{kl_divergence, KlDivLossNode};
 pub use l1::{l1_loss, L1LossNode};
 pub use margin_ranking::{margin_ranking_loss, MarginRankingLossNode};
 pub use nll::{nll_loss, NllLossNode};
+pub use poisson_nll::{poisson_nll, PoissonNllNode};

--- a/coeus-autograd/src/ops/nn/loss/poisson_nll.rs
+++ b/coeus-autograd/src/ops/nn/loss/poisson_nll.rs
@@ -1,0 +1,167 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for the Poisson negative-log-likelihood loss (log-input form).
+pub struct PoissonNllNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Per-element `exp(input) - target`, the `d/d_input` factor before scaling.
+    pub exp_minus_target: Vec<T>,
+    /// Per-element inputs, the `-d/d_target` factor before scaling.
+    pub input_vals: Vec<T>,
+    /// Number of elements in the mean reduction.
+    pub n: usize,
+    /// Original tensor shape for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for PoissonNllNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "poisson_nll"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let mut host_grad = [T::zero()];
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+        let g_out = host_grad[0];
+        let n_t = T::from_f64(self.n as f64);
+        let scale = g_out / n_t;
+
+        // d/d_input = (exp(input) - target) / n.
+        if let Some(Some(ref g)) = input_grads.first() {
+            let mut d_input = vec![T::zero(); self.n];
+            for (i, grad) in d_input.iter_mut().enumerate() {
+                *grad = self.exp_minus_target[i] * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_input, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+
+        // d/d_target = -input / n.
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut d_target = vec![T::zero(); self.n];
+            for (i, grad) in d_target.iter_mut().enumerate() {
+                *grad = (T::zero() - self.input_vals[i]) * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked Poisson negative-log-likelihood loss in the log-input regime
+/// (PyTorch `PoissonNLLLoss(log_input=True, full=False, reduction="mean")`):
+/// `loss = mean_i(exp(input_i) - target_i * input_i)`.
+///
+/// `input` holds the log-rate `log(λ)`, `target` the observed counts; both
+/// share shape. The Stirling `full` correction term is not included (matching
+/// the PyTorch default).
+pub fn poisson_nll<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        input.tensor.shape(),
+        target.tensor.shape(),
+        "poisson_nll requires input and target to have identical shapes"
+    );
+    let n = input.tensor.numel();
+    assert!(n > 0, "poisson_nll requires at least one element");
+    let shape = input.tensor.shape_cloned();
+
+    let z_cont;
+    let z_raw = if input.tensor.is_contiguous() && input.tensor.layout().offset() == 0 {
+        &input.tensor
+    } else {
+        z_cont = input.tensor.to_contiguous_on(&backend);
+        &z_cont
+    };
+    let t_cont;
+    let t_raw = if target.tensor.is_contiguous() && target.tensor.layout().offset() == 0 {
+        &target.tensor
+    } else {
+        t_cont = target.tensor.to_contiguous_on(&backend);
+        &t_cont
+    };
+
+    let z_host: std::borrow::Cow<[T]> = if let Some(s) = z_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(z_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let t_host: std::borrow::Cow<[T]> = if let Some(s) = t_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(t_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let mut exp_minus_target = vec![T::zero(); n];
+    let mut input_vals = vec![T::zero(); n];
+    let mut loss_val = T::zero();
+    for i in 0..n {
+        let z = z_host[i];
+        let y = t_host[i];
+        let ez = z.exp_op();
+        input_vals[i] = z;
+        exp_minus_target[i] = ez - y;
+        loss_val = loss_val + (ez - y * z);
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad = crate::grad_mode::should_track_var(input)
+        || crate::grad_mode::should_track_var(target);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = PoissonNllNode {
+            output_grad,
+            inputs: vec![input.clone(), target.clone()],
+            exp_minus_target,
+            input_vals,
+            n,
+            shape,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -23,7 +23,7 @@ pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, nll_loss,
+    kl_divergence, l1_loss, margin_ranking_loss, nll_loss, poisson_nll,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -85,7 +85,7 @@ pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss,
+    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, poisson_nll,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -152,6 +152,18 @@ pub fn l1_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::l1_loss(pred, target)
 }
 
+/// Poisson negative-log-likelihood loss (log-input form).
+/// input holds `log(λ)`, target the observed counts; both share shape.
+/// Computes `mean(exp(input) - target * input)` (PyTorch
+/// `PoissonNLLLoss(log_input=True, full=False)`).
+#[inline]
+pub fn poisson_nll<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    coeus_autograd::poisson_nll(input, target)
+}
+
 /// KL divergence loss.
 ///
 /// `input` is log-probabilities and `target` is probabilities. Computes

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -2,7 +2,7 @@ use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, nll_loss,
+    l1_loss, margin_ranking_loss, nll_loss, poisson_nll,
 };
 use coeus_tensor::Tensor;
 
@@ -267,6 +267,52 @@ fn test_l1_loss_zero_when_equal() {
     );
     let loss = l1_loss(&pred, &target);
     assert_eq!(loss.tensor.as_slice(), &[0.0_f64], "l1_loss(x, x) = 0");
+}
+
+#[test]
+fn test_poisson_nll() {
+    // log-input form: loss = mean(exp(z) - y*z); d/dz = (exp(z)-y)/n; d/dy = -z/n.
+    let zs = [0.0_f64, 1.0, -0.5];
+    let ys = [2.0_f64, 0.0, 3.0];
+    let n = zs.len() as f64;
+
+    let input = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([3], &zs), true);
+    let target = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([3], &ys), true);
+
+    let loss = poisson_nll(&input, &target);
+    assert_eq!(loss.tensor.shape(), &[1]);
+
+    let mut expected = 0.0;
+    for (&z, &y) in zs.iter().zip(ys.iter()) {
+        expected += z.exp() - y * z;
+    }
+    expected /= n;
+    let loss_val = loss.tensor.as_slice()[0];
+    assert!(
+        (loss_val - expected).abs() <= 1e-12,
+        "poisson_nll forward: got {loss_val:.17}, expected {expected:.17}"
+    );
+
+    loss.backward();
+    let input_grad = input.grad().expect("input must receive a gradient");
+    let target_grad = target.grad().expect("target must receive a gradient");
+    for (i, ((&z, &y), (&gz, &gt))) in zs
+        .iter()
+        .zip(ys.iter())
+        .zip(input_grad.as_slice().iter().zip(target_grad.as_slice().iter()))
+        .enumerate()
+    {
+        let exp_gz = (z.exp() - y) / n;
+        let exp_gt = -z / n;
+        assert!(
+            (gz - exp_gz).abs() <= 1e-12,
+            "poisson_nll d/d_input[{i}]: got {gz:.17}, expected {exp_gz:.17}"
+        );
+        assert!(
+            (gt - exp_gt).abs() <= 1e-12,
+            "poisson_nll d/d_target[{i}]: got {gt:.17}, expected {exp_gt:.17}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Implements PoissonNLL (log-input) from the G-038 loss/distance parity gap.

## Change
- Generic autograd node `poisson_nll` = `mean_i(exp(input_i) - target_i*input_i)` (PyTorch `PoissonNLLLoss(log_input=True, full=False, reduction="mean")`), differentiable w.r.t. both inputs (`d/d_input = (exp(z)-y)/n`, `d/d_target = -z/n`), shape-preserving N-d.
- Wired through the autograd re-export chain + thin coeus-nn delegate, mirroring `l1_loss`/`bce_with_logits`.

## Verification
Value-semantic test: forward + dual-gradient vs an independent f64 oracle. `cargo nextest run -p coeus-nn --test nn_loss_tests` poisson test: 1/1 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the Poisson negative-log-likelihood loss function (`poisson_nll`) for the log-input regime, addressing gap G-038 in the loss/distance parity audit. The implementation adds a new autograd node `PoissonNllNode` that computes `mean(exp(input) - target*input)` with dual gradients for both inputs, wires it through the autograd re-export chain and coeus-nn delegate (similar to `l1_loss`), and includes value-semantic tests validating forward output and both input/target gradients against an independent f64 oracle. The PR also includes some unrelated documentation updates marking G-035 (ConvTranspose3d) as closed and adding an exact f64 regression test for `conv_transpose3d`.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/gap_audit.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/checklist.md` |
| 4 | `coeus-autograd/src/ops/nn/loss/poisson_nll.rs` |
| 5 | `coeus-nn/tests/nn_loss_tests.rs` |
| 6 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 7 | `coeus-autograd/src/ops/nn/mod.rs` |
| 8 | `coeus-autograd/src/ops/mod.rs` |
| 9 | `coeus-autograd/src/lib.rs` |
| 10 | `coeus-nn/src/loss.rs` |
| 11 | `coeus-nn/src/lib.rs` |
| 12 | `coeus-autograd/src/ops/activation/relu.rs` |
| 13 | `coeus-autograd/tests/autograd/nn_conv.rs` |
| 14 | `CHANGELOG.md` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-autograd/tests/autograd/nn_conv.rs` | Adds a ConvTranspose3d backward gradient regression test, which is unrelated to the Poisson NLL loss implementation described in the PR title and body |
| `docs/gap_audit.md` | Marks G-035 (ConvTranspose3d) as closed, which is unrelated to the Poisson NLL loss feature (G-038) this PR is implementing |
| `docs/backlog.md` | Updates ConvTranspose3d (G-035) status and adds MS-196 sprint documentation, which is unrelated to the Poisson NLL loss implementation |
| `docs/checklist.md` | Adds MS-196 sprint details for ConvTranspose3d closure, which is unrelated to the Poisson NLL loss feature |
| `CHANGELOG.md` | Contains extensive ConvTranspose3d documentation updates that are unrelated to the Poisson NLL loss implementation |
| `coeus-autograd/src/ops/activation/relu.rs` | Minor documentation formatting change (backticks to code format) that appears unrelated to Poisson NLL loss implementation |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->