### PR TITLE
feat(nn): Add PairwiseDistance for G-038

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -111,6 +111,7 @@ pub use ops::{
     // New unary math ops
     neg,
     nll_loss,
+    pairwise_distance,
     poisson_nll,
     soft_margin,
     norm,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -35,7 +35,7 @@ pub use nn::{
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
     conv_transpose3d, cosine_embedding_loss,
     cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
-    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
+    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -16,6 +16,8 @@ pub mod l1;
 pub mod margin_ranking;
 /// Negative log-likelihood loss.
 pub mod nll;
+/// Row-wise p-norm pairwise distance.
+pub mod pairwise_distance;
 /// Poisson negative-log-likelihood loss.
 pub mod poisson_nll;
 /// Soft-margin (logistic) loss.
@@ -30,5 +32,6 @@ pub use kl_div::{kl_divergence, KlDivLossNode};
 pub use l1::{l1_loss, L1LossNode};
 pub use margin_ranking::{margin_ranking_loss, MarginRankingLossNode};
 pub use nll::{nll_loss, NllLossNode};
+pub use pairwise_distance::{pairwise_distance, PairwiseDistanceNode};
 pub use poisson_nll::{poisson_nll, PoissonNllNode};
 pub use soft_margin::{soft_margin, SoftMarginNode};

--- a/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs
+++ b/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs
@@ -1,0 +1,185 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for the row-wise p-norm pairwise distance.
+pub struct PairwiseDistanceNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node (shape `[N]`).
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Per-element `d(distance_i)/d(diff_ik)` factors, row-major `[N*D]`.
+    pub grad_unit: Vec<T>,
+    /// Number of rows `N`.
+    pub rows: usize,
+    /// Feature dimension `D`.
+    pub feat: usize,
+    /// Input shape `[N, D]` for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for PairwiseDistanceNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "pairwise_distance"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        let mut g_rows = vec![T::zero(); self.rows];
+        backend.copy_to_host(grad_cont.storage(), &mut g_rows);
+
+        let want_x1 = matches!(input_grads.first(), Some(Some(_)));
+        let want_x2 = matches!(input_grads.get(1), Some(Some(_)));
+        if !want_x1 && !want_x2 {
+            return;
+        }
+
+        let mut dx1 = vec![T::zero(); self.rows * self.feat];
+        for i in 0..self.rows {
+            let gi = g_rows[i];
+            let base = i * self.feat;
+            for k in 0..self.feat {
+                dx1[base + k] = gi * self.grad_unit[base + k];
+            }
+        }
+
+        if let Some(Some(ref g)) = input_grads.first() {
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx1, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut dx2 = dx1;
+            for v in &mut dx2 {
+                *v = T::zero() - *v;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx2, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked row-wise p-norm pairwise distance (PyTorch `PairwiseDistance`):
+/// for inputs `x1, x2` of shape `[N, D]`, returns a `[N]` vector with
+/// `out_i = (sum_k |x1_ik - x2_ik|^p + eps)^(1/p)`.
+pub fn pairwise_distance<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x1: &Var<T, B>,
+    x2: &Var<T, B>,
+    p: T,
+    eps: T,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        x1.tensor.shape(),
+        x2.tensor.shape(),
+        "pairwise_distance requires x1 and x2 to have identical shapes"
+    );
+    let shape_ref = x1.tensor.shape();
+    assert_eq!(shape_ref.len(), 2, "pairwise_distance expects 2D [N, D] inputs");
+    let rows = shape_ref[0];
+    let feat = shape_ref[1];
+    let n = rows * feat;
+    let shape = x1.tensor.shape_cloned();
+
+    let x1_cont;
+    let x1_raw = if x1.tensor.is_contiguous() && x1.tensor.layout().offset() == 0 {
+        &x1.tensor
+    } else {
+        x1_cont = x1.tensor.to_contiguous_on(&backend);
+        &x1_cont
+    };
+    let x2_cont;
+    let x2_raw = if x2.tensor.is_contiguous() && x2.tensor.layout().offset() == 0 {
+        &x2.tensor
+    } else {
+        x2_cont = x2.tensor.to_contiguous_on(&backend);
+        &x2_cont
+    };
+
+    let x1_host: std::borrow::Cow<[T]> = if let Some(s) = x1_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(x1_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let x2_host: std::borrow::Cow<[T]> = if let Some(s) = x2_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(x2_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let one = T::one();
+    let inv_p = one / p;
+    let p_minus_one = p - one;
+    let mut out = vec![T::zero(); rows];
+    let mut grad_unit = vec![T::zero(); n];
+    for i in 0..rows {
+        let base = i * feat;
+        let mut s = T::zero();
+        for k in 0..feat {
+            let diff = x1_host[base + k] - x2_host[base + k];
+            s = s + diff.abs().powf(p);
+        }
+        let s_eps = s + eps;
+        out[i] = s_eps.powf(inv_p);
+        let scale = s_eps.powf(inv_p - one);
+        for k in 0..feat {
+            let diff = x1_host[base + k] - x2_host[base + k];
+            let mag = diff.abs().powf(p_minus_one);
+            let sign = if diff > T::zero() {
+                one
+            } else if diff < T::zero() {
+                T::zero() - one
+            } else {
+                T::zero()
+            };
+            grad_unit[base + k] = scale * mag * sign;
+        }
+    }
+
+    let out_tensor = Tensor::from_slice_on([rows], &out, &backend);
+    let requires_grad =
+        crate::grad_mode::should_track_var(x1) || crate::grad_mode::should_track_var(x2);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([rows], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = PairwiseDistanceNode {
+            output_grad,
+            inputs: vec![x1.clone(), x2.clone()],
+            grad_unit,
+            rows,
+            feat,
+            shape,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var { tensor: out_tensor, grad, creator }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -23,7 +23,7 @@ pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, nll_loss, poisson_nll, soft_margin,
+    kl_divergence, l1_loss, margin_ranking_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -85,7 +85,7 @@ pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, poisson_nll, soft_margin,
+    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -174,6 +174,18 @@ pub fn soft_margin<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::soft_margin(input, target)
 }
 
+/// Row-wise p-norm pairwise distance (PyTorch `PairwiseDistance`).
+/// x1, x2: `[N, D]`; returns `[N]` with `out_i = (sum_k |x1-x2|^p + eps)^(1/p)`.
+#[inline]
+pub fn pairwise_distance<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x1: &Var<T, B>,
+    x2: &Var<T, B>,
+    p: T,
+    eps: T,
+) -> Var<T, B> {
+    coeus_autograd::pairwise_distance(x1, x2, p, eps)
+}
+
 /// KL divergence loss.
 ///
 /// `input` is log-probabilities and `target` is probabilities. Computes

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -2,7 +2,7 @@ use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, nll_loss, poisson_nll, soft_margin,
+    l1_loss, margin_ranking_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin,
 };
 use coeus_tensor::Tensor;
 
@@ -360,6 +360,36 @@ fn test_soft_margin() {
             (gt - exp_gt).abs() <= 1e-12,
             "soft_margin d/d_target[{i}]: got {gt:.17}, expected {exp_gt:.17}"
         );
+    }
+}
+
+#[test]
+fn test_pairwise_distance() {
+    let p = 2.0_f64;
+    let eps = 1e-6_f64;
+    let x1 = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([2, 2], &[1.0, 2.0, 3.0, 4.0]), true);
+    let x2 = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([2, 2], &[0.0, 0.0, 1.0, 1.0]), true);
+    let dist = pairwise_distance(&x1, &x2, p, eps);
+    assert_eq!(dist.tensor.shape(), &[2]);
+    let diffs = [[1.0_f64, 2.0], [2.0, 3.0]];
+    let s: Vec<f64> = diffs.iter().map(|r| r.iter().map(|d| d.abs().powf(p)).sum::<f64>()).collect();
+    let out = dist.tensor.as_slice();
+    for i in 0..2 {
+        let exp = (s[i] + eps).powf(1.0 / p);
+        assert!((out[i] - exp).abs() <= 1e-12, "pd fwd {}", i);
+    }
+    let total = coeus_autograd::sum(&dist);
+    total.backward();
+    let g1 = x1.grad().expect("x1 grad");
+    let g2 = x2.grad().expect("x2 grad");
+    for i in 0..2 {
+        let scale = (s[i] + eps).powf(1.0 / p - 1.0);
+        for k in 0..2 {
+            let d = diffs[i][k];
+            let eg = scale * d.abs().powf(p - 1.0) * d.signum();
+            assert!((g1.as_slice()[i * 2 + k] - eg).abs() <= 1e-12, "pd gx1 {} {}", i, k);
+            assert!((g2.as_slice()[i * 2 + k] + eg).abs() <= 1e-12, "pd gx2 {} {}", i, k);
+        }
     }
 }
 


### PR DESCRIPTION
Implements PairwiseDistance from the G-038 loss/distance parity gap.

## Change
- Row-wise p-norm distance `out_i = (sum_k |x1_ik - x2_ik|^p + eps)^(1/p)` for `[N,D]` inputs → `[N]` (PyTorch `PairwiseDistance`). First vector-output op in the loss family; backward reads `[N]` grad_out, distributes per row. Differentiable w.r.t. both inputs.
- Wired through the autograd re-export chain + thin coeus-nn delegate.

## Verification
Value-semantic test: forward + dual-gradient (through a sum reduction) vs an independent f64 oracle. `cargo nextest run -p coeus-nn --test nn_loss_tests` pairwise test: 1/1 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the `PairwiseDistance` operator to close the G-038 loss/distance parity gap. The implementation computes row-wise p-norm distances between paired `[N,D]` input tensors, producing an `[N]` output where each element is `(sum_k |x1_ik - x2_ik|^p + eps)^(1/p)`. The operator is differentiable with respect to both inputs, with backward propagation distributing gradients per row. The changes include the core autograd node with gradient computation logic, integration through the autograd and neural network API layers via re-exports, and comprehensive value-semantic tests validating both forward computation and dual-gradient propagation against an independent f64 oracle.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/nn_loss_tests.rs` |
| 2 | `coeus-autograd/src/ops/nn/loss/pairwise_distance.rs` |
| 3 | `coeus-nn/src/loss.rs` |
| 4 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 5 | `coeus-autograd/src/ops/nn/mod.rs` |
| 6 | `coeus-autograd/src/ops/mod.rs` |
| 7 | `coeus-autograd/src/lib.rs` |
| 8 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pairwise distance loss, available from the public API.
  * Supports forward computation with configurable `p` and `eps`, plus gradient propagation for both inputs.

* **Bug Fixes**
  * Expanded test coverage to verify the new loss’s output and backward gradients.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->