### PR TITLE
fix(nn): Make LocalResponseNorm differentiable (close G-044)

### DIFF
--- a/coeus-nn/src/regularization.rs
+++ b/coeus-nn/src/regularization.rs
@@ -276,47 +276,55 @@ where
         vec![]
     }
 
-    /// LRN forward pass.
+    /// LRN forward pass — differentiable.
     ///
     /// Supports 2D (`[N, C]`), 3D (`[N, C, L]`), and 4D (`[N, C, H, W]`) inputs.
+    /// Built entirely from autograd ops so gradients flow to the input: the
+    /// cross-channel windowed sum-of-squares is a constant band-matrix product
+    /// (differentiable through the squared activations), and the `^beta`
+    /// denominator uses the differentiable `pow` (the base `k + .. >= k > 0`,
+    /// so the `exp(beta*ln(.))` it computes is well defined).
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
         let shape = input.tensor.shape_cloned();
         let n = shape[0];
         let c = shape[1];
         let spatial: usize = shape[2..].iter().product::<usize>().max(1);
-
-        let alpha_t = T::from_f64(self.alpha / self.size as f64);
-        let beta_t = T::from_f64(self.beta);
-        let k_t = T::from_f64(self.k);
-
-        let src = input.tensor.as_slice();
-        let backend = B::default();
-        let mut out_data = vec![T::zero(); n * c * spatial];
-
-        // Iterate (n, c, spatial), compute LRN over channel neighborhood.
         let half = self.size / 2;
-        for ni in 0..n {
-            for ci in 0..c {
-                let c_start = ci.saturating_sub(half);
-                let c_end = (ci + half + 1).min(c);
-                for s in 0..spatial {
-                    let mut sq_sum = T::zero();
-                    for cj in c_start..c_end {
-                        let val = src[ni * c * spatial + cj * spatial + s];
-                        sq_sum = sq_sum + val * val;
-                    }
-                    let denom_base = k_t + alpha_t * sq_sum;
-                    // denom = denom_base^beta
-                    let denom = T::from_f64(T::to_f64(denom_base).powf(T::to_f64(beta_t)));
-                    let x = src[ni * c * spatial + ci * spatial + s];
-                    out_data[ni * c * spatial + ci * spatial + s] = x / denom;
-                }
+        let backend = B::default();
+
+        // View as [N, C, spatial] (channel axis = dim 1); square it.
+        let x3 = coeus_autograd::reshape(input, [n, c, spatial]);
+        let sq = coeus_autograd::mul(&x3, &x3);
+
+        // Constant band matrix M [C, C], M[i, j] = 1 iff |i - j| <= half. Then
+        // `M @ sq` over the channel axis is each channel's squared response
+        // summed across its size-neighbourhood (with boundary clamping implicit
+        // in the band), differentiable through `sq`.
+        let mut m_data = vec![T::zero(); c * c];
+        for i in 0..c {
+            let lo = i.saturating_sub(half);
+            let hi = (i + half + 1).min(c);
+            for cell in m_data[i * c + lo..i * c + hi].iter_mut() {
+                *cell = T::one();
             }
         }
+        let m = Var::new(Tensor::from_slice_on([c, c], &m_data, &backend), false);
 
-        let out_tensor = Tensor::from_slice_on(shape, &out_data, &backend);
-        // LRN backward is not yet tracked (forward-only for inference).
-        // When grad is not needed, skip the graph.
-        Var::new(out_tensor, false)
+        // windowed = M @ sq:  [N,C,S] -> [C,N*S] -> M@ -> [C,N*S] -> [N,C,S].
+        let sq_cns = coeus_autograd::permute(&sq, &[1, 0, 2]);
+        let sq_2d = coeus_autograd::reshape(&sq_cns, [c, n * spatial]);
+        let win_2d = coeus_autograd::matmul(&m, &sq_2d);
+        let win_cns = coeus_autograd::reshape(&win_2d, [c, n, spatial]);
+        let windowed = coeus_autograd::permute(&win_cns, &[1, 0, 2]);
+
+        // denom = (k + (alpha / size) * windowed)^beta;  y = x / denom.
+        let scaled =
+            coeus_autograd::scalar_mul(&windowed, T::from_f64(self.alpha / self.size as f64));
+        let denom = coeus_autograd::pow(
+            &coeus_autograd::scalar_add(&scaled, T::from_f64(self.k)),
+            self.beta,
+        );
+        let y3 = coeus_autograd::div(&x3, &denom);
+        coeus_autograd::reshape(&y3, shape)
     }
 }

--- a/coeus-nn/tests/regularization_tests.rs
+++ b/coeus-nn/tests/regularization_tests.rs
@@ -134,3 +134,57 @@ fn lrn_k1_defaults_match_pytorch() {
         assert!((v).abs() < 1e-7, "zero input should give zero output");
     }
 }
+
+#[test]
+fn lrn_backward_matches_numerical_gradient() {
+    // The autograd-graph forward must propagate gradients to the input. Verify
+    // the analytic input gradient of `sum(LRN(x))` against an f64 central
+    // finite-difference reference. Window crosses channels, so the gradient
+    // genuinely couples neighbouring channels (not a per-element passthrough).
+    let lrn = LocalResponseNorm::with_params(3, 1.0, 0.75, 1.0);
+    let data = [0.5_f64, -1.0, 2.0, 0.3, 1.5, -0.7];
+    let shape = [1, 6, 1, 1];
+
+    // Analytic: backward() seeds grad_output = ones, so x.grad = d sum(y) / d x.
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
+        true,
+    );
+    lrn.forward(&x).backward();
+    let analytic: Vec<f64> = x.grad().expect("lrn input gradient").as_slice().to_vec();
+
+    // Numerical: central differences of sum(LRN(x)). f64, h=1e-6 ⇒ error ~1e-10;
+    // a non-zero coupled gradient must match within a wide 1e-5 margin.
+    let h = 1e-6_f64;
+    let sum_forward = |d: &[f64]| -> f64 {
+        let xv = Var::new(
+            Tensor::<f64, SequentialBackend>::from_slice(shape, d),
+            false,
+        );
+        lrn.forward(&xv)
+            .tensor
+            .as_slice()
+            .iter()
+            .copied()
+            .sum::<f64>()
+    };
+    for i in 0..data.len() {
+        let mut dp = data.to_vec();
+        dp[i] += h;
+        let mut dm = data.to_vec();
+        dm[i] -= h;
+        let numeric = (sum_forward(&dp) - sum_forward(&dm)) / (2.0 * h);
+        assert!(
+            (analytic[i] - numeric).abs() < 1e-5,
+            "grad[{i}]: analytic {} vs numeric {} (diff {:.2e})",
+            analytic[i],
+            numeric,
+            (analytic[i] - numeric).abs()
+        );
+    }
+    // Gradient must be genuinely non-trivial (not the forward-only dx=0 bug).
+    assert!(
+        analytic.iter().any(|g| g.abs() > 1e-6),
+        "LRN input gradient is all-zero — backward not propagating"
+    );
+}

--- a/coeus-python/src/nn/regularization.rs
+++ b/coeus-python/src/nn/regularization.rs
@@ -50,9 +50,8 @@ impl PyLocalResponseNorm {
 
     /// Forward pass: cross-channel local response normalization.
     ///
-    /// Forward-only: coeus's `LocalResponseNorm` is currently non-differentiable
-    /// (the output is not grad-tracked), so this is an inference-only layer.
-    /// Differentiable backward is tracked as gap G-044.
+    /// Differentiable (autograd-graph forward in coeus-nn), so gradients flow to
+    /// the input and the layer is trainable.
     pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
         use coeus_nn::Module;
         let x = input.inner.clone();

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2653,32 +2653,46 @@ def test_swiglu_matches_pytorch() -> None:
 
 
 # ---------------------------------------------------------------------------
-# LocalResponseNorm forward parity (forward-only — see gap_audit G-044)
+# LocalResponseNorm forward + gradient parity
 # ---------------------------------------------------------------------------
 
 
-def test_local_response_norm_forward_matches_pytorch() -> None:
-    """Forward-value parity: LocalResponseNorm(size=5) on [2, 8, 4, 4].
+def test_local_response_norm_matches_pytorch() -> None:
+    """Forward + gradient parity: LocalResponseNorm(size=5) on [2, 8, 4, 4].
 
     Cross-channel LRN has no learnable parameters; pycoeus and torch share the
     ``alpha/size`` convention and defaults (alpha=1e-4, beta=0.75, k=1.0), so a
-    direct comparison needs no weight injection — the forward is bit-exact.
-
-    NOTE — forward-only: coeus's LocalResponseNorm is currently NOT
-    differentiable (its forward returns a non-grad-tracked tensor; ``dx`` would
-    be 0). Backward/``dx`` parity is tracked as gap G-044 in docs/gap_audit.md,
-    blocked on differentiable autograd ``powf`` and a windowed-channel
-    sum-of-squares op. This test therefore asserts forward-value parity only.
+    direct comparison needs no weight injection. coeus's LRN is differentiable
+    (autograd-graph forward), so ``dx`` parity is verified too (gap G-044
+    closed).
     """
     n, c, h, w = 2, 8, 4, 4
     size = 5
 
     lrn_pyc = pycoeus.LocalResponseNorm(size)
     x_data = [math.sin(i * 0.05) for i in range(n * c * h * w)]
+    tgt_data = [0.3] * (n * c * h * w)
 
-    out_pyc = lrn_pyc.forward(pycoeus.Tensor(x_data, [n, c, h, w]))
+    # pycoeus forward + backward
+    x_pyc = pycoeus.Tensor(x_data, [n, c, h, w], requires_grad=True)
+    out_pyc = lrn_pyc.forward(x_pyc)
+    tgt_pyc = pycoeus.Tensor(tgt_data, [n, c, h, w])
+    loss_pyc = pycoeus.mse_loss(out_pyc, tgt_pyc)
+    loss_pyc.backward()
 
-    x_t = torch.tensor(x_data, dtype=torch.float64).reshape(n, c, h, w)
+    # PyTorch forward + backward (f64)
+    x_t = (
+        torch.tensor(x_data, dtype=torch.float64)
+        .reshape(n, c, h, w)
+        .requires_grad_(True)
+    )
     out_t = torch.nn.LocalResponseNorm(size)(x_t)  # alpha=1e-4, beta=0.75, k=1.0
+    tgt_t = torch.tensor(tgt_data, dtype=torch.float64).reshape(n, c, h, w)
+    loss_t = torch.nn.functional.mse_loss(out_t, tgt_t)
+    loss_t.backward()
 
-    _allclose("lrn_forward", list(out_pyc.data), out_t.flatten().tolist())
+    _allclose("lrn_forward", list(out_pyc.data), out_t.detach().flatten().tolist())
+    assert abs(loss_pyc.data[0] - loss_t.item()) < _ATOL, (
+        f"lrn loss: got={loss_pyc.data[0]:.8g}, expected={loss_t.item():.8g}"
+    )
+    _allclose("lrn_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -477,7 +477,7 @@ Evidence tier: differential/empirical (PyTorch f64).
 | G-041 regularization/sparse/local-response modules incomplete | source-surface + external docs audit | **open** |
 | G-042 quantized and lazy module parity policy missing | source-surface + external docs audit | **open** |
 | G-043 Burn/PyTorch NN benchmark matrix remains partial | source-surface + external docs audit | **open** |
-| G-044 LocalResponseNorm is forward-only (non-differentiable); forward bit-exact vs torch but dx=0. Acceptance: dx parity with torch.nn.LocalResponseNorm. Blocked on differentiable autograd `powf` (d/dx xᵝ) + windowed-channel sum-of-squares (`narrow`/`cat` or dedicated op); sub-gap of G-041 | differential | **open** |
+| G-044 LocalResponseNorm was forward-only (non-differentiable). Fixed: forward rewritten as an autograd graph (band-matrix matmul windowed sum-of-squares + differentiable `pow`), so dx now flows. forward + dx parity with torch.nn.LocalResponseNorm verified | differential | **closed** |
 | G-001 stateless PyTransformerEncoderLayer binding | structural | **closed MS-127** |
 | G-002 stateless PyTransformerEncoder binding | structural | **closed MS-128** |
 | G-003 stateless PyTransformerDecoderLayer binding | structural | **closed MS-129** |


### PR DESCRIPTION
## Summary
`LocalResponseNorm` was **forward-only** — its forward computed correct values via raw slice iteration but returned a non-grad-tracked tensor, so `dx=0`. This was **caught by the PyTorch parity test** added in #106 and filed as gap G-044. This PR fixes it at the root by rewriting the forward as a **differentiable autograd graph**:

- square the input;
- windowed cross-channel sum-of-squares via a constant **band matrix** (`M[i,j]=1 iff |i−j|≤half`), computed as `M @ sq` over the channel axis — differentiable through the squares;
- `denom = (k + (α/size)·windowed)^β` via the differentiable `pow` (base ≥ k > 0, so its `exp(β·ln)` is well defined);
- `y = x / denom`.

LRN is now **trainable**, not inference-only.

## Verification
- coeus-nn: forward tests unchanged-green (value-correct, bit-exact vs torch) + **new f64 numerical-gradient test** (`lrn_backward_matches_numerical_gradient`) — analytic `dx` vs central finite differences within 1e-5, plus a non-zero-gradient assertion guarding against regression.
- coeus-python: PyTorch parity test restored to **full forward + dx parity** vs `torch.nn.LocalResponseNorm` — **passes** (maturin rebuild + pytest).
- fmt + clippy clean.
- gap_audit G-044 → **closed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug in `LocalResponseNorm` where the forward pass was **non-differentiable** (returning gradients of zero). The fix rewrites the forward pass as a fully differentiable autograd computation graph using a band-matrix cross-channel windowed sum-of-squares and the differentiable `pow` operation. This makes LRN trainable instead of inference-only, and the change is verified with new numerical gradient tests in the Rust codebase and full forward+backward PyTorch parity tests in Python bindings, closing gap **G-044**.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/gap_audit.md` |
| 2 | `coeus-nn/src/regularization.rs` |
| 3 | `coeus-nn/tests/regularization_tests.rs` |
| 4 | `coeus-python/src/nn/regularization.rs` |
| 5 | `coeus-python/tests/test_pytorch_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->