### PR TITLE
feat+test: Unfold1d binding + BatchNorm1d training parity + JAX/PyTorch tests (MS-214)

### DIFF
--- a/coeus-nn/tests/norm_parity.rs
+++ b/coeus-nn/tests/norm_parity.rs
@@ -236,9 +236,68 @@ where
     B::DeviceBuffer<f64>: CpuAddressableStorage<f64> + CpuAddressableStorageMut<f64>,
 {
     check_batch_norm_1d(backend);
+    check_batch_norm_1d_training(backend);
     check_group_norm(backend);
     check_functional_group_norm(backend);
     check_rms_norm(backend);
+}
+
+// ── BatchNorm1d training mode ─────────────────────────────────────────────────
+
+/// BatchNorm1d training-mode analytical oracle.
+///
+/// Input `[2, 1, 2]` = `[[[1, 3]], [[5, 7]]]`, C=1 (two batches, seq=2).
+/// Training mode computes per-batch mean+variance over (N, L) = 4 elements.
+///
+/// Population mean = (1+3+5+7)/4 = 4.0
+/// Population variance (unbiased, N=4) = ((1-4)²+(3-4)²+(5-4)²+(7-4)²)/4 = (9+1+1+9)/4 = 5.0
+/// NOTE: PyTorch BatchNorm uses *population* variance in the forward pass (no Bessel correction),
+/// but stores the *unbiased* variance in running_var. Here we verify just the forward output.
+///
+/// With eps=0, weight=1, bias=0:
+/// x_hat_i = (x_i - 4) / sqrt(5)  for each element
+/// x_hat = [(-3, -1, 1, 3) / sqrt(5)]
+///        = [-1.341640..., -0.447213..., 0.447213..., 1.341640...]
+fn check_batch_norm_1d_training<B: BackendOps<f64> + Default>(backend: &B)
+where
+    B::DeviceBuffer<f64>: CpuAddressableStorageMut<f64>,
+{
+    let weight = Var::new(Tensor::from_slice_on(vec![1], &[1.0_f64], backend), true);
+    let bias = Var::new(Tensor::from_slice_on(vec![1], &[0.0_f64], backend), true);
+    let running_mean = Tensor::zeros_on([1], backend);
+    let running_var = Tensor::ones_on([1], backend);
+
+    let mut bn = BatchNorm1d::from_parts(1, weight, bias, 0.0, 0.0, running_mean, running_var);
+    // is_training = true by default
+
+    let inp = Var::new(
+        Tensor::from_slice_on(vec![2, 1, 2], &[1.0_f64, 3.0, 5.0, 7.0], backend),
+        true,
+    );
+    let out = Module::<f64, B>::forward(&bn, &inp);
+    assert_eq!(out.tensor.shape(), &[2, 1, 2]);
+
+    let s = out.tensor.as_slice();
+    let mean = 4.0_f64;
+    let var = 5.0_f64; // population variance of {1,3,5,7}
+    let std = var.sqrt();
+    let expected = [
+        (1.0 - mean) / std,
+        (3.0 - mean) / std,
+        (5.0 - mean) / std,
+        (7.0 - mean) / std,
+    ];
+    for (i, (&got, &exp)) in s.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (got - exp).abs() < 1e-10,
+            "BN1d training [{i}]: got {got:.10}, expected {exp:.10}"
+        );
+    }
+
+    // Verify backward propagates to weight and bias.
+    out.backward();
+    assert!(bn.weight.grad().is_some(), "weight grad must exist");
+    assert!(bn.bias.grad().is_some(), "bias grad must exist");
 }
 
 #[test]

--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -155,6 +155,7 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<nn::PyAdaptiveAvgPool2d>()?;
     m.add_class::<nn::PyUnfold2d>()?;
     m.add_class::<nn::PyFold2d>()?;
+    m.add_class::<nn::PyUnfold1d>()?;
     m.add_class::<PyLocalCommunicator>()?;
     m.add_class::<PyTcpMesh>()?;
     m.add_class::<PyTcpCommunicator>()?;

--- a/coeus-python/src/nn/mod.rs
+++ b/coeus-python/src/nn/mod.rs
@@ -53,4 +53,4 @@ pub use pool::{
 };
 pub use rnn::{PyBidirectional, PyGRUCell, PyLSTMCell, PyRNNCell};
 pub use sequential::PySequential;
-pub use unfold_fold::{PyFold2d, PyUnfold2d};
+pub use unfold_fold::{PyFold2d, PyUnfold1d, PyUnfold2d};

--- a/coeus-python/src/nn/unfold_fold.rs
+++ b/coeus-python/src/nn/unfold_fold.rs
@@ -171,3 +171,65 @@ impl PyFold2d {
     /// Zero gradients (no-op — Fold2d has no parameters).
     pub fn zero_grad(&self) {}
 }
+
+// ── Unfold1d ──────────────────────────────────────────────────────────────────
+
+/// Python-exposed Unfold1d layer (1D sliding-window extraction).
+///
+/// Extracts `[N, C, L]` → `[N, C*kernel_size, L_out]`.
+/// The Rust equivalent does not have a direct PyTorch module API (PyTorch uses
+/// `nn.Unfold` only in 2D), so parity is verified against the manual
+/// `unfold` tensor method: `x.unfold(dim, size, step)`.
+#[pyclass(name = "Unfold1d")]
+pub struct PyUnfold1d {
+    /// Sliding window length.
+    #[pyo3(get)]
+    pub kernel_size: usize,
+    /// Window stride.
+    #[pyo3(get)]
+    pub stride: usize,
+    /// Zero-padding on each side.
+    #[pyo3(get)]
+    pub padding: usize,
+    /// Dilation factor.
+    #[pyo3(get)]
+    pub dilation: usize,
+}
+
+#[pymethods]
+impl PyUnfold1d {
+    #[new]
+    #[pyo3(signature = (kernel_size, stride = 1, padding = 0, dilation = 1))]
+    /// Create an `Unfold1d` layer.
+    pub fn new(kernel_size: usize, stride: usize, padding: usize, dilation: usize) -> Self {
+        Self {
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        }
+    }
+
+    /// Forward pass: `[N, C, L]` → `[N, C*kernel_size, L_out]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let k = self.kernel_size;
+        let s = self.stride;
+        let p = self.padding;
+        let d = self.dilation;
+        let m = coeus_nn::Unfold1d::<f64, coeus_core::MoiraiBackend>::new(k, s, p, d);
+        let inner = py.allow_threads(move || m.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op — Unfold1d has no parameters).
+    pub fn zero_grad(&self) {}
+}

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -804,3 +804,29 @@ def test_multi_margin_matches_jax() -> None:
     x_j = jnp.asarray(x_data, dtype=jnp.float64).reshape(2, 3)
     assert abs(loss_pyc.data[0] - float(f(x_j))) < _ATOL
     _allclose("multi_margin_dx", list(x_pyc.grad), jax.grad(f)(x_j).flatten().tolist())
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveAvgPool2d parity (MS-214)
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_avg_pool2d_global_matches_jax() -> None:
+    """Forward parity: AdaptiveAvgPool2d(1) (global avg) on [2, 3, 5, 5].
+
+    JAX reference: jnp.mean over last two spatial axes with keepdims.
+    """
+    n, c, h, w = 2, 3, 5, 5
+    data = [float(i) * 0.1 - 2.5 for i in range(n * c * h * w)]
+
+    if not hasattr(pycoeus, "AdaptiveAvgPool2d"):
+        pytest.skip("pycoeus.AdaptiveAvgPool2d not available")
+
+    m_pyc = pycoeus.AdaptiveAvgPool2d(1)
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w])
+    y_pyc = m_pyc.forward(x_pyc)
+
+    x_j = jnp.asarray(data, dtype=jnp.float64).reshape(n, c, h, w)
+    y_j = jnp.mean(x_j, axis=(-2, -1), keepdims=True)
+
+    _allclose("adaptive_avg_pool2d_global_jax", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-10)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2540,3 +2540,44 @@ def test_unfold2d_matches_pytorch() -> None:
         y_t.flatten().tolist(),
         atol=1e-10,
     )
+
+
+# ---------------------------------------------------------------------------
+# Unfold1d parity (MS-214)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "Unfold1d"),
+    reason="pycoeus.Unfold1d not available in this build",
+)
+def test_unfold1d_matches_pytorch() -> None:
+    """Forward parity: Unfold1d(kernel=3, stride=1) on [2, 3, 7].
+
+    PyTorch equivalent: x.unfold(dim=2, size=3, step=1) then permute + reshape.
+    """
+    n, c, l = 2, 3, 7
+    kernel, stride = 3, 1
+    data = [float(i) * 0.1 - 1.5 for i in range(n * c * l)]
+
+    m_pyc = pycoeus.Unfold1d(kernel, stride, 0, 1)
+    x_pyc = pycoeus.Tensor(data, [n, c, l])
+    y_pyc = m_pyc.forward(x_pyc)
+
+    # PyTorch: x.unfold(dim, size, step) → [N, C, L_out, kernel]
+    # Coeus output: [N, C*kernel, L_out] with layout [n, c*k+ki, lo]
+    # ki is the SLOW index: row 0..kernel covers ki for c=0,
+    # then ki for c=1, etc.
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, l)
+    y_t_raw = x_t.unfold(2, kernel, stride)  # [N, C, L_out, kernel]
+    # PyTorch stores [N, C, L_out, kernel]; Coeus stores [N, C*kernel, L_out]
+    # where the inner dimension is (ci * kernel + ki).
+    # Reshape PyTorch output to [N, C*kernel, L_out]:
+    y_t = y_t_raw.permute(0, 1, 3, 2).reshape(n, c * kernel, -1)
+
+    _allclose(
+        "unfold1d",
+        list(y_pyc.data),
+        y_t.flatten().tolist(),
+        atol=1e-10,
+    )


### PR DESCRIPTION
Unfold1d Python binding, BatchNorm1d training-mode analytical test, PyTorch parity for Unfold1d, JAX parity for AdaptiveAvgPool2d global pooling. All clean check/clippy.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Python bindings for the `Unfold1d` layer, introduces an analytical training-mode test for `BatchNorm1d` to verify correct normalization behavior during training, and adds comprehensive parity tests against PyTorch for `Unfold1d` and JAX for `AdaptiveAvgPool2d` global pooling. The changes ensure the new `Unfold1d` binding works correctly and that existing normalization and pooling operations match their reference implementations in popular frameworks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/lib.rs` |
| 2 | `coeus-python/src/nn/mod.rs` |
| 3 | `coeus-python/src/nn/unfold_fold.rs` |
| 4 | `coeus-nn/tests/norm_parity.rs` |
| 5 | `coeus-python/tests/test_pytorch_parity.py` |
| 6 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->