### PR TITLE
feat(nn): Add vanilla (Elman) RNNCell + Rnn for G-040

### DIFF
--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -98,7 +98,7 @@ pub use pool::{
     GlobalMaxPool2d, GlobalMaxPool3d, MaxPool1d, MaxPool2d, MaxPool3d,
 };
 pub use positional::{RotaryEmbedding, SinusoidalEncoding};
-pub use rnn::{GRUCell, Gru, LSTMCell, Lstm};
+pub use rnn::{GRUCell, Gru, LSTMCell, Lstm, RNNCell, Rnn, RnnNonlinearity};
 pub use sequential::{ModuleExt, Sequential, StaticSeq};
 pub use softmax::{softmax, Softmax};
 pub use transformer::{

--- a/coeus-nn/src/rnn/mod.rs
+++ b/coeus-nn/src/rnn/mod.rs
@@ -4,6 +4,9 @@
 pub mod gru;
 /// Long Short-Term Memory cell and sequence module.
 pub mod lstm;
+/// Vanilla (Elman) RNN cell and sequence module.
+pub mod vanilla;
 
 pub use gru::{GRUCell, Gru};
 pub use lstm::{LSTMCell, Lstm};
+pub use vanilla::{RNNCell, Rnn, RnnNonlinearity};

--- a/coeus-nn/src/rnn/vanilla.rs
+++ b/coeus-nn/src/rnn/vanilla.rs
@@ -1,0 +1,157 @@
+// ── Vanilla (Elman) RNN ──
+
+use crate::linear::Linear;
+use crate::module::Module;
+use coeus_autograd::Var;
+use coeus_core::{Float, MoiraiBackend};
+use coeus_tensor::Tensor;
+
+/// Pointwise nonlinearity applied to a vanilla RNN cell's pre-activation.
+/// Mirrors PyTorch `RNNCell(nonlinearity=...)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RnnNonlinearity {
+    /// `tanh` (PyTorch default).
+    Tanh,
+    /// `relu`.
+    Relu,
+}
+
+/// Single-timestep Elman (vanilla) RNN cell.
+///
+/// Step computation (PyTorch `RNNCell`):
+/// ```text
+/// h_new = f(x @ W_ih.T + b_ih + h @ W_hh.T + b_hh)
+/// ```
+/// where `f` is [`RnnNonlinearity`] (`tanh` or `relu`).
+#[derive(Clone)]
+pub struct RNNCell<T: Float, B: coeus_ops::BackendOps<T> + Default = MoiraiBackend> {
+    /// Input-to-hidden projection: `[input_size, hidden_size]`.
+    pub w_ih: Linear<T, B>,
+    /// Hidden-to-hidden projection: `[hidden_size, hidden_size]`.
+    pub w_hh: Linear<T, B>,
+    /// Pointwise nonlinearity.
+    pub nonlinearity: RnnNonlinearity,
+    /// Number of input features per timestep.
+    pub input_size: usize,
+    /// Number of hidden features.
+    pub hidden_size: usize,
+}
+
+impl<T: Float + coeus_leto::RandomScalar, B: coeus_ops::BackendOps<T> + Default> RNNCell<T, B> {
+    /// Create with Xavier-initialized weights, zero biases, and the given nonlinearity.
+    pub fn new(input_size: usize, hidden_size: usize, nonlinearity: RnnNonlinearity) -> Self {
+        Self {
+            w_ih: Linear::new(input_size, hidden_size, true),
+            w_hh: Linear::new(hidden_size, hidden_size, true),
+            nonlinearity,
+            input_size,
+            hidden_size,
+        }
+    }
+
+    /// Forward step.
+    ///
+    /// - `x`: `[batch, input_size]`
+    /// - `h`: `[batch, hidden_size]`
+    ///
+    /// Returns `h_new` of shape `[batch, hidden_size]`.
+    pub fn step(&self, x: &Var<T, B>, h: &Var<T, B>) -> Var<T, B> {
+        let pre = coeus_autograd::add(&self.w_ih.forward(x), &self.w_hh.forward(h));
+        match self.nonlinearity {
+            RnnNonlinearity::Tanh => coeus_autograd::tanh(&pre),
+            RnnNonlinearity::Relu => coeus_autograd::relu(&pre),
+        }
+    }
+}
+
+impl<T: Float + coeus_leto::RandomScalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B>
+    for RNNCell<T, B>
+{
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        let mut p = self.w_ih.parameters();
+        p.extend(self.w_hh.parameters());
+        p
+    }
+
+    fn forward(&self, x: &Var<T, B>) -> Var<T, B> {
+        let batch = x.tensor.shape()[0];
+        let backend = B::default();
+        let h = Var::new(Tensor::zeros_on([batch, self.hidden_size], &backend), false);
+        self.step(x, &h)
+    }
+}
+
+// ── Rnn (sequence-level) ──
+
+/// Sequence-level vanilla RNN: unrolls [`RNNCell`] across the time axis.
+///
+/// Input layout: `[batch, seq_len, input_size]`.
+/// Output layout: `[batch, seq_len, hidden_size]`.
+/// Final hidden state: `h_n` of shape `[batch, hidden_size]`.
+#[derive(Clone)]
+pub struct Rnn<T: Float, B: coeus_ops::BackendOps<T> + Default = MoiraiBackend> {
+    cell: RNNCell<T, B>,
+    /// Number of input features per timestep.
+    pub input_size: usize,
+    /// Number of hidden features.
+    pub hidden_size: usize,
+}
+
+impl<T: Float + coeus_leto::RandomScalar, B: coeus_ops::BackendOps<T> + Default> Rnn<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    /// Create with Xavier-initialized weights, zero biases, and the given nonlinearity.
+    pub fn new(input_size: usize, hidden_size: usize, nonlinearity: RnnNonlinearity) -> Self {
+        Self {
+            cell: RNNCell::new(input_size, hidden_size, nonlinearity),
+            input_size,
+            hidden_size,
+        }
+    }
+
+    /// Unroll over the sequence dimension with a zero initial hidden state.
+    ///
+    /// Returns `(output, h_n)`:
+    /// - `output`: `[batch, seq_len, hidden_size]` — all hidden states stacked.
+    /// - `h_n`: `[batch, hidden_size]` — final hidden state.
+    pub fn forward_seq(&self, x: &Var<T, B>) -> (Var<T, B>, Var<T, B>) {
+        let batch = x.tensor.shape()[0];
+        let seq_len = x.tensor.shape()[1];
+        let backend = B::default();
+
+        let mut h = Var::new(Tensor::zeros_on([batch, self.hidden_size], &backend), false);
+        let mut outputs: Vec<Var<T, B>> = Vec::with_capacity(seq_len);
+        for t in 0..seq_len {
+            let x_t_3d = coeus_autograd::slice(x, &[(0, batch), (t, t + 1), (0, self.input_size)]);
+            let x_t = coeus_autograd::reshape(&x_t_3d, vec![batch, self.input_size]);
+            let h_new = self.cell.step(&x_t, &h);
+            outputs.push(coeus_autograd::reshape(
+                &h_new,
+                vec![batch, 1, self.hidden_size],
+            ));
+            h = h_new;
+        }
+
+        let refs: Vec<&Var<T, B>> = outputs.iter().collect();
+        let output = coeus_autograd::cat(&refs, 1);
+        (output, h)
+    }
+}
+
+impl<T: Float + coeus_leto::RandomScalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B>
+    for Rnn<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        self.cell.parameters()
+    }
+
+    /// Returns `output` of shape `[batch, seq_len, hidden_size]`.
+    fn forward(&self, x: &Var<T, B>) -> Var<T, B> {
+        self.forward_seq(x).0
+    }
+}

--- a/coeus-nn/tests/rnn_parity.rs
+++ b/coeus-nn/tests/rnn_parity.rs
@@ -20,7 +20,7 @@
 
 use coeus_autograd::Var;
 use coeus_core::{MoiraiBackend, SequentialBackend};
-use coeus_nn::{GRUCell, LSTMCell, Module};
+use coeus_nn::{GRUCell, LSTMCell, Module, RNNCell, RnnNonlinearity};
 use coeus_ops::BackendOps;
 use coeus_tensor::Tensor;
 
@@ -101,6 +101,55 @@ where
 {
     check_gru_cell(backend);
     check_lstm_cell(backend);
+    check_rnn_cell(backend);
+}
+
+fn check_rnn_cell<B: BackendOps<f64> + Default>(backend: &B)
+where
+    B::DeviceBuffer<f64>:
+        coeus_core::CpuAddressableStorage<f64> + coeus_core::CpuAddressableStorageMut<f64>,
+{
+    // Linear::new → all-ones weights, zero bias. RNNCell step:
+    //   h_new = f(x @ W_ih.T + h @ W_hh.T) with W all-ones.
+    let cell = RNNCell::<f64, B>::new(2, 2, RnnNonlinearity::Tanh);
+
+    // x=0, h=0 → pre=0 → tanh(0)=0 exactly.
+    let x0 = zeros_var(&[1, 2], backend);
+    let h0 = zeros_var(&[1, 2], backend);
+    let h_z = cell.step(&x0, &h0);
+    assert_eq!(h_z.tensor.shape(), &[1, 2], "RNN h_new shape");
+    assert_eq!(
+        h_z.tensor.as_slice(),
+        &[0.0_f64, 0.0],
+        "RNN zero-input → zero h_new"
+    );
+
+    // x=[1,2], h=0, all-ones W_ih → pre = [1+2, 1+2] = [3,3]; h_new = tanh(3).
+    let x = Var::new(Tensor::from_slice_on([1, 2], &[1.0, 2.0], backend), false);
+    let h_new = cell.step(&x, &h0);
+    let t3 = 3.0_f64.tanh();
+    let got = h_new.tensor.as_slice();
+    assert!(
+        (got[0] - t3).abs() <= 1e-12 && (got[1] - t3).abs() <= 1e-12,
+        "RNN tanh: got {got:?}, expected [{t3}, {t3}]"
+    );
+
+    // Relu nonlinearity: pre=[3,3] → relu(3)=3 exactly.
+    let cell_relu = RNNCell::<f64, B>::new(2, 2, RnnNonlinearity::Relu);
+    let h_relu = cell_relu.step(&x, &h0);
+    assert_eq!(
+        h_relu.tensor.as_slice(),
+        &[3.0_f64, 3.0],
+        "RNN relu: pre=3 → relu(3)=3"
+    );
+
+    // Module::forward (h_0 = zeros) == step with h=zeros.
+    let h_mod = Module::<f64, B>::forward(&cell, &x);
+    assert_eq!(
+        h_mod.tensor.as_slice(),
+        h_new.tensor.as_slice(),
+        "RNN Module::forward == step with h=zeros"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds the vanilla recurrent surface missing from G-040 (Coeus had only LSTM/GRU).

## Change
- `RNNCell`: `h_new = f(x @ W_ih.T + b_ih + h @ W_hh.T + b_hh)` with tanh/relu nonlinearity (PyTorch `RNNCell`); `RnnNonlinearity` two-variant enum.
- `Rnn`: sequence-level unroll over `[batch, seq, input]` → `[batch, seq, hidden]` + final hidden state.
- Composed from existing Linear/add/tanh/relu autograd ops (no bespoke node), mirroring GRU/LSTM structure.

## Verification
Differential tests (Sequential vs Moirai, all-ones-weight oracle): zero-input → 0, `x=[1,2]` → `tanh(3)`/`relu(3)=3`, `Module::forward == step(h=0)`. 2/2 pass.

Refs: docs/gap_audit.md#g-040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements vanilla (Elman) recurrent neural network cells to complete the RNN functionality gap in the Coeus neural network library. It adds `RNNCell` for single-timestep recurrent computation with configurable `tanh` or `relu` nonlinearity (matching PyTorch's `RNNCell` API), and `Rnn` for sequence-level unrolling. The implementation is composed from existing autograd operations (linear layers, tanh, relu, add) following the same architectural pattern as the existing GRU and LSTM modules. Differential tests verify correctness against zero-input and known oracle values for both nonlinearity variants.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/rnn/vanilla.rs` |
| 2 | `coeus-nn/tests/rnn_parity.rs` |
| 3 | `coeus-nn/src/rnn/mod.rs` |
| 4 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->