### PR TITLE
MS-202: add Sigmoid/Tanh/SiLU benchmark rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,14 @@
   Coeus `SequentialBackend` and `MoiraiBackend` in the same Criterion group.
   Short local run medians: Burn 3.44–4.17 ms, Coeus Sequential 3.39–4.14 ms,
   Coeus Moirai 2.99–3.68 ms. ([patch])
-- **NN benchmark matrix expansion (ReLU and GeLU forward)** — extended
+- **NN benchmark matrix expansion (Sigmoid, Tanh, SiLU forward)** — extended
+  `coeus-nn/benches/nn_bench.rs` with Sigmoid, Tanh, and SiLU activation rows
+  (`[128,256]`), validating the dispatch-monomorphization speedup across the
+  activation family. Medians: Sigmoid: Burn 134-137 µs, Coeus Sequential
+  45.5-46.2 µs, Coeus Moirai 45.7-46.7 µs (Coeus ~3x faster); Tanh: Burn
+  62.9-67.6 µs, Coeus Sequential 60.9-62.1 µs (parity); SiLU: Burn 140-150 µs,
+  Coeus Sequential 47.0-48.8 µs, Coeus Moirai 46.4-46.9 µs (Coeus ~3x faster).
+  ([patch])- **NN benchmark matrix expansion (ReLU and GeLU forward)** — extended
   `coeus-nn/benches/nn_bench.rs` with ReLU and GeLU activation rows
   (`[128,256]`), comparing Burn NdArray against Coeus `SequentialBackend`
   and `MoiraiBackend`. ReLU medians: Burn 4.12–4.32 µs, Coeus Sequential

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -19,7 +19,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
-    cross_entropy_loss, mse_loss, huber_loss, relu, gelu, AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d,
+    cross_entropy_loss, mse_loss, huber_loss, relu, gelu, sigmoid, tanh, silu, AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d, Conv3d,
     Embedding, GroupNorm, InstanceNorm2d, LayerNorm, Linear, Lstm, MaxPool2d, Module,
     MultiHeadAttention, NullMask, RMSNorm, TransformerEncoderLayer,
 };
@@ -1073,6 +1073,51 @@ fn bench_gelu_forward(c: &mut Criterion) {
     });
     group.finish();
 }
+
+fn bench_sigmoid_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.0031).sin()).collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]), &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+
+    let mut group = c.benchmark_group("Burn vs Coeus — Sigmoid forward (128x256)");
+    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::sigmoid(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(sigmoid(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(sigmoid(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_tanh_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.0031).sin()).collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]), &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+
+    let mut group = c.benchmark_group("Burn vs Coeus — Tanh forward (128x256)");
+    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::tanh(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(tanh(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(tanh(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_silu_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.0031).sin()).collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]), &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+
+    let mut group = c.benchmark_group("Burn vs Coeus — SiLU forward (128x256)");
+    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::silu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(silu(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(silu(black_box(&x_moirai)))) });
+    group.finish();
+}
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -1097,6 +1142,9 @@ criterion_group!(
     bench_mse_loss,
     bench_huber_loss,
     bench_relu_forward,
-    bench_gelu_forward
+    bench_gelu_forward,
+    bench_sigmoid_forward,
+    bench_tanh_forward,
+    bench_silu_forward
 );
 criterion_main!(benches);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,6 +22,10 @@
   so every implemented NN family has an explicit measurement or differential
   row.
 
+## Sprint MS-202: Sigmoid+Tanh+SiLU benchmark expansion [COMPLETE]
+
+- [x] Added `bench_sigmoid_forward`, `bench_tanh_forward`, `bench_silu_forward` rows.
+- [x] Sigma/SiLU: Coeus ~3x faster than Burn; Tanh: parity.
 ## Sprint MS-200: ReLU+GeLU activation benchmark expansion [COMPLETE]
 
 - [x] Added `bench_relu_forward` and `bench_gelu_forward` in nn_bench.rs.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -8,7 +8,7 @@
 **Compared against**: Burn `burn::nn` module families and PyTorch `torch.nn`
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
-(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, CrossEntropyLoss, MSELoss, HuberLoss, ReLU forward, GeLU forward, Conv2d,
+(Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, CrossEntropyLoss, MSELoss, HuberLoss, ReLU forward, GeLU forward, Sigmoid forward, Tanh forward, SiLU forward, Conv2d,
 Conv3d, MHA self-attention, Transformer encoder layer, Embedding lookup, BatchNorm1d
 eval forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
 GroupNorm forward, MaxPool2d forward, AvgPool2d forward), not the full NN family


### PR DESCRIPTION
G-043 benchmark matrix expansion: add Sigmoid, Tanh, and SiLU activation rows [128x256]. Validates dispatch-monomorphization fix across activation family: Sigmoid/SiLU ~3x faster than Burn, Tanh at parity.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extends the neural network benchmark matrix by adding three new activation function benchmarks: Sigmoid, Tanh, and SiLU. These benchmarks compare performance between Burn NdArray and Coeus backends (Sequential and Moirai) for 128x256 input tensors, validating that the dispatch-monomorphization optimization delivers significant speedups across the activation function family. The results show Sigmoid and SiLU are approximately 3x faster in Coeus compared to Burn, while Tanh achieves performance parity.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->