### PR TITLE
fix: repoint coeus patch to eunomia after hermes-numeric promotion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,9 @@ hermes-simd-core = { path = "../hermes/crates/hermes-simd-core" }
 hermes-simd-intrinsics = { path = "../hermes/crates/hermes-simd-intrinsics" }
 hermes-simd-macros = { path = "../hermes/crates/hermes-simd-macros" }
 hermes-simd-types = { path = "../hermes/crates/hermes-simd-types" }
-hermes-numeric = { path = "../hermes/crates/hermes-numeric" }
+
+[patch."https://github.com/ryancinsight/eunomia"]
+eunomia = { path = "../eunomia/crates/eunomia" }
 
 [patch."https://github.com/ryancinsight/melinoe.git"]
 melinoe = { path = "../melinoe" }


### PR DESCRIPTION
Unblocks the coeus build after [hermes#2](https://github.com/ryancinsight/hermes/pull/2) removed `hermes-numeric` (promoted to the [eunomia](https://github.com/ryancinsight/eunomia) foundation repo). The dead `[patch]` for the deleted `hermes-numeric` path caused `failed to load source for dependency hermes-numeric`; replaced with the eunomia path-patch so transitive `hermes-simd`/`leto → eunomia` resolves locally.

Verified: `coeus-core` builds against the eunomia stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a broken dependency reference in the Cargo.toml manifest by removing the obsolete `hermes-numeric` path patch and replacing it with a patch for `eunomia`, which now houses the promoted numeric functionality. This change unblocks the coeus build after `hermes-numeric` was moved to the eunomia foundation repository.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->