### PR TITLE
MS-198: add MSELoss benchmark row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,7 +207,12 @@
   Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion group.
   Short local run medians: Burn 3.44–4.17 ms, Coeus Sequential 3.39–4.14 ms,
   Coeus Moirai 2.99–3.68 ms. ([patch])
-- **NN benchmark matrix expansion (CrossEntropyLoss)** — extended
+- **NN benchmark matrix expansion (MSELoss)** — extended
+  `coeus-nn/benches/nn_bench.rs` with an MSE loss row
+  (`predictions [128,64]` vs same-shape targets), comparing Burn NdArray against
+  Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion group.
+  Short local run medians: Burn 2.26–2.42 µs, Coeus Sequential 2.28–2.55 µs,
+  Coeus Moirai 2.20–2.38 µs (all three backends at parity). ([patch])- **NN benchmark matrix expansion (CrossEntropyLoss)** — extended
   `coeus-nn/benches/nn_bench.rs` with a cross-entropy loss row
   (`logits [128,10]`), comparing Burn NdArray against Coeus `SequentialBackend`
   and `MoiraiBackend` in the same Criterion group. Short local run medians:

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,7 +19,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    cross_entropy_loss, AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d,
+    cross_entropy_loss, mse_loss, AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d,
     Embedding, GroupNorm, InstanceNorm2d, LayerNorm, Linear, Lstm, MaxPool2d, Module,
     MultiHeadAttention, NullMask, RMSNorm, TransformerEncoderLayer,
 };
@@ -31,7 +31,7 @@ use burn::nn::conv::Conv1dConfig;
 use burn::nn::conv::Conv2dConfig;
 use burn::nn::conv::Conv3dConfig;
 use burn::nn::transformer::{TransformerEncoderConfig, TransformerEncoderInput};
-use burn::nn::loss::{CrossEntropyLoss, CrossEntropyLossConfig};
+use burn::nn::loss::{CrossEntropyLoss, CrossEntropyLossConfig, MseLoss, Reduction};
 use burn::nn::{
     BatchNormConfig, GroupNormConfig, InstanceNormConfig, LayerNormConfig, LinearConfig, LstmConfig,
     PaddingConfig1d, PaddingConfig2d, PaddingConfig3d, RmsNormConfig,
@@ -937,6 +937,51 @@ fn bench_cross_entropy_loss(c: &mut Criterion) {
     group.finish();
 }
 
+
+fn bench_mse_loss(c: &mut Criterion) {
+    const MSE_N: usize = 128;
+    const MSE_D: usize = 64;
+
+    let device = NdArrayDevice::default();
+    let pred_data: Vec<f32> = (0..(MSE_N * MSE_D))
+        .map(|i| (i as f32 * 0.0037).sin())
+        .collect();
+    let target_data: Vec<f32> = (0..(MSE_N * MSE_D))
+        .map(|i| (i as f32 * 0.0041).cos())
+        .collect();
+
+    let burn_mse = MseLoss::new();
+    let p_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(pred_data.clone(), [MSE_N, MSE_D]), &device,
+    );
+    let t_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(target_data.clone(), [MSE_N, MSE_D]), &device,
+    );
+    let p_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![MSE_N, MSE_D], &pred_data), false,
+    );
+    let t_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![MSE_N, MSE_D], &target_data), false,
+    );
+    let p_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![MSE_N, MSE_D], &pred_data), false,
+    );
+    let t_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![MSE_N, MSE_D], &target_data), false,
+    );
+
+    let mut group = c.benchmark_group("Burn vs Coeus — MSELoss (128x64)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn_mse.forward(black_box(p_burn.clone()), black_box(t_burn.clone()), Reduction::Mean)))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(mse_loss(black_box(&p_seq), black_box(&t_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(mse_loss(black_box(&p_moirai), black_box(&t_moirai))))
+    });
+    group.finish();
+}
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -957,6 +1002,7 @@ criterion_group!(
     bench_linear_forward_backward,
     bench_lstm_forward,
     bench_instancenorm2d_forward,
-    bench_cross_entropy_loss
+    bench_cross_entropy_loss,
+    bench_mse_loss
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,15 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-198: MSELoss benchmark matrix expansion [COMPLETE]
+
+- [x] [patch] Added a Burn-vs-Coeus MSE loss benchmark row in
+  `coeus-nn/benches/nn_bench.rs` on predictions `[128,64]` vs targets.
+- [x] [patch] Registered the MSELoss row in the Criterion benchmark group.
+- [x] [patch] Updated `docs/gap_audit.md` selected-row detail for G-043.
+- [x] Evidence: cargo check/clippy/bench-no-run all passed; benchmark run confirms
+  all three backends at parity: Burn 2.26-2.42 us, Coeus Sequential 2.28-2.55 us,
+  Coeus Moirai 2.20-2.38 us.
 ## Sprint MS-197: CrossEntropyLoss benchmark matrix expansion [COMPLETE]
 
 - [x] [patch] Added a Burn-vs-Coeus benchmark row for CrossEntropyLoss in

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,7 +2,18 @@
 
 ## Active Epic: Burn Parity, GPU Audit & Python Surface Expansion
 
-### Current Sprint: MS-197 - CrossEntropyLoss benchmark matrix expansion [COMPLETE]
+### Current Sprint: MS-198 - MSELoss benchmark matrix expansion [COMPLETE]
+**Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with an MSE loss row
+comparing Burn NdArray and both Coeus CPU backends.
+**Target version**: 0.5.4 (benchmark/docs [patch]).
+
+- [x] [patch] Added `bench_mse_loss` in `coeus-nn/benches/nn_bench.rs` for
+  predictions `[128,64]` vs same-shape targets.
+- [x] [patch] Updated G-043 selected-row detail in `docs/gap_audit.md`.
+- [x] Evidence: cargo check/clippy/bench-no-run passed; benchmark confirms
+  all three backends at parity (~2.3 us each).
+
+### Previous Sprint: MS-197 - CrossEntropyLoss benchmark matrix expansion [COMPLETE] - CrossEntropyLoss benchmark matrix expansion [COMPLETE]
 **Objective**: Expand the Burn-vs-Coeus NN benchmark matrix with a CrossEntropyLoss
 row so the loss computation family is measured against Burn NdArray and both Coeus
 CPU backends.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,7 +8,7 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, CrossEntropyLoss, Conv2d,
+(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, CrossEntropyLoss, MSELoss, Conv2d,
 Conv3d, MHA self-attention, Transformer encoder layer, Embedding lookup, BatchNorm1d
 eval forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
 GroupNorm forward, MaxPool2d forward, AvgPool2d forward), not the full NN family


### PR DESCRIPTION
Expand the G-043 benchmark matrix with an MSE loss row (predictions [128,64] vs targets) in coeus-nn/benches/nn_bench.rs and update G-043 tracking docs/changelog for MS-198. All three backends at parity: Burn 2.26-2.42 us, Coeus Sequential 2.28-2.55 us, Coeus Moirai 2.20-2.38 us.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR expands the neural network benchmark matrix by adding an MSE (Mean Squared Error) loss benchmark row to compare Burn NdArray against Coeus `SequentialBackend` and `MoiraiBackend`. The new benchmark measures performance on predictions of shape `[128,64]` versus targets, with all three backends showing parity (approximately 2.2-2.5 microseconds). The change includes updating the benchmark file, changelog, and tracking documentation for milestone MS-198.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/checklist.md` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->