### PR TITLE
feat(python): Bind G-038 losses to coeus-python with PyTorch parity

### DIFF
--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -185,6 +185,13 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(losses::kl_divergence, m)?)?;
     m.add_function(wrap_pyfunction!(losses::margin_ranking_loss, m)?)?;
     m.add_function(wrap_pyfunction!(losses::cosine_embedding_loss, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::l1_loss, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::bce_with_logits, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::poisson_nll, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::soft_margin, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::pairwise_distance, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::triplet_margin_loss, m)?)?;
+    m.add_function(wrap_pyfunction!(losses::multi_margin, m)?)?;
 
     m.add_function(wrap_pyfunction!(ops::exp, m)?)?;
     m.add_function(wrap_pyfunction!(ops::log, m)?)?;

--- a/coeus-python/src/losses.rs
+++ b/coeus-python/src/losses.rs
@@ -81,3 +81,86 @@ pub fn cosine_embedding_loss(
         .allow_threads(|| coeus_nn::loss::cosine_embedding_loss(&x1.inner, &x2.inner, &y, margin));
     PyTensor::from_var(inner)
 }
+
+/// L1 (mean absolute error) loss: `mean(|pred - target|)`.
+#[pyfunction]
+pub fn l1_loss(pred: &PyTensor, target: &PyTensor, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::loss::l1_loss(&pred.inner, &target.inner));
+    PyTensor::from_var(inner)
+}
+
+/// Binary cross-entropy with logits (numerically stable). Mirrors PyTorch
+/// `BCEWithLogitsLoss(reduction="mean")`.
+#[pyfunction]
+pub fn bce_with_logits(logits: &PyTensor, target: &PyTensor, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::loss::bce_with_logits(&logits.inner, &target.inner));
+    PyTensor::from_var(inner)
+}
+
+/// Poisson NLL loss (log-input): `mean(exp(input) - target * input)`.
+#[pyfunction]
+pub fn poisson_nll(input: &PyTensor, target: &PyTensor, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::loss::poisson_nll(&input.inner, &target.inner));
+    PyTensor::from_var(inner)
+}
+
+/// Soft-margin (logistic) loss: `mean(log(1 + exp(-target * input)))`.
+#[pyfunction]
+pub fn soft_margin(input: &PyTensor, target: &PyTensor, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::loss::soft_margin(&input.inner, &target.inner));
+    PyTensor::from_var(inner)
+}
+
+/// Row-wise p-norm pairwise distance: `[N,D] -> [N]`.
+#[pyfunction]
+#[pyo3(signature = (x1, x2, p = 2.0, eps = 1e-6))]
+pub fn pairwise_distance(
+    x1: &PyTensor,
+    x2: &PyTensor,
+    p: f64,
+    eps: f64,
+    py: Python<'_>,
+) -> PyTensor {
+    let inner =
+        py.allow_threads(|| coeus_nn::loss::pairwise_distance(&x1.inner, &x2.inner, p, eps));
+    PyTensor::from_var(inner)
+}
+
+/// Triplet-margin loss: `mean max(0, d(a,p) - d(a,n) + margin)`.
+#[pyfunction]
+#[pyo3(signature = (anchor, positive, negative, margin = 1.0, p = 2.0, eps = 1e-6))]
+pub fn triplet_margin_loss(
+    anchor: &PyTensor,
+    positive: &PyTensor,
+    negative: &PyTensor,
+    margin: f64,
+    p: f64,
+    eps: f64,
+    py: Python<'_>,
+) -> PyTensor {
+    let inner = py.allow_threads(|| {
+        coeus_nn::loss::triplet_margin_loss(
+            &anchor.inner,
+            &positive.inner,
+            &negative.inner,
+            margin,
+            p,
+            eps,
+        )
+    });
+    PyTensor::from_var(inner)
+}
+
+/// Multi-class margin loss over scores `[N, C]` with class-index targets.
+#[pyfunction]
+#[pyo3(signature = (x, targets, p = 1.0, margin = 1.0))]
+pub fn multi_margin(
+    x: &PyTensor,
+    targets: Vec<usize>,
+    p: f64,
+    margin: f64,
+    py: Python<'_>,
+) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::loss::multi_margin(&x.inner, &targets, p, margin));
+    PyTensor::from_var(inner)
+}

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2174,3 +2174,127 @@ def test_conv_transpose3d_matches_pytorch() -> None:
         ct_t.bias.grad.flatten().tolist(),
         atol=1e-10,
     )
+
+
+# ---------------------------------------------------------------------------
+# G-038 loss/distance family — forward + input-gradient parity vs torch
+# ---------------------------------------------------------------------------
+
+import torch.nn.functional as _F  # noqa: E402
+
+
+def _loss_grad_parity(label, pyc_loss_fn, torch_loss_fn, x_data, t_data, shape):
+    """Compare a (input, target)->scalar loss: value + d/d_input vs torch f64."""
+    x_pyc = pycoeus.Tensor(x_data, shape, requires_grad=True)
+    t_pyc = pycoeus.Tensor(t_data, shape)
+    loss_pyc = pyc_loss_fn(x_pyc, t_pyc)
+    loss_pyc.backward()
+
+    n = 1
+    for s in shape:
+        n *= s
+    x_t = torch.tensor(x_data, dtype=torch.float64).reshape(shape).requires_grad_(True)
+    t_t = torch.tensor(t_data, dtype=torch.float64).reshape(shape)
+    loss_t = torch_loss_fn(x_t, t_t)
+    loss_t.backward()
+    assert abs(loss_pyc.data[0] - loss_t.item()) < _ATOL, (
+        f"{label}: got={loss_pyc.data[0]:.8g}, expected={loss_t.item():.8g}"
+    )
+    _allclose(f"{label}_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())
+
+
+def test_l1_loss_matches_pytorch() -> None:
+    _loss_grad_parity(
+        "l1_loss",
+        lambda a, b: pycoeus.l1_loss(a, b),
+        lambda a, b: _F.l1_loss(a, b),
+        [0.5, -1.2, 3.0, 0.1, -2.0, 1.5],
+        [1.0, 0.0, 2.0, 0.0, -1.0, 1.0],
+        [2, 3],
+    )
+
+
+def test_bce_with_logits_matches_pytorch() -> None:
+    _loss_grad_parity(
+        "bce_with_logits",
+        lambda a, b: pycoeus.bce_with_logits(a, b),
+        lambda a, b: _F.binary_cross_entropy_with_logits(a, b),
+        [0.5, -1.2, 0.3, 2.0],
+        [1.0, 0.0, 1.0, 0.0],
+        [4],
+    )
+
+
+def test_poisson_nll_matches_pytorch() -> None:
+    _loss_grad_parity(
+        "poisson_nll",
+        lambda a, b: pycoeus.poisson_nll(a, b),
+        lambda a, b: _F.poisson_nll_loss(a, b, log_input=True, full=False),
+        [0.0, 1.0, -0.5, 0.7],
+        [2.0, 0.0, 3.0, 1.0],
+        [4],
+    )
+
+
+def test_soft_margin_matches_pytorch() -> None:
+    _loss_grad_parity(
+        "soft_margin",
+        lambda a, b: pycoeus.soft_margin(a, b),
+        lambda a, b: _F.soft_margin_loss(a, b),
+        [0.5, -1.2, 2.0, -0.3],
+        [1.0, -1.0, 1.0, -1.0],
+        [4],
+    )
+
+
+def test_pairwise_distance_matches_pytorch() -> None:
+    # Vector-output [N]; compare the distance vector (forward).
+    x1d = [1.0, 2.0, 3.0, 4.0]
+    x2d = [0.0, 0.0, 1.0, 1.0]
+    d_pyc = pycoeus.pairwise_distance(
+        pycoeus.Tensor(x1d, [2, 2]), pycoeus.Tensor(x2d, [2, 2]), 2.0, 1e-6
+    )
+    x1_t = torch.tensor(x1d, dtype=torch.float64).reshape(2, 2)
+    x2_t = torch.tensor(x2d, dtype=torch.float64).reshape(2, 2)
+    d_t = _F.pairwise_distance(x1_t, x2_t, p=2.0, eps=1e-6)
+    _allclose("pairwise_distance", list(d_pyc.data), d_t.flatten().tolist())
+
+
+def test_triplet_margin_matches_pytorch() -> None:
+    a = [0.0, 0.0, 1.0, 1.0]
+    p = [2.0, 0.0, 1.0, 2.0]
+    n = [0.0, 2.5, 3.0, 1.0]
+    a_pyc = pycoeus.Tensor(a, [2, 2], requires_grad=True)
+    loss_pyc = pycoeus.triplet_margin_loss(
+        a_pyc, pycoeus.Tensor(p, [2, 2]), pycoeus.Tensor(n, [2, 2]), 1.0, 2.0, 1e-6
+    )
+    loss_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64).reshape(2, 2).requires_grad_(True)
+    loss_t = _F.triplet_margin_loss(
+        a_t,
+        torch.tensor(p, dtype=torch.float64).reshape(2, 2),
+        torch.tensor(n, dtype=torch.float64).reshape(2, 2),
+        margin=1.0,
+        p=2.0,
+        eps=1e-6,
+    )
+    loss_t.backward()
+    assert abs(loss_pyc.data[0] - loss_t.item()) < _ATOL, (
+        f"triplet: got={loss_pyc.data[0]:.8g}, expected={loss_t.item():.8g}"
+    )
+    _allclose("triplet_da", list(a_pyc.grad), a_t.grad.flatten().tolist())
+
+
+def test_multi_margin_matches_pytorch() -> None:
+    x_data = [0.5, 0.8, -0.6, 1.0, 0.2, 0.3]
+    targets = [0, 1]
+    x_pyc = pycoeus.Tensor(x_data, [2, 3], requires_grad=True)
+    loss_pyc = pycoeus.multi_margin(x_pyc, targets, 1.0, 1.0)
+    loss_pyc.backward()
+    x_t = torch.tensor(x_data, dtype=torch.float64).reshape(2, 3).requires_grad_(True)
+    loss_t = _F.multi_margin_loss(x_t, torch.tensor(targets, dtype=torch.long), p=1, margin=1.0)
+    loss_t.backward()
+    assert abs(loss_pyc.data[0] - loss_t.item()) < _ATOL, (
+        f"multi_margin: got={loss_pyc.data[0]:.8g}, expected={loss_t.item():.8g}"
+    )
+    _allclose("multi_margin_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())


### PR DESCRIPTION
Exposes the seven G-038 loss/distance ops in coeus-python and verifies PyTorch parity.

## Change
- Thin pyo3 bindings (delegating to `coeus_nn::loss`, GIL released): `l1_loss`, `bce_with_logits`, `poisson_nll`, `soft_margin`, `pairwise_distance`, `triplet_margin_loss`, `multi_margin`.

## Verification
PyTorch differential tests (forward + input gradients vs `torch.nn.functional` at f64): 7/7 pass.

Refs: docs/gap_audit.md#g-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR binds seven G-038 loss and distance functions (`l1_loss`, `bce_with_logits`, `poisson_nll`, `soft_margin`, `pairwise_distance`, `triplet_margin_loss`, `multi_margin`) from the Rust `coeus_nn::loss` module to the Python interface via PyO3 bindings. All bindings release the GIL for concurrent execution and include comprehensive PyTorch parity tests that verify both forward pass values and input gradients at f64 precision against `torch.nn.functional` equivalents.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/lib.rs` |
| 2 | `coeus-python/src/losses.rs` |
| 3 | `coeus-python/tests/test_pytorch_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->