### PR TITLE
feat(python): SwiGLU pyo3 binding + PyTorch parity test

### DIFF
--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -135,6 +135,7 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<nn::PyMultiHeadAttention>()?;
     m.add_class::<nn::PyRotaryEmbedding>()?;
     m.add_class::<nn::PyFeedForward>()?;
+    m.add_class::<nn::PySwiGlu>()?;
     m.add_class::<nn::PyTransformerDecoderLayer>()?;
     m.add_class::<nn::PyTransformerDecoder>()?;
     m.add_class::<nn::PyTransformerEncoderLayer>()?;

--- a/coeus-python/src/nn/feedforward/mod.rs
+++ b/coeus-python/src/nn/feedforward/mod.rs
@@ -6,6 +6,7 @@
 // `positional.rs`.
 
 mod positional;
+mod swiglu;
 mod transformer;
 
 use crate::nn::linear::PyLinear;
@@ -150,6 +151,7 @@ impl PyFeedForward {
 }
 
 pub use positional::PySinusoidalEncoding;
+pub use swiglu::PySwiGlu;
 pub use transformer::decoder::PyTransformerDecoder;
 pub use transformer::decoder_layer::PyTransformerDecoderLayer;
 pub use transformer::encoder::PyTransformerEncoder;

--- a/coeus-python/src/nn/feedforward/swiglu.rs
+++ b/coeus-python/src/nn/feedforward/swiglu.rs
@@ -1,0 +1,143 @@
+// ── SwiGLU ────────────────────────────────────────────────────────
+//
+// PySwiGlu binds the SwiGLU gated feed-forward unit (coeus_nn::SwiGlu).
+// It holds two PyLinear sub-modules — the inner SiLU-gated projection and the
+// outer value projection — exposed via `#[pyo3(get)]` so Python can inject
+// weights (e.g. for PyTorch parity testing).
+
+use crate::nn::linear::PyLinear;
+use crate::tensor::PyTensor;
+use coeus_nn::Module;
+use pyo3::prelude::*;
+
+/// Python-exposed SwiGLU gated linear unit.
+///
+/// `SwiGLU(x) = silu(linear_inner(x)) ⊙ linear_outer(x)`. Both projections
+/// (`d_input → d_output`) are accessible and mutable from Python.
+///
+/// ```python
+/// sg = pycoeus.SwiGlu(d_input=256, d_output=512, bias=False)
+/// out = sg.forward(x)                  # x: [..., d_input]
+/// sg.linear_inner.weight.data = wi     # inject weights for parity
+/// ```
+#[pyclass(name = "SwiGlu")]
+pub struct PySwiGlu {
+    /// Inner (SiLU-gated) projection, `d_input → d_output`.
+    #[pyo3(get)]
+    pub linear_inner: Py<PyLinear>,
+    /// Outer (value) projection, `d_input → d_output`.
+    #[pyo3(get)]
+    pub linear_outer: Py<PyLinear>,
+}
+
+#[pymethods]
+impl PySwiGlu {
+    #[new]
+    #[pyo3(signature = (d_input, d_output, bias = false))]
+    /// Create a SwiGLU unit projecting `d_input → d_output`, with optional bias
+    /// on both linear layers (default `false`, matching Burn).
+    pub fn new(py: Python<'_>, d_input: usize, d_output: usize, bias: bool) -> PyResult<Self> {
+        let init = coeus_nn::SwiGlu::<f64, coeus_core::MoiraiBackend>::new(d_input, d_output, bias);
+        let linear_inner = Py::new(
+            py,
+            PyLinear {
+                weight: Py::new(
+                    py,
+                    PyTensor {
+                        inner: init.linear_inner.weight,
+                    },
+                )?,
+                bias: init
+                    .linear_inner
+                    .bias
+                    .map(|v| Py::new(py, PyTensor { inner: v }))
+                    .transpose()?,
+            },
+        )?;
+        let linear_outer = Py::new(
+            py,
+            PyLinear {
+                weight: Py::new(
+                    py,
+                    PyTensor {
+                        inner: init.linear_outer.weight,
+                    },
+                )?,
+                bias: init
+                    .linear_outer
+                    .bias
+                    .map(|v| Py::new(py, PyTensor { inner: v }))
+                    .transpose()?,
+            },
+        )?;
+        Ok(Self {
+            linear_inner,
+            linear_outer,
+        })
+    }
+
+    /// Forward pass: `silu(linear_inner(x)) ⊙ linear_outer(x)`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        let w_inner = self
+            .linear_inner
+            .bind(py)
+            .borrow()
+            .weight
+            .bind(py)
+            .borrow()
+            .inner
+            .clone();
+        let b_inner = self
+            .linear_inner
+            .bind(py)
+            .borrow()
+            .bias
+            .as_ref()
+            .map(|b| b.bind(py).borrow().inner.clone());
+        let w_outer = self
+            .linear_outer
+            .bind(py)
+            .borrow()
+            .weight
+            .bind(py)
+            .borrow()
+            .inner
+            .clone();
+        let b_outer = self
+            .linear_outer
+            .bind(py)
+            .borrow()
+            .bias
+            .as_ref()
+            .map(|b| b.bind(py).borrow().inner.clone());
+        let x = input.inner.clone();
+
+        let out = py.allow_threads(move || {
+            let swiglu = coeus_nn::SwiGlu {
+                linear_inner: coeus_nn::linear::Linear {
+                    weight: w_inner,
+                    bias: b_inner,
+                },
+                linear_outer: coeus_nn::linear::Linear {
+                    weight: w_outer,
+                    bias: b_outer,
+                },
+            };
+            swiglu.forward(&x)
+        });
+        Ok(PyTensor::from_var(out))
+    }
+
+    /// Learnable parameters: both projections' weights (and biases if present).
+    pub fn parameters(&self, py: Python<'_>) -> Vec<Py<PyTensor>> {
+        let mut params = self.linear_inner.bind(py).borrow().parameters(py);
+        params.extend(self.linear_outer.bind(py).borrow().parameters(py));
+        params
+    }
+
+    /// Zero gradients of all parameters.
+    pub fn zero_grad(&self, py: Python<'_>) {
+        self.linear_inner.bind(py).borrow().zero_grad(py);
+        self.linear_outer.bind(py).borrow().zero_grad(py);
+    }
+}

--- a/coeus-python/src/nn/mod.rs
+++ b/coeus-python/src/nn/mod.rs
@@ -36,7 +36,7 @@ pub use conv::{PyConv1d, PyConv2d, PyConv3d};
 pub use dropout::PyDropout;
 pub use embedding::{PyEmbedding, PyEmbeddingBag};
 pub use feedforward::{
-    PyFeedForward, PySinusoidalEncoding, PyTransformer, PyTransformerDecoder,
+    PyFeedForward, PySinusoidalEncoding, PySwiGlu, PyTransformer, PyTransformerDecoder,
     PyTransformerDecoderLayer, PyTransformerEncoder, PyTransformerEncoderLayer,
 };
 pub use linear::PyLinear;

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2581,3 +2581,72 @@ def test_unfold1d_matches_pytorch() -> None:
         y_t.flatten().tolist(),
         atol=1e-10,
     )
+
+
+# ---------------------------------------------------------------------------
+# SwiGLU forward + gradient parity
+# ---------------------------------------------------------------------------
+
+
+def test_swiglu_matches_pytorch() -> None:
+    """Forward + gradient parity: SwiGLU(64→128), no bias, via MSELoss.
+
+    PyTorch has no built-in SwiGLU, so the reference is composed from
+    primitives: ``silu(x @ Wi.T) * (x @ Wo.T)``. Both layers' weights are read
+    from pycoeus and injected into the torch reference so the only difference
+    measured is the implementation, not the initialisation.
+    """
+    d_in, d_out, batch = 64, 128, 32
+
+    sg_pyc = pycoeus.SwiGlu(d_in, d_out, bias=False)
+    wi_data = sg_pyc.linear_inner.weight.data  # [d_out, d_in] flat
+    wo_data = sg_pyc.linear_outer.weight.data  # [d_out, d_in] flat
+
+    x_data = [math.sin(i * 0.013) for i in range(batch * d_in)]
+    tgt_data = [0.5] * (batch * d_out)
+
+    # pycoeus forward + backward
+    x_pyc = pycoeus.Tensor(x_data, [batch, d_in], requires_grad=True)
+    out_pyc = sg_pyc.forward(x_pyc)
+    tgt_pyc = pycoeus.Tensor(tgt_data, [batch, d_out])
+    loss_pyc = pycoeus.mse_loss(out_pyc, tgt_pyc)
+    loss_pyc.backward()
+
+    # PyTorch reference (f64 to match pycoeus default precision)
+    x_t = (
+        torch.tensor(x_data, dtype=torch.float64)
+        .reshape(batch, d_in)
+        .requires_grad_(True)
+    )
+    wi_t = (
+        torch.tensor(wi_data, dtype=torch.float64)
+        .reshape(d_out, d_in)
+        .requires_grad_(True)
+    )
+    wo_t = (
+        torch.tensor(wo_data, dtype=torch.float64)
+        .reshape(d_out, d_in)
+        .requires_grad_(True)
+    )
+    inner_t = torch.nn.functional.linear(x_t, wi_t)
+    outer_t = torch.nn.functional.linear(x_t, wo_t)
+    out_t = torch.nn.functional.silu(inner_t) * outer_t
+    tgt_t = torch.tensor(tgt_data, dtype=torch.float64).reshape(batch, d_out)
+    loss_t = torch.nn.functional.mse_loss(out_t, tgt_t)
+    loss_t.backward()
+
+    _allclose("swiglu_forward", list(out_pyc.data), out_t.detach().flatten().tolist())
+    assert abs(loss_pyc.data[0] - loss_t.item()) < _ATOL, (
+        f"swiglu loss: got={loss_pyc.data[0]:.8g}, expected={loss_t.item():.8g}"
+    )
+    _allclose("swiglu_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())
+    _allclose(
+        "swiglu_dWi",
+        list(sg_pyc.linear_inner.weight.grad),
+        wi_t.grad.flatten().tolist(),
+    )
+    _allclose(
+        "swiglu_dWo",
+        list(sg_pyc.linear_outer.weight.grad),
+        wo_t.grad.flatten().tolist(),
+    )


### PR DESCRIPTION
## Summary
Binds `coeus_nn::SwiGlu` as `pycoeus.SwiGlu`, completing **goal-2 parity** for the SwiGLU module (Rust impl [#102](https://github.com/ryancinsight/Coeus/pull/102), Burn bench [#103](https://github.com/ryancinsight/Coeus/pull/103)).

`PySwiGlu` holds two `PyLinear` sub-modules (inner SiLU-gated, outer value) exposed via `#[pyo3(get)]` for weight injection; `forward` reconstructs `coeus_nn::SwiGlu` from the injected weights under `allow_threads`. New leaf module `coeus-python/src/nn/feedforward/swiglu.rs`, registered in `nn` re-exports + `lib` `add_class`.

## PyTorch parity
PyTorch has no built-in SwiGLU, so the reference is composed — `silu(x @ Wi.T) * (x @ Wo.T)` — with pycoeus weights injected into torch. Forward, loss, and gradients (`dx`, `dWi`, `dWo`) all match within `1e-5`.

## Verification
- `cargo check -p coeus-python` · `fmt --check` · `clippy` — clean
- `maturin build` (CPython 3.13) — wheel built
- `pytest test_swiglu_matches_pytorch` — **1 passed** (torch 2.12, f64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Python bindings for the SwiGLU activation function by creating a `PySwiGlu` wrapper that exposes the Rust `coeus_nn::SwiGlu` implementation to Python. The implementation wraps two linear projections (inner SiLU-gated and outer value) with publicly accessible weights for testing, and includes a comprehensive PyTorch parity test that verifies matching forward pass outputs, loss values, and gradients (input, inner weights, outer weights) within `1e-5` tolerance against a composed PyTorch reference implementation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/nn/feedforward/swiglu.rs` |
| 2 | `coeus-python/src/nn/feedforward/mod.rs` |
| 3 | `coeus-python/src/nn/mod.rs` |
| 4 | `coeus-python/src/lib.rs` |
| 5 | `coeus-python/tests/test_pytorch_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->