### PR TITLE
bench+test(nn): EmbeddingBag Burn benchmark row + PyTorch parity tests (MS-210)

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -21,8 +21,9 @@ use coeus_core::{MoiraiBackend, SequentialBackend};
 use coeus_nn::{
     cross_entropy_loss, gelu, huber_loss, mse_loss, relu, sigmoid, silu, tanh,
     AvgPool1d as CoeusAvgPool1d, AvgPool2d, BatchNorm1d, BatchNorm2d, BatchNorm3d, Conv1d, Conv2d,
-    Conv3d, Embedding, GroupNorm, InstanceNorm2d, LayerNorm, Linear, Lstm, MaxPool1d, MaxPool2d,
-    Module, MultiHeadAttention, NullMask, RMSNorm, TransformerEncoderLayer,
+    Conv3d, Embedding, EmbeddingBag, EmbeddingBagMode, GroupNorm, InstanceNorm2d, LayerNorm,
+    Linear, Lstm, MaxPool1d, MaxPool2d, Module, MultiHeadAttention, NullMask, RMSNorm,
+    TransformerEncoderLayer,
 };
 use coeus_tensor::Tensor;
 
@@ -1273,6 +1274,62 @@ fn bench_avgpool1d_forward(c: &mut Criterion) {
     });
     group.finish();
 }
+fn bench_embeddingbag_sum(c: &mut Criterion) {
+    // EmbeddingBag sum-mode forward: 16 bags × 100 tokens each, vocab=200, dim=64.
+    // Burn 0.16 has no dedicated EmbeddingBag; the equivalent is Embedding::forward + sum_dim.
+    const EB_VOCAB: usize = 200;
+    const EB_DIM: usize = 64;
+    const EB_BAGS: usize = 16;
+    const EB_BAG_SIZE: usize = 100;
+
+    let device = NdArrayDevice::default();
+
+    // Build deterministic indices: each bag cycles through vocab.
+    let flat_indices: Vec<usize> = (0..(EB_BAGS * EB_BAG_SIZE))
+        .map(|i| i % EB_VOCAB)
+        .collect();
+    let offsets: Vec<usize> = (0..EB_BAGS).map(|b| b * EB_BAG_SIZE).collect();
+    let idx_i64_2d: Vec<i64> = flat_indices.iter().map(|&x| x as i64).collect();
+
+    // Burn: Embedding + sum_dim (equivalent to EmbeddingBag sum).
+    let burn_emb = burn::nn::EmbeddingConfig::new(EB_VOCAB, EB_DIM).init::<BurnB>(&device);
+    let x_burn: BurnTensor<BurnB, 2, Int> = BurnTensor::from_data(
+        TensorData::new(idx_i64_2d, [EB_BAGS, EB_BAG_SIZE]),
+        &device,
+    );
+
+    // Coeus EmbeddingBag.
+    let eb_seq = EmbeddingBag::<f32, SequentialBackend>::new(EB_VOCAB, EB_DIM, EmbeddingBagMode::Sum);
+    let eb_moirai = EmbeddingBag::<f32, MoiraiBackend>::new(EB_VOCAB, EB_DIM, EmbeddingBagMode::Sum);
+
+    let mut group = c.benchmark_group(
+        "Burn vs Coeus — EmbeddingBag sum (16 bags × 100 tokens, vocab=200 dim=64)",
+    );
+    group.bench_function("Burn NdArray (Embedding + sum_dim)", |b| {
+        b.iter(|| {
+            let embedded = burn_emb.forward(black_box(x_burn.clone()));
+            black_box(embedded.sum_dim(1))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| {
+            black_box(eb_seq.forward_with_offsets(
+                black_box(&flat_indices),
+                Some(black_box(&offsets)),
+            ))
+        })
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| {
+            black_box(eb_moirai.forward_with_offsets(
+                black_box(&flat_indices),
+                Some(black_box(&offsets)),
+            ))
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -1290,6 +1347,7 @@ criterion_group!(
     bench_mha_forward,
     bench_transformer_encoder_forward,
     bench_embedding_forward,
+    bench_embeddingbag_sum,
     bench_linear_forward_backward,
     bench_lstm_forward,
     bench_instancenorm2d_forward,

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2298,3 +2298,132 @@ def test_multi_margin_matches_pytorch() -> None:
         f"multi_margin: got={loss_pyc.data[0]:.8g}, expected={loss_t.item():.8g}"
     )
     _allclose("multi_margin_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingBag forward parity (G-041)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "EmbeddingBag"),
+    reason="pycoeus.EmbeddingBag not available in this build",
+)
+def test_embeddingbag_sum_matches_pytorch() -> None:
+    """Forward parity: EmbeddingBag(vocab=6, dim=4, mode='sum') with two bags.
+
+    Evidence tier: differential/empirical against ``torch.nn.EmbeddingBag`` at f64.
+    Tolerance 1e-10.
+    """
+    num_embeddings, embedding_dim = 6, 4
+    weight_data = [
+        1.0, 0.0, -1.0, 0.5,    # row 0
+        0.5, 0.5,  0.5, 0.5,    # row 1
+        0.0, 1.0,  0.0, 1.0,    # row 2
+       -1.0, 0.0,  1.0, 0.0,    # row 3
+        0.2, 0.3, -0.2, -0.3,   # row 4
+        0.7,-0.7,  0.7, -0.7,   # row 5
+    ]
+    # Two bags: bag0 = [0, 2, 4], bag1 = [1, 3, 5]
+    flat_indices = [0, 2, 4, 1, 3, 5]
+    offsets = [0, 3]
+
+    eb_pyc = pycoeus.EmbeddingBag(num_embeddings, embedding_dim, "sum")
+    eb_pyc.weight.data = weight_data
+    out_pyc = eb_pyc.forward_with_offsets(flat_indices, offsets)
+
+    # PyTorch reference
+    eb_t = torch.nn.EmbeddingBag(num_embeddings, embedding_dim, mode="sum").double()
+    with torch.no_grad():
+        eb_t.weight.copy_(
+            torch.tensor(weight_data, dtype=torch.float64).reshape(num_embeddings, embedding_dim)
+        )
+    idx_t = torch.tensor(flat_indices, dtype=torch.long)
+    off_t = torch.tensor(offsets, dtype=torch.long)
+    out_t = eb_t(idx_t, off_t)
+
+    _allclose(
+        "embeddingbag_sum_fwd",
+        list(out_pyc.data),
+        out_t.flatten().tolist(),
+        atol=1e-10,
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "EmbeddingBag"),
+    reason="pycoeus.EmbeddingBag not available in this build",
+)
+def test_embeddingbag_mean_matches_pytorch() -> None:
+    """Forward parity: EmbeddingBag(vocab=6, dim=4, mode='mean') with two bags."""
+    num_embeddings, embedding_dim = 6, 4
+    weight_data = [
+        1.0, 0.0, -1.0, 0.5,
+        0.5, 0.5,  0.5, 0.5,
+        0.0, 1.0,  0.0, 1.0,
+       -1.0, 0.0,  1.0, 0.0,
+        0.2, 0.3, -0.2, -0.3,
+        0.7,-0.7,  0.7, -0.7,
+    ]
+    flat_indices = [0, 2, 4, 1, 3, 5]
+    offsets = [0, 3]
+
+    eb_pyc = pycoeus.EmbeddingBag(num_embeddings, embedding_dim, "mean")
+    eb_pyc.weight.data = weight_data
+    out_pyc = eb_pyc.forward_with_offsets(flat_indices, offsets)
+
+    eb_t = torch.nn.EmbeddingBag(num_embeddings, embedding_dim, mode="mean").double()
+    with torch.no_grad():
+        eb_t.weight.copy_(
+            torch.tensor(weight_data, dtype=torch.float64).reshape(num_embeddings, embedding_dim)
+        )
+    idx_t = torch.tensor(flat_indices, dtype=torch.long)
+    off_t = torch.tensor(offsets, dtype=torch.long)
+    out_t = eb_t(idx_t, off_t)
+
+    _allclose(
+        "embeddingbag_mean_fwd",
+        list(out_pyc.data),
+        out_t.flatten().tolist(),
+        atol=1e-10,
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "EmbeddingBag"),
+    reason="pycoeus.EmbeddingBag not available in this build",
+)
+def test_embeddingbag_max_matches_pytorch() -> None:
+    """Forward parity: EmbeddingBag(vocab=6, dim=4, mode='max') with two bags."""
+    num_embeddings, embedding_dim = 6, 4
+    weight_data = [
+        1.0, 0.0, -1.0, 0.5,
+        0.5, 0.5,  0.5, 0.5,
+        0.0, 1.0,  0.0, 1.0,
+       -1.0, 0.0,  1.0, 0.0,
+        0.2, 0.3, -0.2, -0.3,
+        0.7,-0.7,  0.7, -0.7,
+    ]
+    flat_indices = [0, 2, 4, 1, 3, 5]
+    offsets = [0, 3]
+
+    eb_pyc = pycoeus.EmbeddingBag(num_embeddings, embedding_dim, "max")
+    eb_pyc.weight.data = weight_data
+    out_pyc = eb_pyc.forward_with_offsets(flat_indices, offsets)
+
+    eb_t = torch.nn.EmbeddingBag(num_embeddings, embedding_dim, mode="max").double()
+    with torch.no_grad():
+        eb_t.weight.copy_(
+            torch.tensor(weight_data, dtype=torch.float64).reshape(num_embeddings, embedding_dim)
+        )
+    idx_t = torch.tensor(flat_indices, dtype=torch.long)
+    off_t = torch.tensor(offsets, dtype=torch.long)
+    out_t = eb_t(idx_t, off_t)
+
+    _allclose(
+        "embeddingbag_max_fwd",
+        list(out_pyc.data),
+        out_t.flatten().tolist(),
+        atol=1e-10,
+    )
+

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -9,9 +9,10 @@
 module families.
 **Gap**: Current Coeus-vs-Burn benchmarks cover selected forward rows
 (Linear, LayerNorm, RMSNorm, LSTM, InstanceNorm2d, CrossEntropyLoss, MSELoss, HuberLoss, ReLU forward, GeLU forward, Sigmoid forward, Tanh forward, SiLU forward, Conv2d,
-Conv3d, MHA self-attention, Transformer encoder layer, Embedding lookup, BatchNorm1d
-eval forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
-GroupNorm forward, MaxPool2d forward, AvgPool2d forward), not the full NN family
+Conv3d, MHA self-attention, Transformer encoder layer, Embedding lookup, EmbeddingBag sum,
+BatchNorm1d eval forward, BatchNorm2d eval forward, BatchNorm3d eval forward, Conv1d forward,
+GroupNorm forward, MaxPool2d forward, AvgPool2d forward, MaxPool1d forward, AvgPool1d forward),
+not the full NN family
 set needed to claim Burn-level performance parity.
 PyTorch differential coverage similarly remains module-family selective.
 **Acceptance**: Add a benchmark/parity manifest keyed by module family, then add


### PR DESCRIPTION
## Summary

- **bench row** \ench_embeddingbag_sum\ in \coeus-nn/benches/nn_bench.rs\: 16 bags × 100 tokens, vocab=200, dim=64, sum mode. Burn equivalent = Embedding + sum_dim (~178 µs); Coeus Sequential ~145 µs; Coeus Moirai ~144 µs (**~1.2× faster**).
- **3 PyTorch parity tests** in \coeus-python/tests/test_pytorch_parity.py\: \	est_embeddingbag_{sum,mean,max}_matches_pytorch\ — forward differential against \	orch.nn.EmbeddingBag\ at f64, atol=1e-10, using two-bag fixed-weight oracles.
- **G-043 gap_audit update**: adds EmbeddingBag, MaxPool1d, and AvgPool1d to the covered-rows list.

## Validation

- \cargo check -p coeus-nn --benches\ — clean
- \cargo clippy -p coeus-nn --benches -- -D warnings\ — clean
- \cargo bench -p coeus-nn --bench nn_bench -- EmbeddingBag\ — runs and measures

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive benchmarking and PyTorch parity testing for the `EmbeddingBag` neural network module. It introduces a new benchmark row measuring `EmbeddingBag` sum-mode performance (16 bags × 100 tokens, vocab=200, dim=64) comparing Burn's equivalent implementation (Embedding + sum_dim at ~178 µs) against Coeus Sequential (~145 µs) and Moirai (~144 µs) backends, showing roughly **1.2× performance improvement**. The PR also includes three PyTorch differential parity tests for all three reduction modes (`sum`, `mean`, `max`) with f64 precision and 1e-10 tolerance. The gap audit documentation is updated to reflect the new coverage for `EmbeddingBag`, `MaxPool1d`, and `AvgPool1d`.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/gap_audit.md` |
| 2 | `coeus-nn/benches/nn_bench.rs` |
| 3 | `coeus-python/tests/test_pytorch_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->