### PR TITLE
test(python): AdaptiveAvgPool dx parity vs PyTorch and JAX

### DIFF
--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -950,3 +950,63 @@ def test_local_response_norm_matches_jax() -> None:
         f"lrn loss: got={loss_pyc.data[0]:.8g}, expected={float(loss_jax):.8g}"
     )
     _allclose("lrn_dx_jax", list(x_pyc.grad), dx_jax.flatten().tolist())
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveAvgPool forward + gradient parity
+# ---------------------------------------------------------------------------
+
+
+def _avg_pool_matrix(in_len: int, out_len: int):
+    """Averaging matrix ``P[out, in]`` for adaptive pooling — PyTorch's region
+    convention ``[floor(o*in/out), ceil((o+1)*in/out))``, ``1/region`` per cell."""
+    rows = []
+    for o in range(out_len):
+        start = o * in_len // out_len
+        end = -(-(o + 1) * in_len // out_len)  # ceil
+        rows.append(
+            [1.0 / (end - start) if start <= li < end else 0.0 for li in range(in_len)]
+        )
+    return jnp.asarray(rows, dtype=jnp.float64)
+
+
+def test_adaptive_avg_pool_matches_jax() -> None:
+    """Forward + gradient parity vs a composed JAX reference (averaging matmul),
+    mirroring the PyTorch dx test. AdaptiveAvgPool is differentiable (G-045)."""
+    # 1d: [2, 4, 7] -> 3
+    n, c, length, out = 2, 4, 7, 3
+    d1 = [math.sin(i * 0.11) for i in range(n * c * length)]
+    x1p = pycoeus.Tensor(d1, [n, c, length], requires_grad=True)
+    y1 = pycoeus.AdaptiveAvgPool1d(out).forward(x1p)
+    pycoeus.mse_loss(y1, pycoeus.Tensor([0.1] * (n * c * out), [n, c, out])).backward()
+
+    p1 = _avg_pool_matrix(length, out)
+    x1j = jnp.asarray(d1, dtype=jnp.float64).reshape(n, c, length)
+    tgt1 = jnp.full((n, c, out), 0.1, dtype=jnp.float64)
+
+    def loss1(x):
+        return jnp.mean((jnp.einsum("ol,ncl->nco", p1, x) - tgt1) ** 2)
+
+    _, dx1 = jax.value_and_grad(loss1)(x1j)
+    y1j = jnp.einsum("ol,ncl->nco", p1, x1j)
+    _allclose("adaptive1d_forward_jax", list(y1.data), y1j.flatten().tolist())
+    _allclose("adaptive1d_dx_jax", list(x1p.grad), dx1.flatten().tolist())
+
+    # 2d: [2, 3, 5, 5] -> (2, 2)
+    n, c, h, w, oh, ow = 2, 3, 5, 5, 2, 2
+    d2 = [math.cos(i * 0.07) for i in range(n * c * h * w)]
+    x2p = pycoeus.Tensor(d2, [n, c, h, w], requires_grad=True)
+    y2 = pycoeus.AdaptiveAvgPool2d(oh, ow).forward(x2p)
+    pycoeus.mse_loss(y2, pycoeus.Tensor([0.2] * (n * c * oh * ow), [n, c, oh, ow])).backward()
+
+    ph, pw = _avg_pool_matrix(h, oh), _avg_pool_matrix(w, ow)
+    x2j = jnp.asarray(d2, dtype=jnp.float64).reshape(n, c, h, w)
+    tgt2 = jnp.full((n, c, oh, ow), 0.2, dtype=jnp.float64)
+
+    def loss2(x):
+        return jnp.mean((jnp.einsum("ah,bw,nchw->ncab", ph, pw, x) - tgt2) ** 2)
+
+    _, dx2 = jax.value_and_grad(loss2)(x2j)
+    y2j = jnp.einsum("ah,bw,nchw->ncab", ph, pw, x2j)
+    _allclose("adaptive2d_forward_jax", list(y2.data), y2j.flatten().tolist())
+    _allclose("adaptive2d_dx_jax", list(x2p.grad), dx2.flatten().tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2511,6 +2511,47 @@ def test_adaptive_avg_pool2d_non_trivial_matches_pytorch() -> None:
     )
 
 
+def test_adaptive_avg_pool_backward_matches_pytorch() -> None:
+    """Gradient parity vs torch: AdaptiveAvgPool1d/2d are now differentiable
+    (G-045). Both use overlapping adaptive regions so the gradient genuinely
+    sums region contributions."""
+    # 1d: [2, 4, 7] -> 3 (overlapping regions)
+    n, c, length = 2, 4, 7
+    d1 = [math.sin(i * 0.11) for i in range(n * c * length)]
+    x1 = pycoeus.Tensor(d1, [n, c, length], requires_grad=True)
+    y1 = pycoeus.AdaptiveAvgPool1d(3).forward(x1)
+    pycoeus.mse_loss(y1, pycoeus.Tensor([0.1] * (n * c * 3), [n, c, 3])).backward()
+    x1t = (
+        torch.tensor(d1, dtype=torch.float64)
+        .reshape(n, c, length)
+        .requires_grad_(True)
+    )
+    y1t = torch.nn.AdaptiveAvgPool1d(3)(x1t)
+    torch.nn.functional.mse_loss(
+        y1t, torch.full((n, c, 3), 0.1, dtype=torch.float64)
+    ).backward()
+    _allclose("adaptive1d_forward", list(y1.data), y1t.detach().flatten().tolist())
+    _allclose("adaptive1d_dx", list(x1.grad), x1t.grad.flatten().tolist())
+
+    # 2d: [2, 3, 5, 5] -> (2, 2) (overlapping on both axes)
+    n, c, h, w = 2, 3, 5, 5
+    d2 = [math.cos(i * 0.07) for i in range(n * c * h * w)]
+    x2 = pycoeus.Tensor(d2, [n, c, h, w], requires_grad=True)
+    y2 = pycoeus.AdaptiveAvgPool2d(2, 2).forward(x2)
+    pycoeus.mse_loss(y2, pycoeus.Tensor([0.2] * (n * c * 2 * 2), [n, c, 2, 2])).backward()
+    x2t = (
+        torch.tensor(d2, dtype=torch.float64)
+        .reshape(n, c, h, w)
+        .requires_grad_(True)
+    )
+    y2t = torch.nn.AdaptiveAvgPool2d((2, 2))(x2t)
+    torch.nn.functional.mse_loss(
+        y2t, torch.full((n, c, 2, 2), 0.2, dtype=torch.float64)
+    ).backward()
+    _allclose("adaptive2d_forward", list(y2.data), y2t.detach().flatten().tolist())
+    _allclose("adaptive2d_dx", list(x2.grad), x2t.grad.flatten().tolist())
+
+
 # ---------------------------------------------------------------------------
 # Unfold2d parity (MS-213)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Completes the AdaptiveAvgPool cross-framework slice now that it is differentiable ([#109](https://github.com/ryancinsight/Coeus/pull/109)). The existing python tests were **forward-only**; this adds forward + gradient (`dx`) parity for `AdaptiveAvgPool1d/2d`:

- **PyTorch**: vs `torch.nn.AdaptiveAvgPool1d/2d` (exact oracle);
- **JAX**: vs a composed averaging-matmul reference + `jax.value_and_grad`.

Both use overlapping adaptive regions (1d `7→3`, 2d `5×5→2×2`) so gradients genuinely sum region contributions.

## Verification
- `pytest` — **2 passed** (pytorch + jax); forward, loss, and `dx` match within 1e-5 in both frameworks.
- Test-only: the differentiable pool (#109) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds gradient (`dx`) testing for `AdaptiveAvgPool1d` and `AdaptiveAvgPool2d` operations to verify backward pass parity with PyTorch and JAX. The existing tests only verified forward pass correctness; these new tests ensure that gradients match reference implementations from both frameworks using overlapping adaptive pooling regions (1d `7→3`, 2d `5×5→2×2`) where gradients genuinely sum contributions from multiple regions. The PyTorch test compares against `torch.nn.AdaptiveAvgPool1d/2d`, while the JAX test uses a custom averaging matrix reference with `jax.value_and_grad`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new parity coverage for adaptive average pooling in both 1D and 2D.
  * Verified forward results and backward gradients against JAX and PyTorch references.
  * Expanded test cases to include overlapping pooling regions for stronger gradient checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->