### PR TITLE
feat(python): AdaptiveAvgPool1d/2d + Unfold2d/Fold2d Python bindings + PyTorch parity tests (MS-213)

### DIFF
--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -151,6 +151,10 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<nn::PyBidirectional>()?;
     m.add_class::<nn::PyMaxPool1d>()?;
     m.add_class::<nn::PyAvgPool1d>()?;
+    m.add_class::<nn::PyAdaptiveAvgPool1d>()?;
+    m.add_class::<nn::PyAdaptiveAvgPool2d>()?;
+    m.add_class::<nn::PyUnfold2d>()?;
+    m.add_class::<nn::PyFold2d>()?;
     m.add_class::<PyLocalCommunicator>()?;
     m.add_class::<PyTcpMesh>()?;
     m.add_class::<PyTcpCommunicator>()?;

--- a/coeus-python/src/nn/mod.rs
+++ b/coeus-python/src/nn/mod.rs
@@ -18,12 +18,14 @@ pub mod module_base;
 pub mod module_list;
 /// Normalization layers (BatchNorm, LayerNorm, RMSNorm, GroupNorm, InstanceNorm).
 pub mod normalization;
-/// Pooling layers (AvgPool, MaxPool, GlobalAvgPool, GlobalMaxPool).
+/// Pooling layers (AvgPool, MaxPool, GlobalAvgPool, GlobalMaxPool, AdaptiveAvgPool).
 pub mod pool;
 /// Recurrent cells (LSTMCell, GRUCell) and Bidirectional wrapper.
 pub mod rnn;
 /// Sequential container that chains module forwards.
 pub mod sequential;
+/// Unfold and Fold sliding-window extraction layers.
+pub mod unfold_fold;
 
 pub use attention::{PyMultiHeadAttention, PyRotaryEmbedding, PyScaledDotProductAttention};
 pub use bilinear::PyBilinear;
@@ -45,8 +47,10 @@ pub use normalization::{
     PyInstanceNorm3d, PyLayerNorm, PyRMSNorm,
 };
 pub use pool::{
-    PyAvgPool1d, PyAvgPool2d, PyAvgPool3d, PyGlobalAvgPool1d, PyGlobalAvgPool2d, PyGlobalAvgPool3d,
-    PyGlobalMaxPool2d, PyGlobalMaxPool3d, PyMaxPool1d, PyMaxPool2d, PyMaxPool3d,
+    PyAdaptiveAvgPool1d, PyAdaptiveAvgPool2d, PyAvgPool1d, PyAvgPool2d, PyAvgPool3d,
+    PyGlobalAvgPool1d, PyGlobalAvgPool2d, PyGlobalAvgPool3d, PyGlobalMaxPool2d, PyGlobalMaxPool3d,
+    PyMaxPool1d, PyMaxPool2d, PyMaxPool3d,
 };
 pub use rnn::{PyBidirectional, PyGRUCell, PyLSTMCell, PyRNNCell};
 pub use sequential::PySequential;
+pub use unfold_fold::{PyFold2d, PyUnfold2d};

--- a/coeus-python/src/nn/pool.rs
+++ b/coeus-python/src/nn/pool.rs
@@ -540,3 +540,95 @@ impl PyAvgPool1d {
     /// Zero gradients (no-op for pooling layers).
     pub fn zero_grad(&self) {}
 }
+
+// ── AdaptiveAvgPool1d ─────────────────────────────────────────────────────────
+
+/// Python-exposed Adaptive 1D Average Pooling layer.
+///
+/// Equivalent to `torch.nn.AdaptiveAvgPool1d(output_size)`.
+#[pyclass(name = "AdaptiveAvgPool1d")]
+pub struct PyAdaptiveAvgPool1d {
+    /// Target spatial output length.
+    #[pyo3(get)]
+    pub output_size: usize,
+}
+
+#[pymethods]
+impl PyAdaptiveAvgPool1d {
+    #[new]
+    /// Create an `AdaptiveAvgPool1d` with the given target output length.
+    pub fn new(output_size: usize) -> Self {
+        Self { output_size }
+    }
+
+    /// Forward pass: `[N, C, L]` → `[N, C, output_size]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let output_size = self.output_size;
+        let pool = coeus_nn::AdaptiveAvgPool1d::<f64, coeus_core::MoiraiBackend>::new(output_size);
+        let inner = py.allow_threads(move || pool.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op for pooling layers).
+    pub fn zero_grad(&self) {}
+}
+
+// ── AdaptiveAvgPool2d ─────────────────────────────────────────────────────────
+
+/// Python-exposed Adaptive 2D Average Pooling layer.
+///
+/// Equivalent to `torch.nn.AdaptiveAvgPool2d((out_h, out_w))`.
+#[pyclass(name = "AdaptiveAvgPool2d")]
+pub struct PyAdaptiveAvgPool2d {
+    /// Target output height.
+    #[pyo3(get)]
+    pub out_h: usize,
+    /// Target output width.
+    #[pyo3(get)]
+    pub out_w: usize,
+}
+
+#[pymethods]
+impl PyAdaptiveAvgPool2d {
+    #[new]
+    #[pyo3(signature = (out_h, out_w = None))]
+    /// Create an `AdaptiveAvgPool2d` pooling to `(out_h, out_w)`.
+    ///
+    /// Passing only one size `n` gives a square `(n, n)` output.
+    pub fn new(out_h: usize, out_w: Option<usize>) -> Self {
+        Self {
+            out_h,
+            out_w: out_w.unwrap_or(out_h),
+        }
+    }
+
+    /// Forward pass: `[N, C, H, W]` → `[N, C, out_h, out_w]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let out_h = self.out_h;
+        let out_w = self.out_w;
+        let pool = coeus_nn::AdaptiveAvgPool2d::<f64, coeus_core::MoiraiBackend>::new(out_h, out_w);
+        let inner = py.allow_threads(move || pool.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op for pooling layers).
+    pub fn zero_grad(&self) {}
+}

--- a/coeus-python/src/nn/unfold_fold.rs
+++ b/coeus-python/src/nn/unfold_fold.rs
@@ -1,0 +1,173 @@
+use crate::tensor::PyTensor;
+use pyo3::prelude::*;
+
+/// Python-exposed Unfold2d layer (sliding-window extraction).
+///
+/// Equivalent to `torch.nn.Unfold(kernel_size, dilation, padding, stride)`.
+/// Extracts `[N, C, H, W]` → `[N, C*kH*kW, H_out*W_out]`.
+#[pyclass(name = "Unfold2d")]
+pub struct PyUnfold2d {
+    /// Square kernel (or height when using per-axis constructor).
+    #[pyo3(get)]
+    pub kernel_h: usize,
+    /// Kernel width.
+    #[pyo3(get)]
+    pub kernel_w: usize,
+    /// Vertical stride.
+    #[pyo3(get)]
+    pub stride_h: usize,
+    /// Horizontal stride.
+    #[pyo3(get)]
+    pub stride_w: usize,
+    /// Vertical padding.
+    #[pyo3(get)]
+    pub padding_h: usize,
+    /// Horizontal padding.
+    #[pyo3(get)]
+    pub padding_w: usize,
+    /// Vertical dilation.
+    #[pyo3(get)]
+    pub dilation_h: usize,
+    /// Horizontal dilation.
+    #[pyo3(get)]
+    pub dilation_w: usize,
+}
+
+#[pymethods]
+impl PyUnfold2d {
+    #[new]
+    #[pyo3(signature = (kernel_size, stride = 1, padding = 0, dilation = 1))]
+    /// Create an `Unfold2d` with a square kernel and equal h/w hyperparameters.
+    pub fn new(kernel_size: usize, stride: usize, padding: usize, dilation: usize) -> Self {
+        Self {
+            kernel_h: kernel_size,
+            kernel_w: kernel_size,
+            stride_h: stride,
+            stride_w: stride,
+            padding_h: padding,
+            padding_w: padding,
+            dilation_h: dilation,
+            dilation_w: dilation,
+        }
+    }
+
+    /// Forward pass: `[N, C, H, W]` → `[N, C*kH*kW, H_out*W_out]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let kh = self.kernel_h;
+        let kw = self.kernel_w;
+        let sh = self.stride_h;
+        let sw = self.stride_w;
+        let ph = self.padding_h;
+        let pw = self.padding_w;
+        let dh = self.dilation_h;
+        let dw = self.dilation_w;
+        let m = coeus_nn::Unfold2d::<f64, coeus_core::MoiraiBackend>::with_params(
+            kh, kw, sh, sw, ph, pw, dh, dw,
+        );
+        let inner = py.allow_threads(move || m.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op — Unfold2d has no parameters).
+    pub fn zero_grad(&self) {}
+}
+
+/// Python-exposed Fold2d layer (inverse of Unfold2d).
+///
+/// Equivalent to `torch.nn.Fold(output_size, kernel_size, ...)`.
+/// Accumulates `[N, C*kH*kW, H_out*W_out]` → `[N, C, output_h, output_w]`.
+#[pyclass(name = "Fold2d")]
+pub struct PyFold2d {
+    /// Target output height.
+    #[pyo3(get)]
+    pub output_h: usize,
+    /// Target output width.
+    #[pyo3(get)]
+    pub output_w: usize,
+    /// Kernel height.
+    #[pyo3(get)]
+    pub kernel_h: usize,
+    /// Kernel width.
+    #[pyo3(get)]
+    pub kernel_w: usize,
+    /// Vertical stride.
+    #[pyo3(get)]
+    pub stride_h: usize,
+    /// Horizontal stride.
+    #[pyo3(get)]
+    pub stride_w: usize,
+    /// Vertical padding.
+    #[pyo3(get)]
+    pub padding_h: usize,
+    /// Horizontal padding.
+    #[pyo3(get)]
+    pub padding_w: usize,
+    /// Vertical dilation.
+    #[pyo3(get)]
+    pub dilation_h: usize,
+    /// Horizontal dilation.
+    #[pyo3(get)]
+    pub dilation_w: usize,
+}
+
+#[pymethods]
+impl PyFold2d {
+    #[new]
+    #[pyo3(signature = (output_h, output_w, kernel_size, stride = 1, padding = 0, dilation = 1))]
+    /// Create a `Fold2d` with a square kernel and equal h/w hyperparameters.
+    pub fn new(
+        output_h: usize,
+        output_w: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+    ) -> Self {
+        Self {
+            output_h,
+            output_w,
+            kernel_h: kernel_size,
+            kernel_w: kernel_size,
+            stride_h: stride,
+            stride_w: stride,
+            padding_h: padding,
+            padding_w: padding,
+            dilation_h: dilation,
+            dilation_w: dilation,
+        }
+    }
+
+    /// Forward pass: `[N, C*kH*kW, H_out*W_out]` → `[N, C, output_h, output_w]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let oh = self.output_h;
+        let ow = self.output_w;
+        let kh = self.kernel_h;
+        let sh = self.stride_h;
+        let ph = self.padding_h;
+        let dh = self.dilation_h;
+        let m = coeus_nn::Fold2d::<f64, coeus_core::MoiraiBackend>::new(oh, ow, kh, sh, ph, dh);
+        let inner = py.allow_threads(move || m.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op — Fold2d has no parameters).
+    pub fn zero_grad(&self) {}
+}

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2427,3 +2427,116 @@ def test_embeddingbag_max_matches_pytorch() -> None:
         atol=1e-10,
     )
 
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveAvgPool1d and AdaptiveAvgPool2d parity (MS-213)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "AdaptiveAvgPool1d"),
+    reason="pycoeus.AdaptiveAvgPool1d not available in this build",
+)
+def test_adaptive_avg_pool1d_matches_pytorch() -> None:
+    """Forward parity: AdaptiveAvgPool1d(output_size=3) on [2, 4, 8]."""
+    n, c, l = 2, 4, 8
+    output_size = 3
+    data = [float(i) * 0.25 - 1.0 for i in range(n * c * l)]
+
+    m_pyc = pycoeus.AdaptiveAvgPool1d(output_size)
+    x_pyc = pycoeus.Tensor(data, [n, c, l])
+    y_pyc = m_pyc.forward(x_pyc)
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, l)
+    m_t = torch.nn.AdaptiveAvgPool1d(output_size)
+    y_t = m_t(x_t)
+
+    _allclose(
+        "adaptive_avg_pool1d",
+        list(y_pyc.data),
+        y_t.flatten().tolist(),
+        atol=1e-10,
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "AdaptiveAvgPool2d"),
+    reason="pycoeus.AdaptiveAvgPool2d not available in this build",
+)
+def test_adaptive_avg_pool2d_global_matches_pytorch() -> None:
+    """Forward parity: AdaptiveAvgPool2d(1) (global avg) on [2, 3, 6, 6]."""
+    n, c, h, w = 2, 3, 6, 6
+    data = [float(i) * 0.1 - 3.0 for i in range(n * c * h * w)]
+
+    m_pyc = pycoeus.AdaptiveAvgPool2d(1)
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w])
+    y_pyc = m_pyc.forward(x_pyc)
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, h, w)
+    m_t = torch.nn.AdaptiveAvgPool2d(1)
+    y_t = m_t(x_t)
+
+    _allclose(
+        "adaptive_avg_pool2d_global",
+        list(y_pyc.data),
+        y_t.flatten().tolist(),
+        atol=1e-10,
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "AdaptiveAvgPool2d"),
+    reason="pycoeus.AdaptiveAvgPool2d not available in this build",
+)
+def test_adaptive_avg_pool2d_non_trivial_matches_pytorch() -> None:
+    """Forward parity: AdaptiveAvgPool2d(3, 4) on [1, 2, 6, 8] (non-square output)."""
+    n, c, h, w = 1, 2, 6, 8
+    out_h, out_w = 3, 4
+    data = [float(i) * 0.05 - 1.5 for i in range(n * c * h * w)]
+
+    m_pyc = pycoeus.AdaptiveAvgPool2d(out_h, out_w)
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w])
+    y_pyc = m_pyc.forward(x_pyc)
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, h, w)
+    m_t = torch.nn.AdaptiveAvgPool2d((out_h, out_w))
+    y_t = m_t(x_t)
+
+    _allclose(
+        "adaptive_avg_pool2d_non_trivial",
+        list(y_pyc.data),
+        y_t.flatten().tolist(),
+        atol=1e-10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unfold2d parity (MS-213)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "Unfold2d"),
+    reason="pycoeus.Unfold2d not available in this build",
+)
+def test_unfold2d_matches_pytorch() -> None:
+    """Forward parity: Unfold2d(kernel=3, stride=1, padding=0) on [1, 2, 5, 5]."""
+    n, c, h, w = 1, 2, 5, 5
+    kernel, stride, padding = 3, 1, 0
+    data = [float(i) * 0.1 for i in range(n * c * h * w)]
+
+    m_pyc = pycoeus.Unfold2d(kernel, stride, padding, 1)
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w])
+    y_pyc = m_pyc.forward(x_pyc)
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, h, w)
+    m_t = torch.nn.Unfold(kernel_size=kernel, stride=stride, padding=padding)
+    y_t = m_t(x_t)
+
+    _allclose(
+        "unfold2d",
+        list(y_pyc.data),
+        y_t.flatten().tolist(),
+        atol=1e-10,
+    )


### PR DESCRIPTION
Extends pycoeus with 4 new stateless NN module bindings and 4 PyTorch parity tests.

Bindings: PyAdaptiveAvgPool1d, PyAdaptiveAvgPool2d (square or asymmetric output), PyUnfold2d, PyFold2d.

Tests: test_adaptive_avg_pool1d_matches_pytorch, test_adaptive_avg_pool2d_global_matches_pytorch, test_adaptive_avg_pool2d_non_trivial_matches_pytorch, test_unfold2d_matches_pytorch. All at f64 atol=1e-10.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Python bindings for four new neural network operations: `AdaptiveAvgPool1d`, `AdaptiveAvgPool2d`, `Unfold2d`, and `Fold2d`. Each binding wraps the corresponding Rust implementation from the `coeus_nn` crate and includes stateless forward pass methods. The PR also includes four PyTorch parity tests that verify the correctness of the new bindings at high precision (f64 with atol=1e-10), ensuring that outputs match PyTorch's reference implementations for adaptive average pooling and unfold operations.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/src/nn/pool.rs` |
| 3 | `coeus-python/src/nn/unfold_fold.rs` |
| 4 | `coeus-python/src/nn/mod.rs` |
| 5 | `coeus-python/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python-accessible 1D and 2D adaptive average pooling layers.
  * Added Python-accessible 2D unfold and fold operations for sliding-window tensor transforms.
  * Improved pooling documentation to reflect the broader set of supported pooling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->