### PR TITLE
fix(nn): Make AdaptiveMaxPool1d/2d differentiable (G-045)

### DIFF
--- a/coeus-nn/src/pool/adaptive.rs
+++ b/coeus-nn/src/pool/adaptive.rs
@@ -50,6 +50,42 @@ where
     )
 }
 
+/// Adaptive **max** pool over the last axis of a 2D view `[rows, in_len]` →
+/// `[rows, out_len]`. Each output takes the max over its adaptive input region
+/// (PyTorch's region convention). Differentiable: non-region positions are
+/// filled with `-inf` and `max_axis` routes the gradient to each region's
+/// argmax. The transient `[rows, out_len, in_len]` mask is `out_len`× the slice
+/// — modest for typical pools; an argmax-scatter kernel would avoid it.
+fn masked_adaptive_max<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x2: &Var<T, B>,
+    rows: usize,
+    in_len: usize,
+    out_len: usize,
+    backend: &B,
+) -> Var<T, B>
+where
+    B::DeviceBuffer<T>: CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
+{
+    // outside[o, l] = 1 where l is NOT in region o → filled with -inf below.
+    let mut outside = vec![T::one(); out_len * in_len];
+    for o in 0..out_len {
+        let start = o * in_len / out_len;
+        let end = ((o + 1) * in_len).div_ceil(out_len);
+        outside[o * in_len + start..o * in_len + end].fill(T::zero());
+    }
+    let outside_var = Var::new(
+        Tensor::from_slice_on([1, out_len, in_len], &outside, backend),
+        false,
+    );
+    let xb = coeus_autograd::broadcast_to(
+        &coeus_autograd::reshape(x2, [rows, 1, in_len]),
+        vec![rows, out_len, in_len],
+    );
+    let ob = coeus_autograd::broadcast_to(&outside_var, vec![rows, out_len, in_len]);
+    let masked = coeus_autograd::masked_fill(&xb, &ob, T::from_f64(f64::NEG_INFINITY));
+    coeus_autograd::max_axis(&masked, 2)
+}
+
 // ── AdaptiveAvgPool1d ─────────────────────────────────────────────────────────
 
 /// Adaptive average pooling for `[N, C, L]` → `[N, C, output_size]`.
@@ -219,9 +255,14 @@ where
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        // Differentiable: masked max over each adaptive region along the length.
+        let shape = input.tensor.shape_cloned();
+        let (n, c, l) = (shape[0], shape[1], shape[2]);
+        let o = self.output_size;
         let backend = B::default();
-        let out_tensor = coeus_ops::adaptive_max_pool1d(&input.tensor, self.output_size, &backend);
-        Var::new(out_tensor, false)
+        let x2 = coeus_autograd::reshape(input, [n * c, l]);
+        let pooled = masked_adaptive_max::<T, B>(&x2, n * c, l, o, &backend);
+        coeus_autograd::reshape(&pooled, [n, c, o])
     }
 }
 
@@ -264,9 +305,29 @@ where
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        // Differentiable separable max pooling: max over W, then over H (max of a
+        // 2D region equals the max of per-axis maxes), each a masked max_axis.
+        let shape = input.tensor.shape_cloned();
+        let (n, c, h, w) = (shape[0], shape[1], shape[2], shape[3]);
+        let (oh, ow) = (self.out_h, self.out_w);
         let backend = B::default();
-        let out_tensor =
-            coeus_ops::adaptive_max_pool2d(&input.tensor, self.out_h, self.out_w, &backend);
-        Var::new(out_tensor, false)
+
+        // Pool W: [N, C, H, W] -> [N*C*H, W] -> [N*C*H, OW] -> [N, C, H, OW].
+        let xw = coeus_autograd::reshape(input, [n * c * h, w]);
+        let pw = masked_adaptive_max::<T, B>(&xw, n * c * h, w, ow, &backend);
+        let yw = coeus_autograd::reshape(&pw, [n, c, h, ow]);
+
+        // Pool H: bring H last, [N, C, OW, H] -> [N*C*OW, H] -> [N*C*OW, OH].
+        let yw_p = coeus_autograd::permute(&yw, &[0, 1, 3, 2]);
+        let ph = masked_adaptive_max::<T, B>(
+            &coeus_autograd::reshape(&yw_p, [n * c * ow, h]),
+            n * c * ow,
+            h,
+            oh,
+            &backend,
+        );
+        let yh = coeus_autograd::reshape(&ph, [n, c, ow, oh]);
+        let out = coeus_autograd::permute(&yh, &[0, 1, 3, 2]);
+        coeus_autograd::reshape(&out, [n, c, oh, ow])
     }
 }

--- a/coeus-nn/tests/adaptive_pool_parity.rs
+++ b/coeus-nn/tests/adaptive_pool_parity.rs
@@ -256,3 +256,66 @@ fn adaptive_avg_pool2d_backward_matches_numerical_gradient() {
             .sum::<f64>()
     });
 }
+
+#[test]
+fn adaptive_max_pool1d_backward_matches_numerical_gradient() {
+    // Distinct values so each region's argmax is unique (no tie ambiguity); the
+    // gradient routes to the argmax of each output and is stable under ±1e-6.
+    let m = AdaptiveMaxPool1d::<f64, SequentialBackend>::new(3);
+    let data = [3.0_f64, 1.0, 4.0, 1.5, 5.0, 9.0, 2.0];
+    let shape = [1, 1, 7];
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
+        true,
+    );
+    m.forward(&x).backward();
+    let analytic: Vec<f64> = x
+        .grad()
+        .expect("adaptive max pool 1d gradient")
+        .as_slice()
+        .to_vec();
+    assert_grad_matches_numeric(&analytic, &data, 1e-6, |d| {
+        let xv = Var::new(
+            Tensor::<f64, SequentialBackend>::from_slice(shape, d),
+            false,
+        );
+        m.forward(&xv)
+            .tensor
+            .as_slice()
+            .iter()
+            .copied()
+            .sum::<f64>()
+    });
+}
+
+#[test]
+fn adaptive_max_pool2d_backward_matches_numerical_gradient() {
+    // 25 distinct values (i*13 mod 25 is a permutation since gcd(13,25)=1).
+    let m = AdaptiveMaxPool2d::<f64, SequentialBackend>::new(2, 2);
+    let data: Vec<f64> = (0..25)
+        .map(|i| ((i * 13 % 25) as f64) * 0.37 + 0.11)
+        .collect();
+    let shape = [1, 1, 5, 5];
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
+        true,
+    );
+    m.forward(&x).backward();
+    let analytic: Vec<f64> = x
+        .grad()
+        .expect("adaptive max pool 2d gradient")
+        .as_slice()
+        .to_vec();
+    assert_grad_matches_numeric(&analytic, &data, 1e-6, |d| {
+        let xv = Var::new(
+            Tensor::<f64, SequentialBackend>::from_slice(shape, d),
+            false,
+        );
+        m.forward(&xv)
+            .tensor
+            .as_slice()
+            .iter()
+            .copied()
+            .sum::<f64>()
+    });
+}

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -478,7 +478,7 @@ Evidence tier: differential/empirical (PyTorch f64).
 | G-042 quantized and lazy module parity policy missing | source-surface + external docs audit | **open** |
 | G-043 Burn/PyTorch NN benchmark matrix remains partial | source-surface + external docs audit | **open** |
 | G-044 LocalResponseNorm was forward-only (non-differentiable). Fixed: forward rewritten as an autograd graph (band-matrix matmul windowed sum-of-squares + differentiable `pow`), so dx now flows. forward + dx parity with torch.nn.LocalResponseNorm verified | differential | **closed** |
-| G-045 forward-only modules sweep: forwards calling raw `coeus_ops::` then returning `Var::new(out, false)` (dx=0). AdaptiveAvgPool1d/2d FIXED (differentiable averaging-matrix matmul; backward verified vs numerical gradient). STILL forward-only: AdaptiveMaxPool1d/2d (need max-index scatter), Unfold1d/2d + Fold1d/2d (need im2col/col2im scatter autograd ops). Acceptance: dx parity with torch for each | differential | **partial** |
+| G-045 forward-only modules sweep: forwards calling raw `coeus_ops::` then returning `Var::new(out, false)` (dx=0). FIXED: AdaptiveAvgPool1d/2d (averaging-matrix matmul) and AdaptiveMaxPool1d/2d (masked `max_axis` over each region, separable 2D); both backward-verified vs numerical gradient. STILL forward-only: Unfold1d/2d + Fold1d/2d (need im2col/col2im scatter autograd ops). Acceptance: dx parity with torch for each | differential | **partial** |
 | G-001 stateless PyTransformerEncoderLayer binding | structural | **closed MS-127** |
 | G-002 stateless PyTransformerEncoder binding | structural | **closed MS-128** |
 | G-003 stateless PyTransformerDecoderLayer binding | structural | **closed MS-129** |


### PR DESCRIPTION
## Summary
Completes the adaptive-pool family. `AdaptiveMaxPool1d/2d` were forward-only (`Var::new(out, false)`, `dx=0`). Rewrites the forwards as differentiable **masked max-reductions**:

- a constant outside-region mask fills non-region positions with `-inf`, then `max_axis` over the expanded region axis routes the gradient to each output's argmax (overlapping regions sum via the broadcast backward);
- 2D is separable (max of a 2D region = max of per-axis maxes): max over W then over H.

## Verification
- Forward stays value-correct: existing adaptive max-pool parity tests pass.
- **New f64 numerical-gradient backward tests** (1d + 2d, distinct values → unique argmax): analytic `dx` matches central differences within 1e-5, non-zero.
- fmt + clippy clean.

`AdaptiveMaxPool` is now **trainable**. Only `Unfold/Fold` remain forward-only (G-045 partial — need im2col/col2im scatter ops).

_Note:_ the masked approach uses an `out_len`× transient; an argmax-scatter kernel would avoid it (future optimization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes `AdaptiveMaxPool1d` and `AdaptiveMaxPool2d` differentiable by rewriting their forward passes as **masked max-reductions** over adaptive regions. Previously, these modules were forward-only (returning `Var::new(out, false)` with `dx=0`). The new implementation uses constant masks that fill non-region positions with `-inf`, then applies `max_axis` to route gradients to each output's argmax. For 2D pooling, the implementation leverages separability by applying max operations sequentially over width then height. Forward value correctness is preserved, and new f64 numerical-gradient tests verify the backward pass accuracy within 1e-5.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/gap_audit.md` |
| 2 | `coeus-nn/src/pool/adaptive.rs` |
| 3 | `coeus-nn/tests/adaptive_pool_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->