### PR TITLE
feat(nn): Add MultiMargin loss for G-038

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -110,6 +110,7 @@ pub use ops::{
     mul,
     // New unary math ops
     neg,
+    multi_margin,
     nll_loss,
     pairwise_distance,
     poisson_nll,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -35,7 +35,7 @@ pub use nn::{
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
     conv_transpose3d, cosine_embedding_loss,
     cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
-    margin_ranking_loss, max_pool2d, max_pool3d, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
+    margin_ranking_loss, max_pool2d, max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -14,6 +14,8 @@ pub mod kl_div;
 pub mod l1;
 /// Margin ranking loss.
 pub mod margin_ranking;
+/// Multi-class margin loss.
+pub mod multi_margin;
 /// Negative log-likelihood loss.
 pub mod nll;
 /// Row-wise p-norm pairwise distance.
@@ -31,6 +33,7 @@ pub use huber::{huber_loss, HuberLossNode};
 pub use kl_div::{kl_divergence, KlDivLossNode};
 pub use l1::{l1_loss, L1LossNode};
 pub use margin_ranking::{margin_ranking_loss, MarginRankingLossNode};
+pub use multi_margin::{multi_margin, MultiMarginNode};
 pub use nll::{nll_loss, NllLossNode};
 pub use pairwise_distance::{pairwise_distance, PairwiseDistanceNode};
 pub use poisson_nll::{poisson_nll, PoissonNllNode};

--- a/coeus-autograd/src/ops/nn/loss/multi_margin.rs
+++ b/coeus-autograd/src/ops/nn/loss/multi_margin.rs
@@ -1,0 +1,146 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for the multi-class margin loss.
+pub struct MultiMarginNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output of this node.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Per-element `d(loss)/d(x_ij)` assuming a unit upstream gradient, `[N*C]`.
+    pub grad_unit: Vec<T>,
+    /// Batch size.
+    pub n: usize,
+    /// Number of classes.
+    pub c: usize,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for MultiMarginNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "multi_margin"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        if let Some(Some(ref g)) = input_grads.first() {
+            let mut host_grad = [T::zero()];
+            let temp_grad;
+            let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+                grad_out
+            } else {
+                temp_grad = grad_out.to_contiguous_on(&backend);
+                &temp_grad
+            };
+            backend.copy_to_host(grad_cont.storage(), &mut host_grad);
+            let g_out = host_grad[0];
+
+            let mut d_x = vec![T::zero(); self.n * self.c];
+            for (i, gv) in d_x.iter_mut().enumerate() {
+                *gv = g_out * self.grad_unit[i];
+            }
+            let grad_tensor = Tensor::from_slice_on([self.n, self.c], &d_x, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked multi-class margin loss (PyTorch `MultiMarginLoss`, `reduction="mean"`):
+/// `mean_i (1/C) sum_{j != y_i} max(0, margin - x[i,y_i] + x[i,j])^p`.
+///
+/// `x`: `[N, C]` scores, `targets`: `[N]` class indices, `p >= 1`, `margin`.
+/// Gradient (unit upstream): for `j != y_i` with `m_ij = margin - x[i,y_i] + x[i,j] > 0`,
+/// `d/d x_ij = p*m_ij^(p-1) / (N*C)`; the target column accumulates the negation of
+/// every active sibling term.
+pub fn multi_margin<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x: &Var<T, B>,
+    targets: &[usize],
+    p: T,
+    margin: T,
+) -> Var<T, B> {
+    let backend = B::default();
+    let shape = x.tensor.shape();
+    assert_eq!(shape.len(), 2, "multi_margin expects 2D [N, C] input");
+    let n = shape[0];
+    let c = shape[1];
+    assert_eq!(targets.len(), n, "targets length must match batch size");
+
+    let cont;
+    let x_raw = if x.tensor.is_contiguous() && x.tensor.layout().offset() == 0 {
+        &x.tensor
+    } else {
+        cont = x.tensor.to_contiguous_on(&backend);
+        &cont
+    };
+    let host: std::borrow::Cow<[T]> = if let Some(s) = x_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n * c])
+    } else {
+        let mut v = vec![T::zero(); n * c];
+        backend.copy_to_host(x_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let one = T::one();
+    let p_minus_one = p - one;
+    let inv_nc = one / T::from_f64((n * c) as f64);
+    let mut grad_unit = vec![T::zero(); n * c];
+    let mut total = T::zero();
+    for i in 0..n {
+        let y = targets[i];
+        assert!(y < c, "target index out of bounds");
+        let base = i * c;
+        let xy = host[base + y];
+        let mut diag_coef = T::zero();
+        for j in 0..c {
+            if j == y {
+                continue;
+            }
+            let m = margin - xy + host[base + j];
+            if m > T::zero() {
+                // loss contribution m^p; derivative coef p*m^(p-1).
+                total = total + m.powf(p);
+                let coef = p * m.powf(p_minus_one);
+                grad_unit[base + j] = coef * inv_nc;
+                diag_coef = diag_coef + coef;
+            }
+        }
+        grad_unit[base + y] = (T::zero() - diag_coef) * inv_nc;
+    }
+    let loss_val = total * inv_nc;
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad = crate::grad_mode::should_track_var(x);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let output_grad = grad.as_ref().unwrap().clone();
+        let node = MultiMarginNode {
+            output_grad,
+            inputs: vec![x.clone()],
+            grad_unit,
+            n,
+            c,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -23,7 +23,7 @@ pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin,
+    kl_divergence, l1_loss, margin_ranking_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll, soft_margin,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -85,7 +85,7 @@ pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
+    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -131,6 +131,19 @@ pub fn nll_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::nll_loss(log_probs, targets)
 }
 
+/// Multi-class margin loss (PyTorch `MultiMarginLoss`, `reduction="mean"`).
+/// x: `[N, C]` scores, targets: `[N]` class indices, p >= 1, margin.
+/// Computes `mean_i (1/C) sum_{j != y_i} max(0, margin - x[i,y_i] + x[i,j])^p`.
+#[inline]
+pub fn multi_margin<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x: &Var<T, B>,
+    targets: &[usize],
+    p: T,
+    margin: T,
+) -> Var<T, B> {
+    coeus_autograd::multi_margin(x, targets, p, margin)
+}
+
 /// Huber (Smooth L1) Loss.
 /// pred: `[N]`, target: `[N]`, delta: huber threshold.
 #[inline]

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -2,7 +2,7 @@ use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, nll_loss, pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
+    l1_loss, margin_ranking_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
 };
 use coeus_tensor::Tensor;
 
@@ -437,6 +437,47 @@ fn test_triplet_margin_loss_inactive() {
     let negative = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[5.0, 0.0]), false);
     let loss = triplet_margin_loss(&anchor, &positive, &negative, 1.0, 2.0, 0.0);
     assert_eq!(loss.tensor.as_slice(), &[0.0_f64], "easy triplet → loss 0");
+}
+
+#[test]
+fn test_multi_margin() {
+    // x=[[0.5, 0.8, -0.6]], target=[0], margin=1, p=1, C=3.
+    // j=1: m=1-0.5+0.8=1.3>0 (active); j=2: m=1-0.5-0.6=-0.1<0 (inactive).
+    // loss = 1.3 / (N*C) = 1.3/3.  grads: x[0,1]=1/3, x[0,2]=0, x[0,0]=-1/3.
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([1, 3], &[0.5, 0.8, -0.6]),
+        true,
+    );
+    let loss = multi_margin(&x, &[0], 1.0, 1.0);
+    assert_eq!(loss.tensor.shape(), &[1]);
+    assert!(
+        (loss.tensor.as_slice()[0] - 1.3 / 3.0).abs() <= 1e-12,
+        "multi_margin forward: got {}, expected {}",
+        loss.tensor.as_slice()[0],
+        1.3 / 3.0
+    );
+
+    loss.backward();
+    let g = x.grad().expect("x must receive a gradient");
+    let third = 1.0 / 3.0;
+    let expected = [-third, third, 0.0];
+    for (k, (&got, &e)) in g.as_slice().iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (got - e).abs() <= 1e-12,
+            "multi_margin grad[{k}]: got {got}, expected {e}"
+        );
+    }
+}
+
+#[test]
+fn test_multi_margin_all_inactive() {
+    // Target score dominates by > margin → all hinges inactive → loss 0.
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([1, 3], &[3.0, 0.5, 0.1]),
+        false,
+    );
+    let loss = multi_margin(&x, &[0], 1.0, 1.0);
+    assert_eq!(loss.tensor.as_slice(), &[0.0_f64], "dominant target → loss 0");
 }
 
 #[test]


### PR DESCRIPTION
Implements MultiMarginLoss from the G-038 loss/distance parity gap — the last loss in the family.

## Change
- `multi_margin(x, targets, p, margin)` = `mean_i (1/C) sum_{j!=y_i} max(0, margin - x[i,y_i] + x[i,j])^p` (PyTorch `MultiMarginLoss`, `reduction="mean"`).
- Class-indexed autograd node (one input) precomputes the per-element gradient at forward: active siblings `d/d x_ij = p*m_ij^(p-1)/(N*C)`, target column accumulates the negation of active siblings. Generic `p`/`margin`. Wired through the autograd chain + thin coeus-nn delegate (mirrors `nll_loss`).

## Verification
Value-semantic tests: active case with mixed active/inactive sibling (forward + all 3 gradients), dominant-target case → 0. 2/2 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the `MultiMarginLoss` function, the final loss function from the G-038 loss/distance parity gap. The implementation includes a custom autograd node that precomputes per-element gradients during the forward pass, computing the mean multi-class hinge loss with configurable power `p` and margin. The change wires the new loss through the autograd chain and adds a thin wrapper in `coeus-nn`, following the same pattern as existing loss functions like `nll_loss`. Two test cases verify correct forward and backward computation for both active and inactive margin scenarios.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/multi_margin.rs` |
| 2 | `coeus-nn/tests/nn_loss_tests.rs` |
| 3 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 4 | `coeus-autograd/src/ops/nn/mod.rs` |
| 5 | `coeus-autograd/src/ops/mod.rs` |
| 6 | `coeus-autograd/src/lib.rs` |
| 7 | `coeus-nn/src/loss.rs` |
| 8 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->