### PR TITLE
test(python): LocalResponseNorm JAX forward + gradient parity

### DIFF
--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -895,3 +895,58 @@ def test_swiglu_matches_jax() -> None:
         list(sg_pyc.linear_outer.weight.grad),
         dwo_jax.flatten().tolist(),
     )
+
+
+# ---------------------------------------------------------------------------
+# LocalResponseNorm forward + gradient parity
+# ---------------------------------------------------------------------------
+
+
+def test_local_response_norm_matches_jax() -> None:
+    """Forward + gradient parity: LocalResponseNorm(size=5) on [2, 8, 4, 4].
+
+    Mirrors ``test_pytorch_parity.py::test_local_response_norm_matches_pytorch``.
+    JAX has no built-in LRN, so the reference composes the same cross-channel
+    windowed sum-of-squares used by coeus — a band matrix ``M[i,j]=1 iff
+    |i-j|<=size//2`` contracted against the squared activations — then
+    ``(k + (alpha/size)*windowed)**beta`` and ``x/denom``. coeus's LRN is
+    differentiable, so ``dx`` parity is verified via ``jax.value_and_grad``.
+    """
+    n, c, h, w = 2, 8, 4, 4
+    size, alpha, beta, k = 5, 1e-4, 0.75, 1.0
+
+    lrn_pyc = pycoeus.LocalResponseNorm(size)
+    x_data = [math.sin(i * 0.05) for i in range(n * c * h * w)]
+    tgt_data = [0.3] * (n * c * h * w)
+
+    # pycoeus forward + backward
+    x_pyc = pycoeus.Tensor(x_data, [n, c, h, w], requires_grad=True)
+    out_pyc = lrn_pyc.forward(x_pyc)
+    tgt_pyc = pycoeus.Tensor(tgt_data, [n, c, h, w])
+    loss_pyc = pycoeus.mse_loss(out_pyc, tgt_pyc)
+    loss_pyc.backward()
+
+    # JAX reference (f64)
+    x_jax = jnp.asarray(x_data, dtype=jnp.float64).reshape(n, c, h, w)
+    tgt_jax = jnp.asarray(tgt_data, dtype=jnp.float64).reshape(n, c, h, w)
+    idx = jnp.arange(c)
+    band = (jnp.abs(idx[:, None] - idx[None, :]) <= size // 2).astype(jnp.float64)
+
+    def lrn_forward(x):
+        sq = (x * x).reshape(n, c, h * w)
+        windowed = jnp.einsum("cj,njs->ncs", band, sq).reshape(n, c, h, w)
+        return x / (k + (alpha / size) * windowed) ** beta
+
+    def lrn_loss(x):
+        diff = lrn_forward(x) - tgt_jax
+        return jnp.mean(diff * diff)
+
+    out_jax = lrn_forward(x_jax)
+    loss_jax, dx_jax = jax.value_and_grad(lrn_loss)(x_jax)
+    loss_jax.block_until_ready()
+
+    _allclose("lrn_forward_jax", list(out_pyc.data), out_jax.flatten().tolist())
+    assert abs(loss_pyc.data[0] - float(loss_jax)) < _ATOL, (
+        f"lrn loss: got={loss_pyc.data[0]:.8g}, expected={float(loss_jax):.8g}"
+    )
+    _allclose("lrn_dx_jax", list(x_pyc.grad), dx_jax.flatten().tolist())


### PR DESCRIPTION
## Summary
Extends LRN cross-framework parity to **JAX**, mirroring the PyTorch test ([#107](https://github.com/ryancinsight/Coeus/pull/107)). JAX has no built-in LRN, so the reference composes the same cross-channel windowed sum-of-squares coeus uses — a band matrix `M[i,j]=1 iff |i−j|≤size//2` contracted against the squared activations — then `(k + (α/size)·windowed)^β` and `x/denom`.

Now that coeus LRN is differentiable, `dx` parity is verified via `jax.value_and_grad`. Forward, loss, and `dx` all match within `1e-5`.

## Verification
- `pytest test_local_response_norm_matches_jax` — **1 passed** (jax f64, x64)
- Test-only: the differentiable LRN (#107) is unchanged; no rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a JAX parity test for the `LocalResponseNorm` layer, verifying both forward pass and gradient computation match between coeus and a reference JAX implementation. Since JAX lacks a built-in LRN operation, the test implements a reference using a band matrix to compute cross-channel windowed sum-of-squares, then validates that coeus produces matching outputs, loss values, and gradients within a tolerance of `1e-5`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->