### PR TITLE
fix(nn): Make AdaptiveAvgPool1d/2d differentiable (G-045)

### DIFF
--- a/coeus-nn/src/pool/adaptive.rs
+++ b/coeus-nn/src/pool/adaptive.rs
@@ -12,7 +12,43 @@
 use crate::module::Module;
 use coeus_autograd::Var;
 use coeus_core::{CpuAddressableStorage, CpuAddressableStorageMut, Float, MoiraiBackend, Scalar};
+use coeus_tensor::Tensor;
 use std::marker::PhantomData;
+
+/// Transposed averaging matrix `P_T` `[in_len, out_len]` for adaptive average
+/// pooling along one axis. Output column `o` carries `1/region` in the rows of
+/// its input region `[floor(o*in/out), ceil((o+1)*in/out))` — PyTorch's adaptive
+/// region convention — and zero elsewhere. `input @ P_T` then averages each
+/// region; being a constant matmul it is differentiable (the backward scatters
+/// the per-region-averaged gradient back to every input position in the region).
+fn avg_pool_matrix_t<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    in_len: usize,
+    out_len: usize,
+    backend: &B,
+) -> Var<T, B>
+where
+    B::DeviceBuffer<T>: CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
+{
+    let mut pt = vec![T::zero(); in_len * out_len];
+    for o in 0..out_len {
+        let start = o * in_len / out_len;
+        let end = ((o + 1) * in_len).div_ceil(out_len);
+        let inv = T::from_f64(1.0 / (end - start) as f64);
+        // Column `o`, rows `start..end`: flat index `l * out_len + o`.
+        for slot in pt
+            .iter_mut()
+            .skip(start * out_len + o)
+            .step_by(out_len)
+            .take(end - start)
+        {
+            *slot = inv;
+        }
+    }
+    Var::new(
+        Tensor::from_slice_on([in_len, out_len], &pt, backend),
+        false,
+    )
+}
 
 // ── AdaptiveAvgPool1d ─────────────────────────────────────────────────────────
 
@@ -61,9 +97,16 @@ where
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        // Differentiable: average each adaptive region via a constant averaging
+        // matmul over the length axis.  [N, C, L] -> [N*C, L] @ P_T[L, O].
+        let shape = input.tensor.shape_cloned();
+        let (n, c, l) = (shape[0], shape[1], shape[2]);
+        let o = self.output_size;
         let backend = B::default();
-        let out_tensor = coeus_ops::adaptive_avg_pool1d(&input.tensor, self.output_size, &backend);
-        Var::new(out_tensor, false)
+        let p_t = avg_pool_matrix_t::<T, B>(l, o, &backend);
+        let x2 = coeus_autograd::reshape(input, [n * c, l]);
+        let out2 = coeus_autograd::matmul(&x2, &p_t);
+        coeus_autograd::reshape(&out2, [n, c, o])
     }
 }
 
@@ -121,10 +164,27 @@ where
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        // Differentiable separable pooling: average over W, then over H, each a
+        // constant averaging matmul. Averaging is separable so this equals the
+        // joint 2D adaptive average.
+        let shape = input.tensor.shape_cloned();
+        let (n, c, h, w) = (shape[0], shape[1], shape[2], shape[3]);
+        let (oh, ow) = (self.out_h, self.out_w);
         let backend = B::default();
-        let out_tensor =
-            coeus_ops::adaptive_avg_pool2d(&input.tensor, self.out_h, self.out_w, &backend);
-        Var::new(out_tensor, false)
+
+        // Pool W: [N, C, H, W] -> [N*C*H, W] @ PW_T[W, OW] -> [N, C, H, OW].
+        let pw_t = avg_pool_matrix_t::<T, B>(w, ow, &backend);
+        let yw = coeus_autograd::matmul(&coeus_autograd::reshape(input, [n * c * h, w]), &pw_t);
+        let yw = coeus_autograd::reshape(&yw, [n, c, h, ow]);
+
+        // Pool H: bring H last, [N, C, OW, H] -> [N*C*OW, H] @ PH_T[H, OH].
+        let ph_t = avg_pool_matrix_t::<T, B>(h, oh, &backend);
+        let yw_p = coeus_autograd::permute(&yw, &[0, 1, 3, 2]);
+        let yh = coeus_autograd::matmul(&coeus_autograd::reshape(&yw_p, [n * c * ow, h]), &ph_t);
+        let yh = coeus_autograd::reshape(&yh, [n, c, ow, oh]);
+        // Final transpose to [N, C, OH, OW]; reshape materializes it contiguous.
+        let out = coeus_autograd::permute(&yh, &[0, 1, 3, 2]);
+        coeus_autograd::reshape(&out, [n, c, oh, ow])
     }
 }
 

--- a/coeus-nn/tests/adaptive_pool_parity.rs
+++ b/coeus-nn/tests/adaptive_pool_parity.rs
@@ -165,3 +165,94 @@ fn adaptive_avg_pool2d_matches_global_avg_pool() {
         assert!((a - b).abs() < 1e-10, "adaptive={a}, global={b}");
     }
 }
+
+// ── Differentiability (G-045 fix): backward vs numerical gradient ──
+
+/// Central finite-difference check of `analytic` against `sum_forward` over
+/// `data`, asserting a non-trivial (non-zero) gradient.
+fn assert_grad_matches_numeric(
+    analytic: &[f64],
+    data: &[f64],
+    h: f64,
+    mut sum_forward: impl FnMut(&[f64]) -> f64,
+) {
+    for i in 0..data.len() {
+        let mut dp = data.to_vec();
+        dp[i] += h;
+        let mut dm = data.to_vec();
+        dm[i] -= h;
+        let numeric = (sum_forward(&dp) - sum_forward(&dm)) / (2.0 * h);
+        assert!(
+            (analytic[i] - numeric).abs() < 1e-5,
+            "grad[{i}]: analytic {} vs numeric {} (diff {:.2e})",
+            analytic[i],
+            numeric,
+            (analytic[i] - numeric).abs()
+        );
+    }
+    assert!(
+        analytic.iter().any(|g| g.abs() > 1e-6),
+        "gradient is all-zero — backward not propagating"
+    );
+}
+
+#[test]
+fn adaptive_avg_pool1d_backward_matches_numerical_gradient() {
+    // [1,1,7] -> 3: regions overlap (element 2 falls in regions 0 and 1), so the
+    // gradient genuinely sums region contributions, not a passthrough.
+    let m = AdaptiveAvgPool1d::<f64, SequentialBackend>::new(3);
+    let data = [1.0_f64, -2.0, 3.0, 0.5, -1.5, 2.5, 4.0];
+    let shape = [1, 1, 7];
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
+        true,
+    );
+    m.forward(&x).backward();
+    let analytic: Vec<f64> = x
+        .grad()
+        .expect("adaptive avg pool 1d gradient")
+        .as_slice()
+        .to_vec();
+    assert_grad_matches_numeric(&analytic, &data, 1e-6, |d| {
+        let xv = Var::new(
+            Tensor::<f64, SequentialBackend>::from_slice(shape, d),
+            false,
+        );
+        m.forward(&xv)
+            .tensor
+            .as_slice()
+            .iter()
+            .copied()
+            .sum::<f64>()
+    });
+}
+
+#[test]
+fn adaptive_avg_pool2d_backward_matches_numerical_gradient() {
+    // [1,1,5,5] -> (2,2): both axes have overlapping adaptive regions.
+    let m = AdaptiveAvgPool2d::<f64, SequentialBackend>::new(2, 2);
+    let data: Vec<f64> = (0..25).map(|i| ((i * 7 % 11) as f64 - 5.0) * 0.3).collect();
+    let shape = [1, 1, 5, 5];
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
+        true,
+    );
+    m.forward(&x).backward();
+    let analytic: Vec<f64> = x
+        .grad()
+        .expect("adaptive avg pool 2d gradient")
+        .as_slice()
+        .to_vec();
+    assert_grad_matches_numeric(&analytic, &data, 1e-6, |d| {
+        let xv = Var::new(
+            Tensor::<f64, SequentialBackend>::from_slice(shape, d),
+            false,
+        );
+        m.forward(&xv)
+            .tensor
+            .as_slice()
+            .iter()
+            .copied()
+            .sum::<f64>()
+    });
+}

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -478,6 +478,7 @@ Evidence tier: differential/empirical (PyTorch f64).
 | G-042 quantized and lazy module parity policy missing | source-surface + external docs audit | **open** |
 | G-043 Burn/PyTorch NN benchmark matrix remains partial | source-surface + external docs audit | **open** |
 | G-044 LocalResponseNorm was forward-only (non-differentiable). Fixed: forward rewritten as an autograd graph (band-matrix matmul windowed sum-of-squares + differentiable `pow`), so dx now flows. forward + dx parity with torch.nn.LocalResponseNorm verified | differential | **closed** |
+| G-045 forward-only modules sweep: forwards calling raw `coeus_ops::` then returning `Var::new(out, false)` (dx=0). AdaptiveAvgPool1d/2d FIXED (differentiable averaging-matrix matmul; backward verified vs numerical gradient). STILL forward-only: AdaptiveMaxPool1d/2d (need max-index scatter), Unfold1d/2d + Fold1d/2d (need im2col/col2im scatter autograd ops). Acceptance: dx parity with torch for each | differential | **partial** |
 | G-001 stateless PyTransformerEncoderLayer binding | structural | **closed MS-127** |
 | G-002 stateless PyTransformerEncoder binding | structural | **closed MS-128** |
 | G-003 stateless PyTransformerDecoderLayer binding | structural | **closed MS-129** |


### PR DESCRIPTION
## Summary
A **forward-only-module sweep** (looking for `Var::new(out, false)` after raw `coeus_ops::` calls — the LRN bug class) found `AdaptiveAvgPool1d/2d` were forward-only: correct values, but `dx=0`. This PR fixes the avg-pool variants by rewriting their forwards as **differentiable averaging-matrix matmuls**:

- a constant `P_T[in, out]` holding `1/region_size` in each output column's input region (PyTorch's adaptive region convention) makes `input @ P_T` average each region differentiably — the matmul backward scatters the averaged gradient back;
- 2D is separable: pool W then H, each a single matmul.

## Verification
- Forward stays value-correct: all existing adaptive parity tests pass (incl. overlapping-region cases).
- **New f64 numerical-gradient backward tests** (1d + 2d): analytic `dx` matches central finite differences within 1e-5, non-zero (overlapping regions, so gradients genuinely sum). 
- fmt + clippy clean.

`AdaptiveAvgPool` is now **trainable**.

## Tracked (G-045 partial)
`AdaptiveMaxPool1d/2d` and `Unfold1d/2d`/`Fold1d/2d` remain forward-only (need max-index / im2col-col2im scatter autograd ops) — filed in `docs/gap_audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug where `AdaptiveAvgPool1d` and `AdaptiveAvgPool2d` were forward-only (non-differentiable) with gradients always being zero. The fix rewrites the forward passes to use **differentiable averaging-matrix matmuls** instead of raw operations—a transposed averaging matrix `P_T` maps each output region to its averaged inputs using `1/region_size` weights following PyTorch's adaptive region convention. For 2D pooling, the operation is implemented as separable pooling (width then height). The changes are verified through new **f64 numerical-gradient backward tests** that confirm analytic gradients match central finite differences within 1e-5 tolerance, making these layers now trainable. The PR also documents that `AdaptiveMaxPool1d/2d` and `Unfold/Fold` layers remain forward-only as part of the G-045 tracking.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/adaptive_pool_parity.rs` |
| 2 | `coeus-nn/src/pool/adaptive.rs` |
| 3 | `docs/gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->