### PR TITLE
feat(nn): Add TripletMargin loss for G-038

### DIFF
--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -85,7 +85,7 @@ pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin,
+    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -186,6 +186,27 @@ pub fn pairwise_distance<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::pairwise_distance(x1, x2, p, eps)
 }
 
+/// Triplet-margin loss (PyTorch `TripletMarginLoss`, `reduction="mean"`):
+/// `mean_i max(0, d(a_i, p_i) - d(a_i, n_i) + margin)` where `d` is the
+/// row-wise p-norm [`pairwise_distance`]. anchor/positive/negative share shape
+/// `[N, D]`. Composed from the tracked pairwise-distance, subtract, shift, ReLU,
+/// and mean ops, so backward (including the anchor's two gradient paths) is the
+/// autograd graph's — no bespoke node.
+#[inline]
+pub fn triplet_margin_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    anchor: &Var<T, B>,
+    positive: &Var<T, B>,
+    negative: &Var<T, B>,
+    margin: T,
+    p: T,
+    eps: T,
+) -> Var<T, B> {
+    let d_ap = coeus_autograd::pairwise_distance(anchor, positive, p, eps);
+    let d_an = coeus_autograd::pairwise_distance(anchor, negative, p, eps);
+    let shifted = coeus_autograd::scalar_add(&coeus_autograd::sub(&d_ap, &d_an), margin);
+    coeus_autograd::mean(&coeus_autograd::relu(&shifted))
+}
+
 /// KL divergence loss.
 ///
 /// `input` is log-probabilities and `target` is probabilities. Computes

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -2,7 +2,7 @@ use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin,
+    l1_loss, margin_ranking_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
 };
 use coeus_tensor::Tensor;
 
@@ -391,6 +391,52 @@ fn test_pairwise_distance() {
             assert!((g2.as_slice()[i * 2 + k] + eg).abs() <= 1e-12, "pd gx2 {} {}", i, k);
         }
     }
+}
+
+#[test]
+fn test_triplet_margin_loss() {
+    // anchor=[0,0], positive=[2,0], negative=[0,2.5], margin=1, p=2, eps=0.
+    // d_ap=2, d_an=2.5, hinge=max(0, 2 - 2.5 + 1)=0.5 (active) → loss=0.5.
+    // grads (N=1): d/anchor=[-1,1], d/positive=[1,0], d/negative=[0,-1].
+    let anchor = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[0.0, 0.0]), true);
+    let positive = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[2.0, 0.0]), true);
+    let negative = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[0.0, 2.5]), true);
+
+    let loss = triplet_margin_loss(&anchor, &positive, &negative, 1.0, 2.0, 0.0);
+    assert_eq!(loss.tensor.shape(), &[1]);
+    assert!(
+        (loss.tensor.as_slice()[0] - 0.5).abs() <= 1e-12,
+        "triplet forward: got {}, expected 0.5",
+        loss.tensor.as_slice()[0]
+    );
+
+    loss.backward();
+    let ga = anchor.grad().expect("anchor grad");
+    let gp = positive.grad().expect("positive grad");
+    let gn = negative.grad().expect("negative grad");
+    let approx = |a: &[f64], b: [f64; 2], who: &str| {
+        for k in 0..2 {
+            assert!(
+                (a[k] - b[k]).abs() <= 1e-12,
+                "triplet d/d_{who}[{k}]: got {}, expected {}",
+                a[k],
+                b[k]
+            );
+        }
+    };
+    approx(ga.as_slice(), [-1.0, 1.0], "anchor");
+    approx(gp.as_slice(), [1.0, 0.0], "positive");
+    approx(gn.as_slice(), [0.0, -1.0], "negative");
+}
+
+#[test]
+fn test_triplet_margin_loss_inactive() {
+    // Easy triplet (d_ap << d_an by more than margin) → hinge 0, loss 0.
+    let anchor = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[0.0, 0.0]), false);
+    let positive = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[0.5, 0.0]), false);
+    let negative = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[5.0, 0.0]), false);
+    let loss = triplet_margin_loss(&anchor, &positive, &negative, 1.0, 2.0, 0.0);
+    assert_eq!(loss.tensor.as_slice(), &[0.0_f64], "easy triplet → loss 0");
 }
 
 #[test]


### PR DESCRIPTION
Implements TripletMarginLoss from the G-038 loss/distance parity gap.

## Change
- `triplet_margin_loss(a, p, n, margin, p_norm, eps)` = `mean_i max(0, d(a_i,p_i) - d(a_i,n_i) + margin)` (PyTorch `TripletMarginLoss`, `reduction="mean"`).
- **Composed** from the tracked `pairwise_distance`/`sub`/`scalar_add`/`relu`/`mean` autograd ops — backward (incl. the anchor's two gradient paths) is the autograd DAG's, no bespoke node (DRY, mirrors `mse_loss`). coeus-nn loss layer only.

## Verification
Value-semantic tests: active triplet (forward 0.5 + all three input gradients `[-1,1]/[1,0]/[0,-1]`, exercising dual-path anchor accumulation) and an inactive (easy) triplet → 0. `cargo nextest run -p coeus-nn --test nn_loss_tests` triplet tests: 2/2 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the `triplet_margin_loss` function to address the G-038 loss/distance parity gap. The implementation computes `mean(max(0, d(anchor, positive) - d(anchor, negative) + margin))` where `d` is the pairwise p-norm distance. The function is composed from existing tracked autograd operations (`pairwise_distance`, `sub`, `scalar_add`, `relu`, `mean`), allowing automatic differentiation through the computation graph without requiring a custom backward pass. This mirrors the design pattern used for `mse_loss` in the codebase.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/loss.rs` |
| 2 | `coeus-nn/tests/nn_loss_tests.rs` |
| 3 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->