### PR TITLE
MS-196: add InstanceNorm2d benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,12 @@
   Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion group.
   Short local run medians: Burn 3.44–4.17 ms, Coeus Sequential 3.39–4.14 ms,
   Coeus Moirai 2.99–3.68 ms. ([patch])
+- **NN benchmark matrix expansion (InstanceNorm2d forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with an InstanceNorm2d forward row
+  (`[2,32,16,16]`), comparing Burn NdArray against Coeus `SequentialBackend`
+  and `MoiraiBackend` in the same Criterion group. Short local run medians:
+  Burn 42.84–44.61 µs, Coeus Sequential 123.04–129.59 µs,
+  Coeus Moirai 165.21–186.95 µs (gap logged as optimization target). ([patch])
 - **NN benchmark matrix expansion (AvgPool2d forward)** — extended
   `coeus-nn/benches/nn_bench.rs` with an AvgPool2d forward row
   (`[8,16,32,32]`, `k=2`, `s=2`), comparing Burn NdArray against Coeus

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -20,8 +20,8 @@ use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
     AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
-    LayerNorm, Linear, Lstm, MaxPool2d, Module, MultiHeadAttention, NullMask, RMSNorm,
-    TransformerEncoderLayer,
+    InstanceNorm2d, LayerNorm, Linear, Lstm, MaxPool2d, Module, MultiHeadAttention, NullMask,
+    RMSNorm, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -32,8 +32,8 @@ use burn::nn::conv::Conv2dConfig;
 use burn::nn::conv::Conv3dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
 use burn::nn::{
-    BatchNormConfig, GroupNormConfig, LayerNormConfig, LinearConfig, LstmConfig, PaddingConfig1d,
-    PaddingConfig2d, PaddingConfig3d, RmsNormConfig,
+    BatchNormConfig, GroupNormConfig, InstanceNormConfig, LayerNormConfig, LinearConfig, LstmConfig,
+    PaddingConfig1d, PaddingConfig2d, PaddingConfig3d, RmsNormConfig,
 };
 use burn::tensor::{Int, Tensor as BurnTensor, TensorData};
 type BurnB = NdArray<f32>;
@@ -840,6 +840,54 @@ fn bench_lstm_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_instancenorm2d_forward(c: &mut Criterion) {
+    // InstanceNorm2d forward on [N=2, C=32, H=16, W=16].
+    const IN_N: usize = 2;
+    const IN_C: usize = 32;
+    const IN_H: usize = 16;
+    const IN_W: usize = 16;
+
+    let device = NdArrayDevice::default();
+    let input_data: Vec<f32> = (0..(IN_N * IN_C * IN_H * IN_W))
+        .map(|i| (i as f32 * 0.0027).cos())
+        .collect();
+
+    // Burn: InstanceNormConfig(num_channels).
+    let burn_in = InstanceNormConfig::new(IN_C).init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 4> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [IN_N, IN_C, IN_H, IN_W]),
+        &device,
+    );
+
+    // Coeus: InstanceNorm2d::new(num_features, eps).
+    let in_seq = InstanceNorm2d::<f32, SequentialBackend>::new(IN_C, 1e-5);
+    let in_moirai = InstanceNorm2d::<f32, MoiraiBackend>::new(IN_C, 1e-5);
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(
+            vec![IN_N, IN_C, IN_H, IN_W],
+            &input_data,
+        ),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![IN_N, IN_C, IN_H, IN_W], &input_data),
+        false,
+    );
+
+    let mut group =
+        c.benchmark_group("Burn vs Coeus — InstanceNorm2d forward (2x32x16x16)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_in.forward(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(in_seq.forward(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(in_moirai.forward(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -858,6 +906,7 @@ criterion_group!(
     bench_transformer_encoder_forward,
     bench_embedding_forward,
     bench_linear_forward_backward,
-    bench_lstm_forward
+    bench_lstm_forward,
+    bench_instancenorm2d_forward
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,19 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-196: InstanceNorm2d benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus forward benchmark row for InstanceNorm2d in
+  `coeus-nn/benches/nn_bench.rs` on `[2,32,16,16]`, comparing Burn NdArray,
+  Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the InstanceNorm2d row in the Criterion benchmark group.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043 and
+  added a changelog entry for the new benchmark row.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench --
+  InstanceNorm2d --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
 ## Sprint MS-195: LSTM benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for LSTM in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,24 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-195 - LSTM benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-196 - InstanceNorm2d benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an InstanceNorm2d
+forward row so one additional implemented NN family is measured across Burn NdArray
+and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_instancenorm2d_forward` in
+  `coeus-nn/benches/nn_bench.rs` for `[2,32,16,16]`.
+- [x] [patch] Benchmarks Burn NdArray InstanceNorm2d forward vs Coeus
+  `InstanceNorm2d::<_, SequentialBackend>` and `InstanceNorm2d::<_, MoiraiBackend>`
+  and registers the row in `criterion_group!`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: `cargo check -p coeus-nn --all-targets`; `cargo clippy -p
+  coeus-nn --all-targets -- -D warnings`; `cargo bench -p coeus-nn --bench
+  nn_bench --no-run`; `cargo bench -p coeus-nn --bench nn_bench --
+  InstanceNorm2d --warm-up-time 1 --measurement-time 2 --sample-size 10`.
+
+### Previous Sprint: MS-195 - LSTM benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an LSTM forward
 row so one additional implemented NN family is measured across Burn NdArray and
 both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,11 +8,11 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, RMSNorm, LSTM, Conv2d, Conv3d, MHA self-attention, Transformer encoder
-layer, Embedding lookup, BatchNorm1d eval forward, BatchNorm2d eval forward,
-BatchNorm3d eval forward, Conv1d forward, GroupNorm forward, MaxPool2d forward,
-AvgPool2d forward), not the full NN family set needed to claim Burn-level
-performance parity.
+(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, Conv2d, Conv3d, MHA
+self-attention, Transformer encoder layer, Embedding lookup, BatchNorm1d eval
+forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
+GroupNorm forward, MaxPool2d forward, AvgPool2d forward), not the full NN family
+set needed to claim Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add
 rows for every newly implemented G-035..G-042 family with Coeus sequential,


### PR DESCRIPTION
Expand the G-043 benchmark matrix with an InstanceNorm2d forward row [2,32,16,16] in coeus-nn/benches/nn_bench.rs, register it in the criterion group, and update G-043 tracking docs/changelog for MS-196.

Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- InstanceNorm2d --warm-up-time 1 --measurement-time 2 --sample-size 10.

Medians: Burn 42.84-44.61 us, Coeus Sequential 123.04-129.59 us, Coeus Moirai 165.21-186.95 us (gap logged as optimization target).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR expands the neural network benchmark matrix by adding an `InstanceNorm2d` forward pass benchmark row with input shape `[2,32,16,16]`. The benchmark compares Burn NdArray implementation against Coeus `SequentialBackend` and `MoiraiBackend`, and includes corresponding documentation updates across the changelog, backlog, checklist, and gap audit tracking files. Local benchmark runs show Burn performing at 42.84–44.61 µs, while Coeus Sequential runs at 123.04–129.59 µs and Coeus Moirai at 165.21–186.95 µs, with the performance gap logged as an optimization target.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `docs/backlog.md` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
| 4 | `docs/gap_audit.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new InstanceNorm2d forward benchmark, comparing Burn and Coeus backends on a 2×32×16×16 input.
  * Expanded the benchmark matrix with additional performance data and recorded timings.

* **Documentation**
  * Updated the changelog with the new benchmark entry.
  * Refreshed planning and audit docs to reflect the latest sprint status and benchmark evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->