### PR TITLE
MS-197: add CrossEntropyLoss benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,12 @@
   Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion group.
   Short local run medians: Burn 3.44–4.17 ms, Coeus Sequential 3.39–4.14 ms,
   Coeus Moirai 2.99–3.68 ms. ([patch])
+- **NN benchmark matrix expansion (CrossEntropyLoss)** — extended
+  `coeus-nn/benches/nn_bench.rs` with a cross-entropy loss row
+  (`logits [128,10]`), comparing Burn NdArray against Coeus `SequentialBackend`
+  and `MoiraiBackend` in the same Criterion group. Short local run medians:
+  Burn 9.70–10.38 µs, Coeus Sequential 3.68–4.00 µs, Coeus Moirai 3.61–4.06 µs
+  (Coeus ~2.6× faster). ([patch])
 - **NN benchmark matrix expansion (InstanceNorm2d forward)** — extended
   `coeus-nn/benches/nn_bench.rs` with an InstanceNorm2d forward row
   (`[2,32,16,16]`), comparing Burn NdArray against Coeus `SequentialBackend`

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,9 +19,9 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d, Embedding, GroupNorm,
-    InstanceNorm2d, LayerNorm, Linear, Lstm, MaxPool2d, Module, MultiHeadAttention, NullMask,
-    RMSNorm, TransformerEncoderLayer,
+    cross_entropy_loss, AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d,
+    Embedding, GroupNorm, InstanceNorm2d, LayerNorm, Linear, Lstm, MaxPool2d, Module,
+    MultiHeadAttention, NullMask, RMSNorm, TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -31,6 +31,7 @@ use burn::nn::conv::Conv1dConfig;
 use burn::nn::conv::Conv2dConfig;
 use burn::nn::conv::Conv3dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
+use burn::nn::loss::{CrossEntropyLoss, CrossEntropyLossConfig};
 use burn::nn::{
     BatchNormConfig, GroupNormConfig, InstanceNormConfig, LayerNormConfig, LinearConfig, LstmConfig,
     PaddingConfig1d, PaddingConfig2d, PaddingConfig3d, RmsNormConfig,
@@ -888,6 +889,54 @@ fn bench_instancenorm2d_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_cross_entropy_loss(c: &mut Criterion) {
+    // Cross-entropy loss on logits [BATCH=128, num_classes=10].
+    const CE_N: usize = 128;
+    const CE_C: usize = 10;
+
+    let device = NdArrayDevice::default();
+    let logit_data: Vec<f32> = (0..(CE_N * CE_C))
+        .map(|i| (i as f32 * 0.0041).sin())
+        .collect();
+    let targets: Vec<usize> = (0..CE_N).map(|i| i % CE_C).collect();
+    let targets_i64: Vec<i64> = targets.iter().map(|&t| t as i64).collect();
+
+    // Burn: CrossEntropyLossConfig(no pad).forward(logits [N,C], targets [N, Int]).
+    let burn_ce: CrossEntropyLoss<BurnB> = CrossEntropyLossConfig::new().init(&device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(logit_data.clone(), [CE_N, CE_C]),
+        &device,
+    );
+    let t_burn: BurnTensor<BurnB, 1, Int> = BurnTensor::from_data(
+        TensorData::new(targets_i64, [CE_N]),
+        &device,
+    );
+
+    // Coeus: cross_entropy_loss(logits, &targets).
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![CE_N, CE_C], &logit_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![CE_N, CE_C], &logit_data),
+        false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — CrossEntropyLoss (128x10)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn_ce.forward(black_box(x_burn.clone()), black_box(t_burn.clone())))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(cross_entropy_loss(black_box(&x_seq), black_box(&targets))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(cross_entropy_loss(black_box(&x_moirai), black_box(&targets))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -907,6 +956,7 @@ criterion_group!(
     bench_embedding_forward,
     bench_linear_forward_backward,
     bench_lstm_forward,
-    bench_instancenorm2d_forward
+    bench_instancenorm2d_forward,
+    bench_cross_entropy_loss
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,16 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-197: CrossEntropyLoss benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus benchmark row for CrossEntropyLoss in
+  `coeus-nn/benches/nn_bench.rs` on logits `[128,10]`, comparing Burn NdArray,
+  Coeus `SequentialBackend`, and Coeus `MoiraiBackend`.
+- [x] [patch] Registered the CrossEntropyLoss row in the Criterion benchmark group.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043.
+- [x] Evidence: full validation gates passed. Coeus ~2.6× faster than Burn:
+  Burn 9.70–10.38 µs, Coeus Sequential 3.68–4.00 µs, Coeus Moirai 3.61–4.06 µs.
+
 ## Sprint MS-196: InstanceNorm2d benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus forward benchmark row for InstanceNorm2d in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,21 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-196 - InstanceNorm2d benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-197 - CrossEntropyLoss benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a CrossEntropyLoss
+row so the loss computation family is measured against Burn NdArray and both Coeus
+CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_cross_entropy_loss` in `coeus-nn/benches/nn_bench.rs`
+  for logits `[128,10]`.
+- [x] [patch] Benchmarks Burn NdArray CrossEntropyLoss vs Coeus
+  `cross_entropy_loss` on `SequentialBackend` and `MoiraiBackend`.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: cargo check/clippy/bench-no-run all passed; benchmark run confirms
+  Coeus ~2.6× faster than Burn NdArray (Burn 9.70–10.38 µs, Coeus ~3.7–4.1 µs).
+
+### Previous Sprint: MS-196 - InstanceNorm2d benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an InstanceNorm2d
 forward row so one additional implemented NN family is measured across Burn NdArray
 and both Coeus CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,9 +8,9 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, Conv2d, Conv3d, MHA
-self-attention, Transformer encoder layer, Embedding lookup, BatchNorm1d eval
-forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
+(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, CrossEntropyLoss, Conv2d,
+Conv3d, MHA self-attention, Transformer encoder layer, Embedding lookup, BatchNorm1d
+eval forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
 GroupNorm forward, MaxPool2d forward, AvgPool2d forward), not the full NN family
 set needed to claim Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.


### PR DESCRIPTION
Expand the G-043 benchmark matrix with a CrossEntropyLoss row (logits [128,10]) in coeus-nn/benches/nn_bench.rs, register it in the criterion group, and update G-043 tracking docs/changelog for MS-197.

Validation: cargo check -p coeus-nn --all-targets; cargo clippy -p coeus-nn --all-targets -- -D warnings; cargo bench -p coeus-nn --bench nn_bench --no-run; cargo bench -p coeus-nn --bench nn_bench -- CrossEntropy --warm-up-time 1 --measurement-time 2 --sample-size 10.

Medians: Burn 9.70-10.38 us, Coeus Sequential 3.68-4.00 us, Coeus Moirai 3.61-4.06 us (Coeus ~2.6x faster).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a **CrossEntropyLoss** benchmark to the existing NN benchmark matrix, comparing Burn's NdArray implementation against Coeus's SequentialBackend and MoiraiBackend. The benchmark uses logits of shape `[128,10]` and demonstrates that Coeus is approximately 2.6x faster than Burn (Burn: 9.70-10.38 µs, Coeus: 3.61-4.06 µs). The changes include the new benchmark function in `nn_bench.rs`, registration in the criterion group, and corresponding documentation updates across changelog, backlog, checklist, and gap audit files to track the MS-197 milestone completion.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->