### PR TITLE
test(python): SwiGLU JAX output + gradient parity

### DIFF
--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -830,3 +830,68 @@ def test_adaptive_avg_pool2d_global_matches_jax() -> None:
     y_j = jnp.mean(x_j, axis=(-2, -1), keepdims=True)
 
     _allclose("adaptive_avg_pool2d_global_jax", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# SwiGLU forward + gradient parity
+# ---------------------------------------------------------------------------
+
+
+def test_swiglu_matches_jax() -> None:
+    """Forward + gradient parity: SwiGLU(64→128), no bias, via MSELoss.
+
+    Mirrors ``test_pytorch_parity.py::test_swiglu_matches_pytorch``. JAX has no
+    built-in SwiGLU, so the reference is composed from primitives:
+    ``silu(x @ Wi.T) * (x @ Wo.T)`` with silu computed as ``z * sigmoid(z)``.
+    """
+    d_in, d_out, batch = 64, 128, 32
+
+    sg_pyc = pycoeus.SwiGlu(d_in, d_out, bias=False)
+    wi_data = sg_pyc.linear_inner.weight.data  # [d_out, d_in] flat
+    wo_data = sg_pyc.linear_outer.weight.data  # [d_out, d_in] flat
+
+    x_data = [math.sin(i * 0.013) for i in range(batch * d_in)]
+    tgt_data = [0.5] * (batch * d_out)
+
+    # pycoeus forward + backward
+    x_pyc = pycoeus.Tensor(x_data, [batch, d_in], requires_grad=True)
+    out_pyc = sg_pyc.forward(x_pyc)
+    tgt_pyc = pycoeus.Tensor(tgt_data, [batch, d_out])
+    loss_pyc = pycoeus.mse_loss(out_pyc, tgt_pyc)
+    loss_pyc.backward()
+
+    # JAX reference (f64 to match pycoeus default precision)
+    x_jax = jnp.asarray(x_data, dtype=jnp.float64).reshape(batch, d_in)
+    wi_jax = jnp.asarray(wi_data, dtype=jnp.float64).reshape(d_out, d_in)
+    wo_jax = jnp.asarray(wo_data, dtype=jnp.float64).reshape(d_out, d_in)
+    tgt_jax = jnp.asarray(tgt_data, dtype=jnp.float64).reshape(batch, d_out)
+
+    def _silu(z):
+        return z / (1.0 + jnp.exp(-z))
+
+    def jax_loss(x, wi, wo):
+        out = _silu(x @ wi.T) * (x @ wo.T)
+        diff = out - tgt_jax
+        return jnp.mean(diff * diff)
+
+    grad_fn = jax.value_and_grad(jax_loss, argnums=(0, 1, 2))
+    loss_jax, (dx_jax, dwi_jax, dwo_jax) = grad_fn(x_jax, wi_jax, wo_jax)
+    loss_jax.block_until_ready()
+
+    out_jax = _silu(x_jax @ wi_jax.T) * (x_jax @ wo_jax.T)
+
+    _allclose("swiglu_forward_jax", list(out_pyc.data), out_jax.flatten().tolist())
+    assert abs(loss_pyc.data[0] - float(loss_jax)) < _ATOL, (
+        f"swiglu loss: got={loss_pyc.data[0]:.8g}, expected={float(loss_jax):.8g}"
+    )
+    _allclose("swiglu_dx_jax", list(x_pyc.grad), dx_jax.flatten().tolist())
+    _allclose(
+        "swiglu_dWi_jax",
+        list(sg_pyc.linear_inner.weight.grad),
+        dwi_jax.flatten().tolist(),
+    )
+    _allclose(
+        "swiglu_dWo_jax",
+        list(sg_pyc.linear_outer.weight.grad),
+        dwo_jax.flatten().tolist(),
+    )


### PR DESCRIPTION
## Summary
Extends SwiGLU cross-framework parity to **JAX**, mirroring the PyTorch test ([#104](https://github.com/ryancinsight/Coeus/pull/104)). JAX has no built-in SwiGLU, so the reference is composed from primitives — `silu(x @ Wi.T) * (x @ Wo.T)`, with `silu` as `z*sigmoid(z)` in pure `jnp` — and pycoeus weights injected. `jax.value_and_grad` supplies the gradients.

Forward, loss, and `dx`/`dWi`/`dWo` all match pycoeus within `1e-5`.

## Verification
- `pytest test_swiglu_matches_jax` — **1 passed** (jax f64, x64 enabled)
- Test-only: the merged `PySwiGlu` binding is unchanged; no rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a JAX parity test for the SwiGLU activation function, verifying that the pycoeus implementation matches JAX's primitive operations for both forward pass outputs and gradients. Since JAX lacks a built-in SwiGLU, the test implements a reference using `silu(x @ Wi.T) * (x @ Wo.T)` with manual SiLU computation (`z * sigmoid(z)`), then compares forward outputs, loss values, and all gradients (`dx`, `dWi`, `dWo`) against pycoeus within `1e-5` tolerance. This mirrors an existing PyTorch parity test and requires no changes to the core library.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new parity test to verify SwiGLU produces matching outputs and gradients against a JAX reference.
  * Covers forward pass and backward pass checks for input and weight gradients, improving confidence in numerical consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->