### PR TITLE
feat(nn): Bidirectional RNN wrapper (G-040)

### DIFF
--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -98,7 +98,7 @@ pub use pool::{
     GlobalMaxPool2d, GlobalMaxPool3d, MaxPool1d, MaxPool2d, MaxPool3d,
 };
 pub use positional::{RotaryEmbedding, SinusoidalEncoding};
-pub use rnn::{GRUCell, Gru, LSTMCell, Lstm, RNNCell, Rnn, RnnNonlinearity};
+pub use rnn::{Bidirectional, GRUCell, Gru, LSTMCell, Lstm, RNNCell, Rnn, RnnNonlinearity};
 pub use sequential::{ModuleExt, Sequential, StaticSeq};
 pub use softmax::{softmax, Softmax};
 pub use transformer::{

--- a/coeus-nn/src/rnn/bidirectional.rs
+++ b/coeus-nn/src/rnn/bidirectional.rs
@@ -1,0 +1,59 @@
+// ── Bidirectional recurrent wrapper ──
+
+use crate::module::Module;
+use coeus_autograd::Var;
+use coeus_core::Scalar;
+
+/// Bidirectional wrapper over any sequence [`Module`] (e.g. [`Rnn`](super::Rnn),
+/// [`Gru`](super::Gru), [`Lstm`](super::Lstm)).
+///
+/// Runs `forward_module` over the input and `backward_module` over the
+/// time-reversed input, then concatenates the two `[batch, seq, hidden]`
+/// outputs along the hidden axis to `[batch, seq, 2*hidden]` — matching PyTorch
+/// `bidirectional=True`. Generic over the cell type, so no per-cell code: the
+/// reversal and concatenation reuse the tracked `flip`/`cat` autograd ops.
+///
+/// The two sub-modules carry independent parameters (PyTorch likewise learns
+/// separate forward/backward weights).
+#[derive(Clone)]
+pub struct Bidirectional<M> {
+    /// Module applied to the sequence in forward (left-to-right) order.
+    pub forward_module: M,
+    /// Module applied to the time-reversed sequence.
+    pub backward_module: M,
+}
+
+impl<M> Bidirectional<M> {
+    /// Wrap a forward and a (time-reversed) backward sequence module.
+    pub fn new(forward_module: M, backward_module: M) -> Self {
+        Self {
+            forward_module,
+            backward_module,
+        }
+    }
+}
+
+impl<T, B, M> Module<T, B> for Bidirectional<M>
+where
+    T: Scalar,
+    B: coeus_ops::BackendOps<T> + Default,
+    M: Module<T, B>,
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        let mut p = self.forward_module.parameters();
+        p.extend(self.backward_module.parameters());
+        p
+    }
+
+    /// `x`: `[batch, seq_len, input_size]` → `[batch, seq_len, 2*hidden_size]`.
+    fn forward(&self, x: &Var<T, B>) -> Var<T, B> {
+        let fwd = self.forward_module.forward(x);
+        // Reverse along the time axis, run the backward module, then restore order.
+        let rev_x = coeus_autograd::flip(x, 1);
+        let bwd_rev = self.backward_module.forward(&rev_x);
+        let bwd = coeus_autograd::flip(&bwd_rev, 1);
+        coeus_autograd::cat(&[&fwd, &bwd], 2)
+    }
+}

--- a/coeus-nn/src/rnn/mod.rs
+++ b/coeus-nn/src/rnn/mod.rs
@@ -1,5 +1,7 @@
 // ── RNN module ──
 
+/// Bidirectional recurrent wrapper.
+pub mod bidirectional;
 /// Gated Recurrent Unit cell and sequence module.
 pub mod gru;
 /// Long Short-Term Memory cell and sequence module.
@@ -7,6 +9,7 @@ pub mod lstm;
 /// Vanilla (Elman) RNN cell and sequence module.
 pub mod vanilla;
 
+pub use bidirectional::Bidirectional;
 pub use gru::{GRUCell, Gru};
 pub use lstm::{LSTMCell, Lstm};
 pub use vanilla::{RNNCell, Rnn, RnnNonlinearity};

--- a/coeus-nn/tests/rnn_seq_parity.rs
+++ b/coeus-nn/tests/rnn_seq_parity.rs
@@ -29,7 +29,7 @@ use coeus_autograd::Var;
 use coeus_core::{
     CpuAddressableStorage, CpuAddressableStorageMut, MoiraiBackend, SequentialBackend,
 };
-use coeus_nn::{Gru, Lstm, Module};
+use coeus_nn::{Bidirectional, Gru, Lstm, Module, Rnn, RnnNonlinearity};
 use coeus_ops::BackendOps;
 use coeus_tensor::Tensor;
 
@@ -141,6 +141,49 @@ where
 {
     check_lstm(backend);
     check_gru(backend);
+    check_bidirectional(backend);
+}
+
+fn check_bidirectional<B: BackendOps<f64> + Default>(backend: &B)
+where
+    B::DeviceBuffer<f64>: CpuAddressableStorage<f64> + CpuAddressableStorageMut<f64>,
+{
+    // Bidirectional<Rnn>: forward over x, backward over reversed x, concat on hidden.
+    let fwd = Rnn::<f64, B>::new(2, 3, RnnNonlinearity::Tanh);
+    let bwd = Rnn::<f64, B>::new(2, 3, RnnNonlinearity::Tanh);
+    let bi = Bidirectional::new(fwd.clone(), bwd.clone());
+
+    // Zero input → zeros, shape [batch, seq, 2*hidden].
+    let xz = Var::new(Tensor::zeros_on([1, 2, 2], backend), false);
+    let oz = Module::<f64, B>::forward(&bi, &xz);
+    assert_eq!(oz.tensor.shape(), &[1, 2, 6], "bidirectional output shape");
+    assert!(
+        oz.tensor.as_slice().iter().all(|&v| v == 0.0),
+        "bidirectional zero-input → zeros"
+    );
+
+    // Non-zero: the concatenation must place forward output in [0:H] and the
+    // re-reversed backward output in [H:2H] at every timestep.
+    let x = Var::new(
+        Tensor::from_slice_on([1, 2, 2], &[1.0, 2.0, 3.0, 4.0], backend),
+        false,
+    );
+    let o = Module::<f64, B>::forward(&bi, &x);
+    assert_eq!(o.tensor.shape(), &[1, 2, 6]);
+    let o_s = o.tensor.as_slice();
+
+    let f_out = Module::<f64, B>::forward(&fwd, &x);
+    let b_out = coeus_autograd::flip(
+        &Module::<f64, B>::forward(&bwd, &coeus_autograd::flip(&x, 1)),
+        1,
+    );
+    let f_s = f_out.tensor.as_slice(); // [1,2,3]
+    let b_s = b_out.tensor.as_slice(); // [1,2,3]
+    // Layout per (batch, seq): [forward(3), backward(3)].
+    assert_eq!(&o_s[0..3], &f_s[0..3], "t0 forward half");
+    assert_eq!(&o_s[3..6], &b_s[0..3], "t0 backward half");
+    assert_eq!(&o_s[6..9], &f_s[3..6], "t1 forward half");
+    assert_eq!(&o_s[9..12], &b_s[3..6], "t1 backward half");
 }
 
 #[test]
@@ -151,4 +194,42 @@ fn sequential_rnn_seq_match_reference() {
 #[test]
 fn moirai_rnn_seq_match_reference() {
     check_all(&MoiraiBackend);
+}
+
+// ── Bidirectional tests ──
+
+#[test]
+fn bidirectional_lstm_doubles_hidden_dim() {
+    // A Bidirectional<Lstm> with hidden=4 should produce [batch, seq, 8] output.
+    use coeus_nn::{Bidirectional, Lstm, Module};
+    let fwd = Lstm::<f32, SequentialBackend>::new(2, 4);
+    let bwd = Lstm::<f32, SequentialBackend>::new(2, 4);
+    let bi = Bidirectional::new(fwd, bwd);
+
+    let x = Var::new(
+        coeus_tensor::Tensor::<f32, SequentialBackend>::zeros(vec![2, 3, 2]),
+        false,
+    );
+    let y = bi.forward(&x);
+    assert_eq!(y.tensor.shape(), &[2, 3, 8], "bidirectional hidden dim should be 2*hidden");
+}
+
+#[test]
+fn bidirectional_gru_zeros_output_for_zeros_input() {
+    // Zeros input + zeros state → zeros output for any weight init.
+    use coeus_nn::{Bidirectional, Gru, Module};
+    let fwd = Gru::<f32, SequentialBackend>::new(2, 4);
+    let bwd = Gru::<f32, SequentialBackend>::new(2, 4);
+    let bi = Bidirectional::new(fwd, bwd);
+
+    let x = Var::new(
+        coeus_tensor::Tensor::<f32, SequentialBackend>::zeros(vec![1, 5, 2]),
+        false,
+    );
+    let y = bi.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 5, 8]);
+    // Zeros input → zeros output (analytically, same as unidirectional).
+    for &v in y.tensor.as_slice() {
+        assert!((v).abs() < 1e-6, "expected zero output, got {v}");
+    }
 }


### PR DESCRIPTION
Generic Bidirectional<M> wraps any Module (Lstm, Gru, Rnn). Matches PyTorch bidirectional=True: reverses time axis, runs backward module, concatenates [batch,seq,2*hidden]. 4 tests all pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Adds a generic `Bidirectional` wrapper for RNN modules that processes sequences in both forward and backward directions, then concatenates the outputs along the hidden dimension. This implementation matches PyTorch's `bidirectional=True` behavior by reversing the time axis for the backward pass, running a separate backward module, and concatenating the results to produce `[batch, seq, 2*hidden]` outputs. The wrapper works with any RNN type (`Lstm`, `Gru`, `Rnn`) and maintains independent parameters for forward and backward modules. Includes comprehensive tests validating shape transformations and zero-input behavior across all RNN variants.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/rnn/bidirectional.rs` |
| 2 | `coeus-nn/src/rnn/mod.rs` |
| 3 | `coeus-nn/src/lib.rs` |
| 4 | `coeus-nn/tests/rnn_seq_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->