### PR TITLE
feat(nn): SwiGLU gated feed-forward unit (Burn parity)

### DIFF
--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -63,6 +63,8 @@ pub mod rnn;
 pub mod sequential;
 /// Softmax layer and functional softmax.
 pub mod softmax;
+/// SwiGLU gated feed-forward unit.
+pub mod swiglu;
 /// Transformer encoder, decoder, and sub-layers.
 pub mod transformer;
 
@@ -109,6 +111,7 @@ pub use regularization::{AlphaDropout, FeatureAlphaDropout, GaussianNoise, Local
 pub use rnn::{Bidirectional, GRUCell, Gru, LSTMCell, Lstm, RNNCell, Rnn, RnnNonlinearity};
 pub use sequential::{ModuleExt, Sequential, StaticSeq};
 pub use softmax::{softmax, Softmax};
+pub use swiglu::SwiGlu;
 pub use transformer::{
     feed_forward, transformer_decoder_layer, transformer_encoder_layer, FeedForward, Transformer,
     TransformerDecoder, TransformerDecoderLayer, TransformerDecoderLayerParams, TransformerEncoder,

--- a/coeus-nn/src/swiglu.rs
+++ b/coeus-nn/src/swiglu.rs
@@ -1,0 +1,51 @@
+//! SwiGLU gated feed-forward unit.
+//!
+//! `SwiGLU(x) = silu(W_inner · x) ⊙ (W_outer · x)` — the Swish/SiLU-gated linear
+//! unit used in modern transformer feed-forward blocks (PaLM, LLaMA). Two
+//! parallel linear projections of the same input share the input tensor; the
+//! inner projection is SiLU-gated and multiplied element-wise by the outer
+//! projection. Burn parity: `burn::nn::SwiGlu`.
+
+use crate::activation::silu;
+use crate::linear::Linear;
+use crate::module::Module;
+use coeus_autograd::Var;
+use coeus_core::{Float, MoiraiBackend};
+
+/// SwiGLU gated linear unit projecting `d_input -> d_output`.
+///
+/// Composed of two [`Linear`] layers over the same input: the inner projection
+/// is SiLU-gated, the outer is the gate's value path, combined by an
+/// element-wise product. Generic over any [`Float`] scalar and backend.
+#[derive(Clone)]
+pub struct SwiGlu<T: Float, B: coeus_ops::BackendOps<T> + Default = MoiraiBackend> {
+    /// Inner (SiLU-gated) projection, weight `[d_output × d_input]`.
+    pub linear_inner: Linear<T, B>,
+    /// Outer (value) projection, weight `[d_output × d_input]`.
+    pub linear_outer: Linear<T, B>,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> SwiGlu<T, B> {
+    /// Create a SwiGLU unit projecting `d_input -> d_output`, with optional bias
+    /// on both linear layers.
+    pub fn new(d_input: usize, d_output: usize, bias: bool) -> Self {
+        Self {
+            linear_inner: Linear::new(d_input, d_output, bias),
+            linear_outer: Linear::new(d_input, d_output, bias),
+        }
+    }
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for SwiGlu<T, B> {
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        let mut params = self.linear_inner.parameters();
+        params.extend(self.linear_outer.parameters());
+        params
+    }
+
+    fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        let gated = silu(&self.linear_inner.forward(input));
+        let outer = self.linear_outer.forward(input);
+        coeus_autograd::mul(&gated, &outer)
+    }
+}

--- a/coeus-nn/tests/swiglu_tests.rs
+++ b/coeus-nn/tests/swiglu_tests.rs
@@ -1,0 +1,91 @@
+// ── SwiGLU gated feed-forward unit: value-semantic tests ──
+//
+// `SwiGlu::new` builds two ones-initialised Linear layers, so each projection
+// maps a row to its element sum: inner(row) = outer(row) = S = sum(row). With
+// no bias the forward is therefore the closed form
+//     SwiGLU(row)[j] = silu(S) * S   for every output column j,
+// which we assert exactly (analytic oracle), plus the parameter inventory and
+// gradient flow through the composed silu/mul/matmul graph.
+//
+// Burn parity: burn::nn::SwiGlu (silu(linear_inner(x)) ⊙ linear_outer(x)).
+
+use coeus_autograd::Var;
+use coeus_core::MoiraiBackend;
+use coeus_nn::{Module, SwiGlu};
+use coeus_tensor::Tensor;
+
+/// Reference SiLU: x · sigmoid(x).
+fn silu_f64(x: f64) -> f64 {
+    x / (1.0 + (-x).exp())
+}
+
+fn assert_close_slice(label: &str, got: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(got.len(), expected.len(), "{label}: length mismatch");
+    for (&g, &e) in got.iter().zip(expected.iter()) {
+        assert!(
+            (g - e).abs() <= tol,
+            "{label}: expected {e} got {g} (diff {:.3e})",
+            (g - e).abs()
+        );
+    }
+}
+
+#[test]
+fn swiglu_forward_matches_analytic() {
+    // ones-weight projection ⇒ each output column equals the input row sum S.
+    // Two rows with sums 6 and 1; d_output = 2 (both columns share S).
+    let (d_input, d_output) = (3usize, 2usize);
+    let data = vec![1.0_f64, 2.0, 3.0, 0.0, 1.0, 0.0]; // [2 × 3], row sums 6, 1
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2, d_input], &data),
+        true,
+    );
+
+    let swiglu = SwiGlu::<f64, MoiraiBackend>::new(d_input, d_output, false);
+    let output = swiglu.forward(&input);
+
+    // Tolerance: the only transcendental is silu's sigmoid (~1 ulp); the result
+    // magnitude is ~36, so the analytic error is O(1e-14). 1e-10 is a safe
+    // margin well below any real divergence.
+    let (s0, s1) = (6.0_f64, 1.0_f64);
+    let (v0, v1) = (silu_f64(s0) * s0, silu_f64(s1) * s1);
+    let expected = vec![v0, v0, v1, v1]; // [2 × 2], row-major
+    assert_close_slice("swiglu_forward", output.tensor.as_slice(), &expected, 1e-10);
+}
+
+#[test]
+fn swiglu_parameter_inventory() {
+    // No bias: two weight matrices. With bias: two weights + two bias vectors.
+    let no_bias = SwiGlu::<f64, MoiraiBackend>::new(4, 8, false);
+    assert_eq!(no_bias.parameters().len(), 2);
+    let with_bias = SwiGlu::<f64, MoiraiBackend>::new(4, 8, true);
+    assert_eq!(with_bias.parameters().len(), 4);
+}
+
+#[test]
+fn swiglu_backward_populates_parameter_grads() {
+    let swiglu = SwiGlu::<f64, MoiraiBackend>::new(3, 2, true);
+    let data = vec![0.5_f64, -1.0, 2.0];
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([1, 3], &data),
+        true,
+    );
+
+    let output = swiglu.forward(&input);
+    output.backward();
+
+    for (i, p) in swiglu.parameters().iter().enumerate() {
+        let grad = p
+            .grad()
+            .unwrap_or_else(|| panic!("param {i} missing gradient"));
+        assert_eq!(
+            grad.as_slice().len(),
+            p.tensor.as_slice().len(),
+            "param {i}: gradient shape mismatch"
+        );
+        assert!(
+            grad.as_slice().iter().all(|x: &f64| x.is_finite()),
+            "param {i}: gradient has non-finite entries"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Adds **SwiGLU**, the SiLU-gated linear unit used in modern transformer FFN blocks (PaLM, LLaMA) — a genuine `burn::nn::SwiGlu` parity gap (coeus had `glu` but not SwiGLU).

`SwiGLU(x) = silu(W_inner · x) ⊙ (W_outer · x)`

Composed from two `Linear` projections + `silu` + element-wise `mul`; generic over any `Float` scalar and backend. New leaf module `coeus-nn/src/swiglu.rs` (deep-vertical hierarchy). `Module` impl exposes both projections' parameters and threads gradients through the composed graph.

## Verification
- **Value-semantic** (`swiglu_forward_matches_analytic`): ones-weight init reduces each projection to the input row sum `S`, so the forward is the closed form `silu(S)·S`, asserted analytically (tol 1e-10, derived from the single transcendental).
- **Parameter inventory**: 2 weights (no bias) / 4 with bias.
- **Gradient flow**: backward populates correctly-shaped, finite grads on every parameter.
- 3/3 pass · `cargo fmt --check` clean · `cargo clippy --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a **SwiGLU** (Swish/SiLU-gated linear unit) module to achieve parity with `burn::nn::SwiGlu`. SwiGLU is a gated feed-forward component used in modern transformer architectures like PaLM and LLaMA. The implementation composes two parallel `Linear` projections where one is gated by the `silu` activation and element-wise multiplied with the other. The module is fully generic over float types and backends, exposes both linear projections' parameters, and properly threads gradients through the computational graph. Comprehensive tests validate the forward pass against an analytic oracle (using ones-initialized weights), verify parameter counts with and without bias, and confirm gradient flow through all parameters.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/swiglu.rs` |
| 2 | `coeus-nn/tests/swiglu_tests.rs` |
| 3 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->