### PR TITLE
feat(nn): Add SoftMargin (logistic) loss for G-038

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -112,6 +112,7 @@ pub use ops::{
     neg,
     nll_loss,
     poisson_nll,
+    soft_margin,
     norm,
     norm_p,
     norm_p_axis,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -35,7 +35,7 @@ pub use nn::{
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
     conv_transpose3d, cosine_embedding_loss,
     cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
-    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, poisson_nll, rmsnorm, sdp_attention, softmax,
+    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -18,6 +18,8 @@ pub mod margin_ranking;
 pub mod nll;
 /// Poisson negative-log-likelihood loss.
 pub mod poisson_nll;
+/// Soft-margin (logistic) loss.
+pub mod soft_margin;
 
 pub use bce::{binary_cross_entropy, BinaryCrossEntropyNode};
 pub use bce_with_logits::{bce_with_logits, BceWithLogitsNode};
@@ -29,3 +31,4 @@ pub use l1::{l1_loss, L1LossNode};
 pub use margin_ranking::{margin_ranking_loss, MarginRankingLossNode};
 pub use nll::{nll_loss, NllLossNode};
 pub use poisson_nll::{poisson_nll, PoissonNllNode};
+pub use soft_margin::{soft_margin, SoftMarginNode};

--- a/coeus-autograd/src/ops/nn/loss/soft_margin.rs
+++ b/coeus-autograd/src/ops/nn/loss/soft_margin.rs
@@ -1,0 +1,184 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Numerically stable sigmoid `1 / (1 + exp(-z))` without intermediate overflow.
+#[inline]
+fn stable_sigmoid<T: Float>(z: T) -> T {
+    let one = T::one();
+    if z >= T::zero() {
+        one / (one + (T::zero() - z).exp_op())
+    } else {
+        let ez = z.exp_op();
+        ez / (one + ez)
+    }
+}
+
+/// Autograd node for the soft-margin (logistic) loss.
+pub struct SoftMarginNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Per-element `-target * sigmoid(-target*input)`, the `d/d_input` factor.
+    pub d_input: Vec<T>,
+    /// Per-element `-input * sigmoid(-target*input)`, the `d/d_target` factor.
+    pub d_target: Vec<T>,
+    /// Number of elements in the mean reduction.
+    pub n: usize,
+    /// Original tensor shape for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for SoftMarginNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "soft_margin"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let mut host_grad = [T::zero()];
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+        let g_out = host_grad[0];
+        let n_t = T::from_f64(self.n as f64);
+        let scale = g_out / n_t;
+
+        if let Some(Some(ref g)) = input_grads.first() {
+            let mut d = vec![T::zero(); self.n];
+            for (i, grad) in d.iter_mut().enumerate() {
+                *grad = self.d_input[i] * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut d = vec![T::zero(); self.n];
+            for (i, grad) in d.iter_mut().enumerate() {
+                *grad = self.d_target[i] * scale;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked soft-margin (logistic) loss, the `reduction="mean"` form of PyTorch
+/// `SoftMarginLoss`: `mean_i log(1 + exp(-target_i * input_i))`, with `target`
+/// in `{-1, +1}`. `input` and `target` must share shape.
+///
+/// Forward uses the stable softplus identity
+/// `log(1+exp(-m)) = max(-m, 0) + log(1 + exp(-|m|))` with `m = target*input`.
+/// Differentiable w.r.t. both inputs:
+/// `d/d_input = -target * sigmoid(-m) / n`, `d/d_target = -input * sigmoid(-m) / n`.
+pub fn soft_margin<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        input.tensor.shape(),
+        target.tensor.shape(),
+        "soft_margin requires input and target to have identical shapes"
+    );
+    let n = input.tensor.numel();
+    assert!(n > 0, "soft_margin requires at least one element");
+    let shape = input.tensor.shape_cloned();
+
+    let x_cont;
+    let x_raw = if input.tensor.is_contiguous() && input.tensor.layout().offset() == 0 {
+        &input.tensor
+    } else {
+        x_cont = input.tensor.to_contiguous_on(&backend);
+        &x_cont
+    };
+    let t_cont;
+    let t_raw = if target.tensor.is_contiguous() && target.tensor.layout().offset() == 0 {
+        &target.tensor
+    } else {
+        t_cont = target.tensor.to_contiguous_on(&backend);
+        &t_cont
+    };
+
+    let x_host: std::borrow::Cow<[T]> = if let Some(s) = x_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(x_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let t_host: std::borrow::Cow<[T]> = if let Some(s) = t_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(t_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let one = T::one();
+    let mut d_input = vec![T::zero(); n];
+    let mut d_target = vec![T::zero(); n];
+    let mut loss_val = T::zero();
+    for i in 0..n {
+        let x = x_host[i];
+        let y = t_host[i];
+        let m = y * x;
+        // softplus(-m) = max(-m, 0) + log(1 + exp(-|m|)).
+        let neg_m = T::zero() - m;
+        let max_part = if neg_m > T::zero() { neg_m } else { T::zero() };
+        loss_val = loss_val + max_part + (one + (T::zero() - m.abs()).exp_op()).log_op();
+        // sigmoid(-m); grads: d/dx = -y*sig, d/dy = -x*sig.
+        let sig = stable_sigmoid(neg_m);
+        d_input[i] = (T::zero() - y) * sig;
+        d_target[i] = (T::zero() - x) * sig;
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad = crate::grad_mode::should_track_var(input)
+        || crate::grad_mode::should_track_var(target);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = SoftMarginNode {
+            output_grad,
+            inputs: vec![input.clone(), target.clone()],
+            d_input,
+            d_target,
+            n,
+            shape,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -23,7 +23,7 @@ pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, nll_loss, poisson_nll,
+    kl_divergence, l1_loss, margin_ranking_loss, nll_loss, poisson_nll, soft_margin,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -85,7 +85,7 @@ pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, poisson_nll,
+    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, poisson_nll, soft_margin,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -164,6 +164,16 @@ pub fn poisson_nll<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::poisson_nll(input, target)
 }
 
+/// Soft-margin (logistic) loss. input: `[..]`, target: `[..]` in `{-1, +1}`.
+/// Computes `mean(log(1 + exp(-target * input)))` (PyTorch `SoftMarginLoss`).
+#[inline]
+pub fn soft_margin<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    target: &Var<T, B>,
+) -> Var<T, B> {
+    coeus_autograd::soft_margin(input, target)
+}
+
 /// KL divergence loss.
 ///
 /// `input` is log-probabilities and `target` is probabilities. Computes

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -2,7 +2,7 @@ use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, nll_loss, poisson_nll,
+    l1_loss, margin_ranking_loss, nll_loss, poisson_nll, soft_margin,
 };
 use coeus_tensor::Tensor;
 
@@ -311,6 +311,54 @@ fn test_poisson_nll() {
         assert!(
             (gt - exp_gt).abs() <= 1e-12,
             "poisson_nll d/d_target[{i}]: got {gt:.17}, expected {exp_gt:.17}"
+        );
+    }
+}
+
+#[test]
+fn test_soft_margin() {
+    // loss = mean(log(1+exp(-y*x))); d/dx = -y*sigmoid(-y*x)/n; d/dy = -x*sigmoid(-y*x)/n.
+    let xs = [0.5_f64, -1.2, 2.0];
+    let ys = [1.0_f64, -1.0, 1.0];
+    let n = xs.len() as f64;
+
+    let input = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([3], &xs), true);
+    let target = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([3], &ys), true);
+
+    let loss = soft_margin(&input, &target);
+    assert_eq!(loss.tensor.shape(), &[1]);
+
+    let mut expected = 0.0;
+    for (&x, &y) in xs.iter().zip(ys.iter()) {
+        expected += (1.0 + (-y * x).exp()).ln();
+    }
+    expected /= n;
+    let loss_val = loss.tensor.as_slice()[0];
+    assert!(
+        (loss_val - expected).abs() <= 1e-12,
+        "soft_margin forward: got {loss_val:.17}, expected {expected:.17}"
+    );
+
+    loss.backward();
+    let sigmoid = |z: f64| 1.0 / (1.0 + (-z).exp());
+    let input_grad = input.grad().expect("input must receive a gradient");
+    let target_grad = target.grad().expect("target must receive a gradient");
+    for (i, ((&x, &y), (&gx, &gt))) in xs
+        .iter()
+        .zip(ys.iter())
+        .zip(input_grad.as_slice().iter().zip(target_grad.as_slice().iter()))
+        .enumerate()
+    {
+        let sig = sigmoid(-y * x);
+        let exp_gx = -y * sig / n;
+        let exp_gt = -x * sig / n;
+        assert!(
+            (gx - exp_gx).abs() <= 1e-12,
+            "soft_margin d/d_input[{i}]: got {gx:.17}, expected {exp_gx:.17}"
+        );
+        assert!(
+            (gt - exp_gt).abs() <= 1e-12,
+            "soft_margin d/d_target[{i}]: got {gt:.17}, expected {exp_gt:.17}"
         );
     }
 }


### PR DESCRIPTION
Implements SoftMarginLoss from the G-038 loss/distance parity gap.

## Change
- Generic autograd node `soft_margin` = `mean_i log(1 + exp(-target_i*input_i))`, target in {-1,+1} (PyTorch `SoftMarginLoss(reduction="mean")`). Stable softplus forward; differentiable w.r.t. both inputs (`d/d_input = -target*σ(-m)/n`, `d/d_target = -input*σ(-m)/n`, m=target*input), shape-preserving N-d.
- Wired through the autograd re-export chain + thin coeus-nn delegate, mirroring `l1_loss`/`bce_with_logits`/`poisson_nll`.

## Verification
Value-semantic test: forward + dual-gradient vs an independent f64 oracle. `cargo nextest run -p coeus-nn --test nn_loss_tests` soft_margin test: 1/1 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the **SoftMarginLoss** (also known as logistic loss) to address gap G-038 in the loss/distance parity audit. The implementation adds a new autograd node `soft_margin` that computes `mean(log(1 + exp(-target * input)))` where target values are in `{-1, +1}`, matching PyTorch's `SoftMarginLoss` with `reduction="mean"`. The forward pass uses a numerically stable softplus implementation to avoid overflow, and the backward pass correctly differentiates with respect to both input and target tensors using sigmoid gradients. The change follows the existing pattern for loss functions like `l1_loss`, `bce_with_logits`, and `poisson_nll`, wiring the new operation through the autograd re-export chain and exposing it via the `coeus-nn` API. Comprehensive tests verify both forward computation and dual-gradient correctness against an independent f64 oracle.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/soft_margin.rs` |
| 2 | `coeus-nn/tests/nn_loss_tests.rs` |
| 3 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 4 | `coeus-autograd/src/ops/nn/mod.rs` |
| 5 | `coeus-autograd/src/ops/mod.rs` |
| 6 | `coeus-autograd/src/lib.rs` |
| 7 | `coeus-nn/src/loss.rs` |
| 8 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->