### PR TITLE
feat(python): AdaptiveMaxPool1d/2d binding + dx parity (PyTorch, JAX)

### DIFF
--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -155,6 +155,8 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<nn::PyAvgPool1d>()?;
     m.add_class::<nn::PyAdaptiveAvgPool1d>()?;
     m.add_class::<nn::PyAdaptiveAvgPool2d>()?;
+    m.add_class::<nn::PyAdaptiveMaxPool1d>()?;
+    m.add_class::<nn::PyAdaptiveMaxPool2d>()?;
     m.add_class::<nn::PyUnfold2d>()?;
     m.add_class::<nn::PyFold2d>()?;
     m.add_class::<nn::PyUnfold1d>()?;

--- a/coeus-python/src/nn/mod.rs
+++ b/coeus-python/src/nn/mod.rs
@@ -49,9 +49,9 @@ pub use normalization::{
     PyInstanceNorm3d, PyLayerNorm, PyRMSNorm,
 };
 pub use pool::{
-    PyAdaptiveAvgPool1d, PyAdaptiveAvgPool2d, PyAvgPool1d, PyAvgPool2d, PyAvgPool3d,
-    PyGlobalAvgPool1d, PyGlobalAvgPool2d, PyGlobalAvgPool3d, PyGlobalMaxPool2d, PyGlobalMaxPool3d,
-    PyMaxPool1d, PyMaxPool2d, PyMaxPool3d,
+    PyAdaptiveAvgPool1d, PyAdaptiveAvgPool2d, PyAdaptiveMaxPool1d, PyAdaptiveMaxPool2d,
+    PyAvgPool1d, PyAvgPool2d, PyAvgPool3d, PyGlobalAvgPool1d, PyGlobalAvgPool2d, PyGlobalAvgPool3d,
+    PyGlobalMaxPool2d, PyGlobalMaxPool3d, PyMaxPool1d, PyMaxPool2d, PyMaxPool3d,
 };
 pub use regularization::PyLocalResponseNorm;
 pub use rnn::{PyBidirectional, PyGRUCell, PyLSTMCell, PyRNNCell};

--- a/coeus-python/src/nn/pool.rs
+++ b/coeus-python/src/nn/pool.rs
@@ -632,3 +632,95 @@ impl PyAdaptiveAvgPool2d {
     /// Zero gradients (no-op for pooling layers).
     pub fn zero_grad(&self) {}
 }
+
+// ── AdaptiveMaxPool1d ─────────────────────────────────────────────────────────
+
+/// Python-exposed Adaptive 1D Max Pooling layer.
+///
+/// Equivalent to `torch.nn.AdaptiveMaxPool1d(output_size)`. Differentiable.
+#[pyclass(name = "AdaptiveMaxPool1d")]
+pub struct PyAdaptiveMaxPool1d {
+    /// Target spatial output length.
+    #[pyo3(get)]
+    pub output_size: usize,
+}
+
+#[pymethods]
+impl PyAdaptiveMaxPool1d {
+    #[new]
+    /// Create an `AdaptiveMaxPool1d` with the given target output length.
+    pub fn new(output_size: usize) -> Self {
+        Self { output_size }
+    }
+
+    /// Forward pass: `[N, C, L]` → `[N, C, output_size]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let output_size = self.output_size;
+        let pool = coeus_nn::AdaptiveMaxPool1d::<f64, coeus_core::MoiraiBackend>::new(output_size);
+        let inner = py.allow_threads(move || pool.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op for pooling layers).
+    pub fn zero_grad(&self) {}
+}
+
+// ── AdaptiveMaxPool2d ─────────────────────────────────────────────────────────
+
+/// Python-exposed Adaptive 2D Max Pooling layer.
+///
+/// Equivalent to `torch.nn.AdaptiveMaxPool2d((out_h, out_w))`. Differentiable.
+#[pyclass(name = "AdaptiveMaxPool2d")]
+pub struct PyAdaptiveMaxPool2d {
+    /// Target output height.
+    #[pyo3(get)]
+    pub out_h: usize,
+    /// Target output width.
+    #[pyo3(get)]
+    pub out_w: usize,
+}
+
+#[pymethods]
+impl PyAdaptiveMaxPool2d {
+    #[new]
+    #[pyo3(signature = (out_h, out_w = None))]
+    /// Create an `AdaptiveMaxPool2d` pooling to `(out_h, out_w)`.
+    ///
+    /// Passing only one size `n` gives a square `(n, n)` output.
+    pub fn new(out_h: usize, out_w: Option<usize>) -> Self {
+        Self {
+            out_h,
+            out_w: out_w.unwrap_or(out_h),
+        }
+    }
+
+    /// Forward pass: `[N, C, H, W]` → `[N, C, out_h, out_w]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let out_h = self.out_h;
+        let out_w = self.out_w;
+        let pool = coeus_nn::AdaptiveMaxPool2d::<f64, coeus_core::MoiraiBackend>::new(out_h, out_w);
+        let inner = py.allow_threads(move || pool.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op for pooling layers).
+    pub fn zero_grad(&self) {}
+}

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1010,3 +1010,65 @@ def test_adaptive_avg_pool_matches_jax() -> None:
     y2j = jnp.einsum("ah,bw,nchw->ncab", ph, pw, x2j)
     _allclose("adaptive2d_forward_jax", list(y2.data), y2j.flatten().tolist())
     _allclose("adaptive2d_dx_jax", list(x2p.grad), dx2.flatten().tolist())
+
+
+def test_adaptive_max_pool_matches_jax() -> None:
+    """Forward + gradient parity vs a JAX per-region-max reference, mirroring the
+    PyTorch dx test. AdaptiveMaxPool is differentiable (G-045). Distinct values
+    ((i*13)%211, gcd=1) keep each region's argmax unique."""
+
+    def ceil_div(a: int, b: int) -> int:
+        return -(-a // b)
+
+    # 1d: [2, 4, 7] -> 3
+    n, c, length, out = 2, 4, 7, 3
+    d1 = [((i * 13) % 211) * 0.07 for i in range(n * c * length)]
+    x1p = pycoeus.Tensor(d1, [n, c, length], requires_grad=True)
+    y1 = pycoeus.AdaptiveMaxPool1d(out).forward(x1p)
+    pycoeus.mse_loss(y1, pycoeus.Tensor([0.5] * (n * c * out), [n, c, out])).backward()
+
+    x1j = jnp.asarray(d1, dtype=jnp.float64).reshape(n, c, length)
+    tgt1 = jnp.full((n, c, out), 0.5, dtype=jnp.float64)
+
+    def fwd1(x):
+        cols = [
+            jnp.max(x[:, :, o * length // out : ceil_div((o + 1) * length, out)], axis=2)
+            for o in range(out)
+        ]
+        return jnp.stack(cols, axis=2)
+
+    _, dx1 = jax.value_and_grad(lambda x: jnp.mean((fwd1(x) - tgt1) ** 2))(x1j)
+    _allclose("adaptivemax1d_forward_jax", list(y1.data), fwd1(x1j).flatten().tolist())
+    _allclose("adaptivemax1d_dx_jax", list(x1p.grad), dx1.flatten().tolist())
+
+    # 2d: [2, 3, 5, 5] -> (2, 2)
+    n, c, h, w, oh, ow = 2, 3, 5, 5, 2, 2
+    d2 = [((i * 13) % 211) * 0.07 for i in range(n * c * h * w)]
+    x2p = pycoeus.Tensor(d2, [n, c, h, w], requires_grad=True)
+    y2 = pycoeus.AdaptiveMaxPool2d(oh, ow).forward(x2p)
+    pycoeus.mse_loss(y2, pycoeus.Tensor([0.5] * (n * c * oh * ow), [n, c, oh, ow])).backward()
+
+    x2j = jnp.asarray(d2, dtype=jnp.float64).reshape(n, c, h, w)
+    tgt2 = jnp.full((n, c, oh, ow), 0.5, dtype=jnp.float64)
+
+    def fwd2(x):
+        rows = []
+        for oi in range(oh):
+            cols = [
+                jnp.max(
+                    x[
+                        :,
+                        :,
+                        oi * h // oh : ceil_div((oi + 1) * h, oh),
+                        oj * w // ow : ceil_div((oj + 1) * w, ow),
+                    ],
+                    axis=(2, 3),
+                )
+                for oj in range(ow)
+            ]
+            rows.append(jnp.stack(cols, axis=2))
+        return jnp.stack(rows, axis=2)
+
+    _, dx2 = jax.value_and_grad(lambda x: jnp.mean((fwd2(x) - tgt2) ** 2))(x2j)
+    _allclose("adaptivemax2d_forward_jax", list(y2.data), fwd2(x2j).flatten().tolist())
+    _allclose("adaptivemax2d_dx_jax", list(x2p.grad), dx2.flatten().tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2552,6 +2552,47 @@ def test_adaptive_avg_pool_backward_matches_pytorch() -> None:
     _allclose("adaptive2d_dx", list(x2.grad), x2t.grad.flatten().tolist())
 
 
+def test_adaptive_max_pool_backward_matches_pytorch() -> None:
+    """Forward + gradient parity vs torch: AdaptiveMaxPool1d/2d are differentiable
+    (G-045). Distinct values ((i*13)%211 is a permutation, gcd(13,211)=1) so each
+    region's argmax is unique and matches torch's, making dx unambiguous."""
+    # 1d: [2, 4, 7] -> 3
+    n, c, length = 2, 4, 7
+    d1 = [((i * 13) % 211) * 0.07 for i in range(n * c * length)]
+    x1 = pycoeus.Tensor(d1, [n, c, length], requires_grad=True)
+    y1 = pycoeus.AdaptiveMaxPool1d(3).forward(x1)
+    pycoeus.mse_loss(y1, pycoeus.Tensor([0.5] * (n * c * 3), [n, c, 3])).backward()
+    x1t = (
+        torch.tensor(d1, dtype=torch.float64)
+        .reshape(n, c, length)
+        .requires_grad_(True)
+    )
+    y1t = torch.nn.AdaptiveMaxPool1d(3)(x1t)
+    torch.nn.functional.mse_loss(
+        y1t, torch.full((n, c, 3), 0.5, dtype=torch.float64)
+    ).backward()
+    _allclose("adaptivemax1d_forward", list(y1.data), y1t.detach().flatten().tolist())
+    _allclose("adaptivemax1d_dx", list(x1.grad), x1t.grad.flatten().tolist())
+
+    # 2d: [2, 3, 5, 5] -> (2, 2)
+    n, c, h, w = 2, 3, 5, 5
+    d2 = [((i * 13) % 211) * 0.07 for i in range(n * c * h * w)]
+    x2 = pycoeus.Tensor(d2, [n, c, h, w], requires_grad=True)
+    y2 = pycoeus.AdaptiveMaxPool2d(2, 2).forward(x2)
+    pycoeus.mse_loss(y2, pycoeus.Tensor([0.5] * (n * c * 4), [n, c, 2, 2])).backward()
+    x2t = (
+        torch.tensor(d2, dtype=torch.float64)
+        .reshape(n, c, h, w)
+        .requires_grad_(True)
+    )
+    y2t = torch.nn.AdaptiveMaxPool2d((2, 2))(x2t)
+    torch.nn.functional.mse_loss(
+        y2t, torch.full((n, c, 2, 2), 0.5, dtype=torch.float64)
+    ).backward()
+    _allclose("adaptivemax2d_forward", list(y2.data), y2t.detach().flatten().tolist())
+    _allclose("adaptivemax2d_dx", list(x2.grad), x2t.grad.flatten().tolist())
+
+
 # ---------------------------------------------------------------------------
 # Unfold2d parity (MS-213)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`AdaptiveMaxPool` was **unbound** in coeus-python (only AdaptiveAvgPool was). Binds `PyAdaptiveMaxPool1d/2d` (config-only) over the now-differentiable `coeus_nn::AdaptiveMaxPool` ([#111](https://github.com/ryancinsight/Coeus/pull/111)); registered in nn + lib.

## Forward + gradient parity
- **PyTorch**: vs `torch.nn.AdaptiveMaxPool1d/2d` (exact oracle);
- **JAX**: vs a per-region `jnp.max` reference + `jax.value_and_grad`.

Distinct values (`(i*13)%211`, a permutation) keep each region's argmax unique so `dx` is unambiguous and matches both frameworks (1d `7→3`, 2d `5×5→2×2`). forward + `dx` within 1e-5. **2 passed** (maturin rebuild + pytest).

Completes the **adaptive-pool family** end-to-end (avg + max, Rust + PyTorch + JAX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Python bindings for `AdaptiveMaxPool1d` and `AdaptiveMaxPool2d` layers to complete the adaptive pooling family in coeus-python. The implementation exposes the now-differentiable Rust `coeus_nn::AdaptiveMaxPool` operations with configuration-only wrappers that mirror PyTorch's API. Comprehensive tests verify both forward and backward pass correctness against PyTorch's `torch.nn.AdaptiveMaxPool1d/2d` (exact oracle) and JAX's per-region max implementation, using distinct input values to ensure unambiguous gradients where each pooling region has a unique maximum.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/nn/pool.rs` |
| 2 | `coeus-python/src/nn/mod.rs` |
| 3 | `coeus-python/src/lib.rs` |
| 4 | `coeus-python/tests/test_pytorch_parity.py` |
| 5 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->