### PR TITLE
feat(nn): MaxPool1d and AvgPool1d (closes G-036 pool1d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Changed
 
-- **`Tensor::alloc_on` zero-copy allocation** — added `Tensor::alloc_on` which
+- **G-036: MaxPool1d and AvgPool1d** — implemented 1D pooling layers closing the
+  G-036 pool family gap. Added CPU kernels (`pool/pool1d.rs`), extended the
+  `PoolOps` trait with `max_pool1d/avg_pool1d` (forward + backward), extended
+  the const-generic `MaxPoolNode<DIM=1>` and `AvgPoolNode<DIM=1>` autograd
+  nodes, and added `MaxPool1d` / `AvgPool1d` `Module` structs in `coeus-nn`
+  with full public API re-exports. 6 parity tests pass (forward correctness
+  for no-pad, stride-1, multi-channel, and batch cases). ([minor])- **`Tensor::alloc_on` zero-copy allocation** — added `Tensor::alloc_on` which
   allocates a raw buffer without zero-initializing, eliminating a redundant
   write pass for all kernels that unconditionally overwrite their output.
   Applied in `elementwise_unary`, `elementwise_binary`, `matmul` (2D and batched),

--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -40,6 +40,7 @@ pub use node::BackwardNode;
 pub use ops::{
     abs,
     add,
+    avg_pool1d,
     avg_pool2d,
     avg_pool3d,
     batchnorm1d,
@@ -101,6 +102,7 @@ pub use ops::{
     matmul,
     // New axis reductions
     max_axis,
+    max_pool1d,
     max_pool2d,
     max_pool3d,
     mean,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -31,11 +31,11 @@ pub use reduction::{log_sum_exp, max_axis, min_axis, norm, norm_p, norm_p_axis};
 pub use arithmetic::VarScalarExt;
 pub use linalg::{matmul, sparse_matmul, sparse_matmul_coo, transpose_2d};
 pub use nn::{
-    avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, bce_with_logits,
+    avg_pool1d, avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, bce_with_logits,
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
     conv_transpose3d, cosine_embedding_loss,
     cross_entropy_loss, dropout, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
-    margin_ranking_loss, max_pool2d, max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
+    margin_ranking_loss, max_pool1d, max_pool2d, max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention, soft_margin, softmax,
     AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -12,7 +12,7 @@ pub mod log_softmax;
 pub mod loss;
 /// Normalization layers (batchnorm, layernorm, rmsnorm).
 pub mod normalization;
-/// Pooling layers (max-pool, avg-pool 2D/3D).
+/// Pooling layers (max-pool, avg-pool 1D/2D/3D).
 pub mod pool;
 /// Softmax operation.
 pub mod softmax;
@@ -26,5 +26,5 @@ pub use loss::{
     kl_divergence, l1_loss, margin_ranking_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll, soft_margin,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
-pub use pool::{avg_pool2d, avg_pool3d, max_pool2d, max_pool3d};
+pub use pool::{avg_pool1d, avg_pool2d, avg_pool3d, max_pool1d, max_pool2d, max_pool3d};
 pub use softmax::softmax;

--- a/coeus-autograd/src/ops/nn/pool.rs
+++ b/coeus-autograd/src/ops/nn/pool.rs
@@ -38,6 +38,18 @@ fn dispatch_max_pool_backward<T: Float, B: coeus_ops::BackendOps<T> + Default, c
     } = request;
 
     match DIM {
+        1 => backend.max_pool1d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            input_storage,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
         2 => backend.max_pool2d_backward(
             grad_out_storage,
             grad_out_layout,
@@ -83,6 +95,16 @@ fn dispatch_avg_pool_backward<T: Float, B: coeus_ops::BackendOps<T> + Default, c
     } = request;
 
     match DIM {
+        1 => backend.avg_pool1d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
         2 => backend.avg_pool2d_backward(
             grad_out_storage,
             grad_out_layout,
@@ -133,6 +155,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
     #[inline]
     fn op_name(&self) -> &'static str {
         match DIM {
+            1 => "max_pool1d",
             2 => "max_pool2d",
             3 => "max_pool3d",
             _ => "max_poolNd",
@@ -221,6 +244,18 @@ fn max_pool_nd_inner<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM:
     }
 }
 
+/// Tracked 1D Max Pooling.
+pub fn max_pool1d<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    out_tensor: Tensor<T, B>,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Var<T, B> {
+    max_pool_nd_inner::<T, B, 1>(input, out_tensor, kernel_size, stride, padding, dilation)
+}
+
 /// Tracked 2D Max Pooling.
 pub fn max_pool2d<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     input: &Var<T, B>,
@@ -271,6 +306,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
     #[inline]
     fn op_name(&self) -> &'static str {
         match DIM {
+            1 => "avg_pool1d",
             2 => "avg_pool2d",
             3 => "avg_pool3d",
             _ => "avg_poolNd",
@@ -353,6 +389,18 @@ fn avg_pool_nd_inner<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM:
         grad,
         creator,
     }
+}
+
+/// Tracked 1D Average Pooling.
+pub fn avg_pool1d<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    out_tensor: Tensor<T, B>,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Var<T, B> {
+    avg_pool_nd_inner::<T, B, 1>(input, out_tensor, kernel_size, stride, padding, dilation)
 }
 
 /// Tracked 2D Average Pooling.

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -94,8 +94,8 @@ pub use normalization::{
 };
 pub use parameter::Parameter;
 pub use pool::{
-    AvgPool2d, AvgPool3d, GlobalAvgPool1d, GlobalAvgPool2d, GlobalAvgPool3d, GlobalMaxPool2d,
-    GlobalMaxPool3d, MaxPool2d, MaxPool3d,
+    AvgPool1d, AvgPool2d, AvgPool3d, GlobalAvgPool1d, GlobalAvgPool2d, GlobalAvgPool3d,
+    GlobalMaxPool2d, GlobalMaxPool3d, MaxPool1d, MaxPool2d, MaxPool3d,
 };
 pub use positional::{RotaryEmbedding, SinusoidalEncoding};
 pub use rnn::{GRUCell, Gru, LSTMCell, Lstm};

--- a/coeus-nn/src/pool/mod.rs
+++ b/coeus-nn/src/pool/mod.rs
@@ -5,12 +5,14 @@
 mod avg;
 mod global;
 mod max;
+mod pool1d;
 
 pub use avg::{AvgPool2d, AvgPool3d};
 pub use global::{
     GlobalAvgPool1d, GlobalAvgPool2d, GlobalAvgPool3d, GlobalMaxPool2d, GlobalMaxPool3d,
 };
 pub use max::{MaxPool2d, MaxPool3d};
+pub use pool1d::{AvgPool1d, MaxPool1d};
 
 // ── Shared pooling helpers ──
 

--- a/coeus-nn/src/pool/pool1d.rs
+++ b/coeus-nn/src/pool/pool1d.rs
@@ -1,0 +1,193 @@
+// ── Pool1d ──
+// MaxPool1d and AvgPool1d for 1D spatial inputs `[N, C, L]`.
+
+use crate::module::Module;
+use crate::pool::out_dim;
+use coeus_autograd::Var;
+use coeus_core::{Float, MoiraiBackend, Scalar};
+use coeus_tensor::Tensor;
+use std::marker::PhantomData;
+
+// ── MaxPool1d ──
+
+/// 1D max pooling layer for inputs shaped `[N, C, L]`.
+///
+/// Slides a window of `kernel_size` along the length dimension and takes the maximum.
+///
+/// # Examples
+///
+/// ```
+/// use coeus_nn::{MaxPool1d, Module};
+/// use coeus_autograd::Var;
+/// use coeus_tensor::Tensor;
+/// use coeus_core::SequentialBackend;
+///
+/// let pool = MaxPool1d::<f32, SequentialBackend>::new(2);
+/// let x = Var::new(Tensor::from_slice([1, 1, 4], &[1.0_f32, 3.0, 2.0, 4.0]), false);
+/// let y = pool.forward(&x);
+/// assert_eq!(y.tensor.shape(), &[1, 1, 2]);
+/// ```
+#[derive(Clone)]
+pub struct MaxPool1d<T: Scalar, B: coeus_ops::BackendOps<T> + Default = MoiraiBackend> {
+    /// Pooling window length.
+    pub kernel_size: usize,
+    /// Stride along the L dimension.
+    pub stride: usize,
+    /// Zero-padding applied to both sides.
+    pub padding: usize,
+    /// Spacing between pooling window elements.
+    pub dilation: usize,
+    _marker: PhantomData<(T, B)>,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> MaxPool1d<T, B> {
+    /// Create with stride equal to kernel_size, no padding, no dilation.
+    pub fn new(kernel_size: usize) -> Self {
+        Self::with_params(kernel_size, kernel_size, 0, 1)
+    }
+
+    /// Create with explicit hyperparameters.
+    pub fn with_params(kernel_size: usize, stride: usize, padding: usize, dilation: usize) -> Self {
+        assert!(stride >= 1 && dilation >= 1, "stride and dilation must be >= 1");
+        Self { kernel_size, stride, padding, dilation, _marker: PhantomData }
+    }
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for MaxPool1d<T, B> {
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        vec![]
+    }
+
+    fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        let backend = B::default();
+
+        let n = input.tensor.shape()[0];
+        let c = input.tensor.shape()[1];
+        let l = input.tensor.shape()[2];
+        let l_out = out_dim(l, self.kernel_size, self.padding, self.stride, self.dilation);
+
+        assert!(
+            l_out > 0,
+            "MaxPool1d: kernel ({}) with dilation ({}) and padding ({}) \
+             does not fit input length {l}; output would be {l_out}",
+            self.kernel_size,
+            self.dilation,
+            self.padding,
+        );
+
+        let mut out_tensor = Tensor::alloc_on([n, c, l_out], &backend);
+        let (out_storage, out_layout) = out_tensor.storage_mut_and_layout();
+
+        backend.max_pool1d(
+            input.tensor.storage(),
+            input.tensor.layout(),
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.dilation,
+            out_storage,
+            out_layout,
+        );
+
+        coeus_autograd::max_pool1d(
+            input,
+            out_tensor,
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.dilation,
+        )
+    }
+}
+
+// ── AvgPool1d ──
+
+/// 1D average pooling layer for inputs shaped `[N, C, L]`.
+///
+/// Slides a window of `kernel_size` along the length dimension and takes the average.
+///
+/// # Examples
+///
+/// ```
+/// use coeus_nn::{AvgPool1d, Module};
+/// use coeus_autograd::Var;
+/// use coeus_tensor::Tensor;
+/// use coeus_core::SequentialBackend;
+///
+/// let pool = AvgPool1d::<f32, SequentialBackend>::new(2);
+/// let x = Var::new(Tensor::from_slice([1, 1, 4], &[1.0_f32, 3.0, 2.0, 4.0]), false);
+/// let y = pool.forward(&x);
+/// assert_eq!(y.tensor.shape(), &[1, 1, 2]);
+/// ```
+#[derive(Clone)]
+pub struct AvgPool1d<T: Scalar, B: coeus_ops::BackendOps<T> + Default = MoiraiBackend> {
+    /// Pooling window length.
+    pub kernel_size: usize,
+    /// Stride along the L dimension.
+    pub stride: usize,
+    /// Zero-padding applied to both sides.
+    pub padding: usize,
+    /// Spacing between pooling window elements.
+    pub dilation: usize,
+    _marker: PhantomData<(T, B)>,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> AvgPool1d<T, B> {
+    /// Create with stride equal to kernel_size, no padding, no dilation.
+    pub fn new(kernel_size: usize) -> Self {
+        Self::with_params(kernel_size, kernel_size, 0, 1)
+    }
+
+    /// Create with explicit hyperparameters.
+    pub fn with_params(kernel_size: usize, stride: usize, padding: usize, dilation: usize) -> Self {
+        assert!(stride >= 1 && dilation >= 1, "stride and dilation must be >= 1");
+        Self { kernel_size, stride, padding, dilation, _marker: PhantomData }
+    }
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for AvgPool1d<T, B> {
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        vec![]
+    }
+
+    fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        let backend = B::default();
+
+        let n = input.tensor.shape()[0];
+        let c = input.tensor.shape()[1];
+        let l = input.tensor.shape()[2];
+        let l_out = out_dim(l, self.kernel_size, self.padding, self.stride, self.dilation);
+
+        assert!(
+            l_out > 0,
+            "AvgPool1d: kernel ({}) with dilation ({}) and padding ({}) \
+             does not fit input length {l}; output would be {l_out}",
+            self.kernel_size,
+            self.dilation,
+            self.padding,
+        );
+
+        let mut out_tensor = Tensor::alloc_on([n, c, l_out], &backend);
+        let (out_storage, out_layout) = out_tensor.storage_mut_and_layout();
+
+        backend.avg_pool1d(
+            input.tensor.storage(),
+            input.tensor.layout(),
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.dilation,
+            out_storage,
+            out_layout,
+        );
+
+        coeus_autograd::avg_pool1d(
+            input,
+            out_tensor,
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.dilation,
+        )
+    }
+}

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -384,8 +384,7 @@ fn test_pairwise_distance() {
     let g2 = x2.grad().expect("x2 grad");
     for i in 0..2 {
         let scale = (s[i] + eps).powf(1.0 / p - 1.0);
-        for k in 0..2 {
-            let d = diffs[i][k];
+        for (k, &d) in diffs[i].iter().enumerate() {
             let eg = scale * d.abs().powf(p - 1.0) * d.signum();
             assert!((g1.as_slice()[i * 2 + k] - eg).abs() <= 1e-12, "pd gx1 {} {}", i, k);
             assert!((g2.as_slice()[i * 2 + k] + eg).abs() <= 1e-12, "pd gx2 {} {}", i, k);

--- a/coeus-nn/tests/pool1d_parity.rs
+++ b/coeus-nn/tests/pool1d_parity.rs
@@ -1,0 +1,101 @@
+// ── Pool1d parity tests ──
+//
+// Verifies MaxPool1d and AvgPool1d forward outputs against hand-computed values.
+
+use coeus_autograd::Var;
+use coeus_core::SequentialBackend;
+use coeus_nn::{AvgPool1d, MaxPool1d, Module};
+use coeus_tensor::Tensor;
+
+fn seq_var(shape: impl Into<coeus_core::Shape>, data: &[f32]) -> Var<f32, SequentialBackend> {
+    Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(shape, data),
+        false,
+    )
+}
+
+#[test]
+fn maxpool1d_no_pad() {
+    // Input [1, 1, 6]: [1, 3, 2, 4, 1, 5], k=2, s=2, p=0
+    // Windows: [1,3]=3, [2,4]=4, [1,5]=5  → output [3, 4, 5]
+    let pool = MaxPool1d::<f32, SequentialBackend>::new(2);
+    let x = seq_var([1, 1, 6], &[1.0, 3.0, 2.0, 4.0, 1.0, 5.0]);
+    let y = pool.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 1, 3]);
+    let s = y.tensor.as_slice();
+    assert!((s[0] - 3.0).abs() < 1e-6, "window 0");
+    assert!((s[1] - 4.0).abs() < 1e-6, "window 1");
+    assert!((s[2] - 5.0).abs() < 1e-6, "window 2");
+}
+
+#[test]
+fn maxpool1d_stride1() {
+    // Input [1, 1, 4]: [1, 4, 2, 3], k=2, s=1
+    // Windows: [1,4]=4, [4,2]=4, [2,3]=3  → output [4, 4, 3]
+    let pool = MaxPool1d::<f32, SequentialBackend>::with_params(2, 1, 0, 1);
+    let x = seq_var([1, 1, 4], &[1.0, 4.0, 2.0, 3.0]);
+    let y = pool.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 1, 3]);
+    let s = y.tensor.as_slice();
+    assert!((s[0] - 4.0).abs() < 1e-6);
+    assert!((s[1] - 4.0).abs() < 1e-6);
+    assert!((s[2] - 3.0).abs() < 1e-6);
+}
+
+#[test]
+fn maxpool1d_multi_channel() {
+    // Input [1, 2, 4], k=2, s=2
+    // Ch0: [1,3]=3, [2,4]=4  → [3, 4]
+    // Ch1: [5,7]=7, [6,8]=8  → [7, 8]
+    let pool = MaxPool1d::<f32, SequentialBackend>::new(2);
+    let x = seq_var([1, 2, 4], &[1.0, 3.0, 2.0, 4.0, 5.0, 7.0, 6.0, 8.0]);
+    let y = pool.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 2, 2]);
+    let s = y.tensor.as_slice();
+    assert!((s[0] - 3.0).abs() < 1e-6, "ch0 w0");
+    assert!((s[1] - 4.0).abs() < 1e-6, "ch0 w1");
+    assert!((s[2] - 7.0).abs() < 1e-6, "ch1 w0");
+    assert!((s[3] - 8.0).abs() < 1e-6, "ch1 w1");
+}
+
+#[test]
+fn avgpool1d_no_pad() {
+    // Input [1, 1, 4]: [1, 3, 2, 4], k=2, s=2
+    // Windows: (1+3)/2=2.0, (2+4)/2=3.0
+    let pool = AvgPool1d::<f32, SequentialBackend>::new(2);
+    let x = seq_var([1, 1, 4], &[1.0, 3.0, 2.0, 4.0]);
+    let y = pool.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 1, 2]);
+    let s = y.tensor.as_slice();
+    assert!((s[0] - 2.0).abs() < 1e-6, "window 0");
+    assert!((s[1] - 3.0).abs() < 1e-6, "window 1");
+}
+
+#[test]
+fn avgpool1d_stride1() {
+    // Input [1, 1, 4]: [2, 4, 6, 8], k=3, s=1
+    // Windows: (2+4+6)/3=4.0, (4+6+8)/3=6.0
+    let pool = AvgPool1d::<f32, SequentialBackend>::with_params(3, 1, 0, 1);
+    let x = seq_var([1, 1, 4], &[2.0, 4.0, 6.0, 8.0]);
+    let y = pool.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 1, 2]);
+    let s = y.tensor.as_slice();
+    assert!((s[0] - 4.0).abs() < 1e-6, "window 0");
+    assert!((s[1] - 6.0).abs() < 1e-6, "window 1");
+}
+
+#[test]
+fn avgpool1d_batch() {
+    // Input [2, 1, 4], k=2, s=2: batch of two independent rows
+    let pool = AvgPool1d::<f32, SequentialBackend>::new(2);
+    let x = seq_var([2, 1, 4], &[1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0]);
+    let y = pool.forward(&x);
+    assert_eq!(y.tensor.shape(), &[2, 1, 2]);
+    let s = y.tensor.as_slice();
+    // batch0: 2.0, 6.0
+    assert!((s[0] - 2.0).abs() < 1e-6);
+    assert!((s[1] - 6.0).abs() < 1e-6);
+    // batch1: 3.0, 7.0
+    assert!((s[2] - 3.0).abs() < 1e-6);
+    assert!((s[3] - 7.0).abs() < 1e-6);
+}

--- a/coeus-ops/src/backend_ops/cpu_impl.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl.rs
@@ -668,6 +668,82 @@ where
             grad_input_layout,
         );
     }
+
+    // ── Pool 1D ──────────────────────────────────────────────────────────────
+
+    #[inline]
+    fn max_pool1d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) {
+        pool::max_pool1d(
+            self, input, input_layout, kernel_size, stride, padding, dilation, output,
+            output_layout,
+        );
+    }
+
+    #[inline]
+    fn max_pool1d_backward(
+        &self,
+        grad_out: &Self::DeviceBuffer<T>,
+        grad_out_layout: &Layout,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        grad_input: &mut Self::DeviceBuffer<T>,
+        grad_input_layout: &Layout,
+    ) {
+        pool::max_pool1d_backward(
+            self, grad_out, grad_out_layout, input, input_layout, kernel_size, stride, padding,
+            dilation, grad_input, grad_input_layout,
+        );
+    }
+
+    #[inline]
+    fn avg_pool1d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) {
+        pool::avg_pool1d(
+            self, input, input_layout, kernel_size, stride, padding, dilation, output,
+            output_layout,
+        );
+    }
+
+    #[inline]
+    fn avg_pool1d_backward(
+        &self,
+        grad_out: &Self::DeviceBuffer<T>,
+        grad_out_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        grad_input: &mut Self::DeviceBuffer<T>,
+        grad_input_layout: &Layout,
+    ) {
+        pool::avg_pool1d_backward(
+            self, grad_out, grad_out_layout, kernel_size, stride, padding, dilation, grad_input,
+            grad_input_layout,
+        );
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/coeus-ops/src/backend_ops/cpu_impl/pool/mod.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/pool/mod.rs
@@ -1,5 +1,9 @@
 mod avg;
 mod max;
+mod pool1d;
 
 pub(crate) use avg::{avg_pool2d, avg_pool2d_backward, avg_pool3d, avg_pool3d_backward};
 pub(crate) use max::{max_pool2d, max_pool2d_backward, max_pool3d, max_pool3d_backward};
+pub(crate) use pool1d::{
+    avg_pool1d, avg_pool1d_backward, max_pool1d, max_pool1d_backward,
+};

--- a/coeus-ops/src/backend_ops/cpu_impl/pool/pool1d.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/pool/pool1d.rs
@@ -1,0 +1,291 @@
+// ── 1D pooling CPU kernels (max and avg, forward and backward) ──
+//
+// Input layout:  `[N, C, L]`
+// Output layout: `[N, C, L_out]`
+// L_out = (L + 2*padding - dilation*(kernel_size-1) - 1) / stride + 1
+
+use crate::ptr::{MutPtr, Ptr};
+use coeus_core::{Backend, CpuAddressableStorage, CpuAddressableStorageMut, Layout, Scalar};
+
+// ── Max Pool 1D forward ──
+
+#[inline]
+pub(crate) fn max_pool1d<T: Scalar, B: Backend>(
+    backend: &B,
+    input: &B::DeviceBuffer<T>,
+    input_layout: &Layout,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+    output: &mut B::DeviceBuffer<T>,
+    output_layout: &Layout,
+) where
+    B::DeviceBuffer<T>: CpuAddressableStorageMut<T>,
+{
+    let n = input_layout.shape()[0];
+    let c = input_layout.shape()[1];
+    let l = input_layout.shape()[2];
+    let l_out = output_layout.shape()[2];
+    let out_numel = n * c * l_out;
+
+    let input_slice = input.as_slice();
+    let output_slice = output.as_mut_slice();
+
+    let input_ptr = Ptr(input_slice.as_ptr());
+    let output_ptr = MutPtr(output_slice.as_mut_ptr());
+
+    let input_layout = input_layout.clone();
+    let output_layout = output_layout.clone();
+
+    let pad_s = padding as isize;
+    let stride_s = stride as isize;
+    let dil_s = dilation as isize;
+    let k_size = kernel_size;
+
+    backend.parallel_for(0, out_numel, move |i| {
+        let ol = i % l_out;
+        let temp = i / l_out;
+        let ci = temp % c;
+        let ni = temp / c;
+
+        let mut max_val: Option<T> = None;
+
+        for ik in 0..k_size {
+            let l_in = ol as isize * stride_s + ik as isize * dil_s - pad_s;
+            if l_in >= 0 && (l_in as usize) < l {
+                let input_idx = input_layout.physical_index(&[ni, ci, l_in as usize]);
+                let val = unsafe { input_ptr.read(input_idx) };
+                max_val = Some(match max_val {
+                    None => val,
+                    Some(m) => if val > m { val } else { m },
+                });
+            }
+        }
+
+        let output_idx = output_layout.physical_index(&[ni, ci, ol]);
+        unsafe {
+            output_ptr.write(output_idx, max_val.unwrap_or(T::zero()));
+        }
+    });
+}
+
+// ── Max Pool 1D backward ──
+
+#[inline]
+pub(crate) fn max_pool1d_backward<T: Scalar, B: Backend>(
+    backend: &B,
+    grad_out: &B::DeviceBuffer<T>,
+    grad_out_layout: &Layout,
+    input: &B::DeviceBuffer<T>,
+    input_layout: &Layout,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+    grad_input: &mut B::DeviceBuffer<T>,
+    grad_input_layout: &Layout,
+) where
+    B::DeviceBuffer<T>: CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
+{
+    let n = input_layout.shape()[0];
+    let c = input_layout.shape()[1];
+    let l = input_layout.shape()[2];
+    let l_out = grad_out_layout.shape()[2];
+    let out_numel = n * c * l_out;
+
+    let input_slice = input.as_slice();
+    let grad_out_slice = grad_out.as_slice();
+    let grad_input_slice = grad_input.as_mut_slice();
+
+    let input_ptr = Ptr(input_slice.as_ptr());
+    let grad_out_ptr = Ptr(grad_out_slice.as_ptr());
+    let grad_input_ptr = MutPtr(grad_input_slice.as_mut_ptr());
+
+    let input_layout = input_layout.clone();
+    let grad_out_layout = grad_out_layout.clone();
+    let grad_input_layout = grad_input_layout.clone();
+
+    let pad_s = padding as isize;
+    let stride_s = stride as isize;
+    let dil_s = dilation as isize;
+    let k_size = kernel_size;
+
+    // Sequential pass: for each output element, find argmax in window and accumulate.
+    // Parallel version would need atomic adds; use sequential for correctness.
+    for i in 0..out_numel {
+        let ol = i % l_out;
+        let temp = i / l_out;
+        let ci = temp % c;
+        let ni = temp / c;
+
+        let mut max_val: Option<T> = None;
+        let mut max_l_in: usize = 0;
+
+        for ik in 0..k_size {
+            let l_in = ol as isize * stride_s + ik as isize * dil_s - pad_s;
+            if l_in >= 0 && (l_in as usize) < l {
+                let idx = input_layout.physical_index(&[ni, ci, l_in as usize]);
+                let val = unsafe { input_ptr.read(idx) };
+                let better = match max_val {
+                    None => true,
+                    Some(m) => val > m,
+                };
+                if better {
+                    max_val = Some(val);
+                    max_l_in = l_in as usize;
+                }
+            }
+        }
+
+        if max_val.is_some() {
+            let g_idx = grad_out_layout.physical_index(&[ni, ci, ol]);
+            let g_val = unsafe { grad_out_ptr.read(g_idx) };
+            let gi_idx = grad_input_layout.physical_index(&[ni, ci, max_l_in]);
+            unsafe {
+                let cur = grad_input_ptr.read(gi_idx);
+                grad_input_ptr.write(gi_idx, cur + g_val);
+            }
+        }
+    }
+    let _ = backend; // backend unused in sequential backward
+}
+
+// ── Avg Pool 1D forward ──
+
+#[inline]
+pub(crate) fn avg_pool1d<T: Scalar, B: Backend>(
+    backend: &B,
+    input: &B::DeviceBuffer<T>,
+    input_layout: &Layout,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+    output: &mut B::DeviceBuffer<T>,
+    output_layout: &Layout,
+) where
+    B::DeviceBuffer<T>: CpuAddressableStorageMut<T>,
+{
+    let n = input_layout.shape()[0];
+    let c = input_layout.shape()[1];
+    let l = input_layout.shape()[2];
+    let l_out = output_layout.shape()[2];
+    let out_numel = n * c * l_out;
+
+    let input_slice = input.as_slice();
+    let output_slice = output.as_mut_slice();
+
+    let input_ptr = Ptr(input_slice.as_ptr());
+    let output_ptr = MutPtr(output_slice.as_mut_ptr());
+
+    let input_layout = input_layout.clone();
+    let output_layout = output_layout.clone();
+
+    let pad_s = padding as isize;
+    let stride_s = stride as isize;
+    let dil_s = dilation as isize;
+    let k_size = kernel_size;
+
+    backend.parallel_for(0, out_numel, move |i| {
+        let ol = i % l_out;
+        let temp = i / l_out;
+        let ci = temp % c;
+        let ni = temp / c;
+
+        let mut sum = T::zero();
+        let mut count = 0usize;
+
+        for ik in 0..k_size {
+            let l_in = ol as isize * stride_s + ik as isize * dil_s - pad_s;
+            if l_in >= 0 && (l_in as usize) < l {
+                let input_idx = input_layout.physical_index(&[ni, ci, l_in as usize]);
+                let val = unsafe { input_ptr.read(input_idx) };
+                sum = sum + val;
+                count += 1;
+            }
+        }
+
+        let mean = if count > 0 {
+            sum / T::from_f64(count as f64)
+        } else {
+            T::zero()
+        };
+
+        let output_idx = output_layout.physical_index(&[ni, ci, ol]);
+        unsafe {
+            output_ptr.write(output_idx, mean);
+        }
+    });
+}
+
+// ── Avg Pool 1D backward ──
+
+#[inline]
+pub(crate) fn avg_pool1d_backward<T: Scalar, B: Backend>(
+    backend: &B,
+    grad_out: &B::DeviceBuffer<T>,
+    grad_out_layout: &Layout,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+    grad_input: &mut B::DeviceBuffer<T>,
+    grad_input_layout: &Layout,
+) where
+    B::DeviceBuffer<T>: CpuAddressableStorageMut<T>,
+{
+    let n = grad_input_layout.shape()[0];
+    let c = grad_input_layout.shape()[1];
+    let l = grad_input_layout.shape()[2];
+    let l_out = grad_out_layout.shape()[2];
+    let out_numel = n * c * l_out;
+
+    let grad_out_slice = grad_out.as_slice();
+    let grad_input_slice = grad_input.as_mut_slice();
+
+    let grad_out_ptr = Ptr(grad_out_slice.as_ptr());
+    let grad_input_ptr = MutPtr(grad_input_slice.as_mut_ptr());
+
+    let grad_out_layout = grad_out_layout.clone();
+    let grad_input_layout = grad_input_layout.clone();
+
+    let pad_s = padding as isize;
+    let stride_s = stride as isize;
+    let dil_s = dilation as isize;
+    let k_size = kernel_size;
+
+    // Sequential backward: scatter 1/count gradient to each input element in the window.
+    for i in 0..out_numel {
+        let ol = i % l_out;
+        let temp = i / l_out;
+        let ci = temp % c;
+        let ni = temp / c;
+
+        // Count valid elements in the window.
+        let mut count = 0usize;
+        for ik in 0..k_size {
+            let l_in = ol as isize * stride_s + ik as isize * dil_s - pad_s;
+            if l_in >= 0 && (l_in as usize) < l {
+                count += 1;
+            }
+        }
+        if count == 0 { continue; }
+
+        let g_idx = grad_out_layout.physical_index(&[ni, ci, ol]);
+        let g_val = unsafe { grad_out_ptr.read(g_idx) };
+        let g_share = g_val / T::from_f64(count as f64);
+
+        for ik in 0..k_size {
+            let l_in = ol as isize * stride_s + ik as isize * dil_s - pad_s;
+            if l_in >= 0 && (l_in as usize) < l {
+                let gi_idx = grad_input_layout.physical_index(&[ni, ci, l_in as usize]);
+                unsafe {
+                    let cur = grad_input_ptr.read(gi_idx);
+                    grad_input_ptr.write(gi_idx, cur + g_share);
+                }
+            }
+        }
+    }
+    let _ = backend;
+}

--- a/coeus-ops/src/backend_ops/traits/pool.rs
+++ b/coeus-ops/src/backend_ops/traits/pool.rs
@@ -1,7 +1,7 @@
 //! Pooling sub-trait.
 //!
 //! [`PoolOps`] is the interface-segregated sub-trait for all pooling
-//! kernel dispatch (max/avg pool 2D/3D forward and backward).
+//! kernel dispatch (max/avg pool 1D/2D/3D forward and backward).
 
 use coeus_core::{ComputeBackend, Layout, Scalar};
 
@@ -13,6 +13,60 @@ use coeus_core::{ComputeBackend, Layout, Scalar};
 ///
 /// [`BackendOps`]: super::super::BackendOps
 pub trait PoolOps<T: Scalar>: ComputeBackend {
+    /// 1D Max Pooling over `[N, C, L]` input.
+    fn max_pool1d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    );
+
+    /// 1D Max Pooling Backward.
+    fn max_pool1d_backward(
+        &self,
+        grad_out: &Self::DeviceBuffer<T>,
+        grad_out_layout: &Layout,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        grad_input: &mut Self::DeviceBuffer<T>,
+        grad_input_layout: &Layout,
+    );
+
+    /// 1D Average Pooling over `[N, C, L]` input.
+    fn avg_pool1d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    );
+
+    /// 1D Average Pooling Backward.
+    fn avg_pool1d_backward(
+        &self,
+        grad_out: &Self::DeviceBuffer<T>,
+        grad_out_layout: &Layout,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        grad_input: &mut Self::DeviceBuffer<T>,
+        grad_input_layout: &Layout,
+    );
+
     /// 2D Max Pooling
     fn max_pool2d(
         &self,


### PR DESCRIPTION
Implements 1D max/avg pooling for Burn parity. CPU kernels, PoolOps trait extension with max/avg pool1d forward+backward, autograd const-generic dispatch (DIM=1), MaxPool1d/AvgPool1d Module structs, public exports, 6 correctness tests all pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements 1D max pooling (`MaxPool1d`) and 1D average pooling (`AvgPool1d`) operations to achieve feature parity with other deep learning frameworks like Burn. The implementation adds CPU kernels for forward and backward passes, extends the `PoolOps` trait with the new operations, integrates them into the autograd system with const-generic dispatch for `DIM=1`, and provides `Module` implementations in `coeus-nn` with full public API exports. Six correctness tests verify forward pass behavior for various scenarios including no padding, different strides, multi-channel inputs, and batched inputs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-ops/src/backend_ops/traits/pool.rs` |
| 2 | `coeus-ops/src/backend_ops/cpu_impl/pool/pool1d.rs` |
| 3 | `coeus-ops/src/backend_ops/cpu_impl/pool/mod.rs` |
| 4 | `coeus-ops/src/backend_ops/cpu_impl.rs` |
| 5 | `coeus-autograd/src/ops/nn/pool.rs` |
| 6 | `coeus-autograd/src/ops/nn/mod.rs` |
| 7 | `coeus-autograd/src/ops/mod.rs` |
| 8 | `coeus-autograd/src/lib.rs` |
| 9 | `coeus-nn/src/pool/pool1d.rs` |
| 10 | `coeus-nn/src/pool/mod.rs` |
| 11 | `coeus-nn/src/lib.rs` |
| 12 | `coeus-nn/tests/pool1d_parity.rs` |
| 13 | `coeus-nn/tests/nn_loss_tests.rs` |
| 14 | `CHANGELOG.md` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-nn/tests/nn_loss_tests.rs` | This file contains a small refactoring (iterator usage) in a loss test unrelated to the pool1d feature implementation |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 1D max and average pooling support across the library.
  * New pooling layers are available for `[N, C, L]` inputs, with configurable kernel size, stride, padding, and dilation.
  * Backward/gradient support was added for 1D pooling as well.

* **Documentation**
  * Updated pooling docs to include 1D support.

* **Tests**
  * Added parity tests covering several 1D pooling scenarios and expected outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->