### PR TITLE
feat(nn): Add LogSigmoid and Tanhshrink activations

### DIFF
--- a/coeus-nn/src/activation.rs
+++ b/coeus-nn/src/activation.rs
@@ -659,3 +659,54 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for PReLU {
         prelu(input, self.alpha)
     }
 }
+
+/// Functional LogSigmoid activation: `log(sigmoid(x)) = -softplus(-x)`.
+///
+/// Uses the numerically stable `-softplus(-x)` identity (avoids `log` of a tiny
+/// sigmoid); matches `torch.nn.functional.logsigmoid`.
+#[inline]
+pub fn log_sigmoid<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+) -> Var<T, B> {
+    coeus_autograd::neg(&coeus_autograd::softplus(&coeus_autograd::neg(input)))
+}
+
+/// LogSigmoid activation module.
+#[derive(Clone, Debug, Default)]
+pub struct LogSigmoid;
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for LogSigmoid {
+    #[inline]
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        vec![]
+    }
+
+    #[inline]
+    fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        log_sigmoid(input)
+    }
+}
+
+/// Functional Tanhshrink activation: `x - tanh(x)`.
+///
+/// Matches `torch.nn.functional.tanhshrink`.
+#[inline]
+pub fn tanhshrink<T: Float, B: coeus_ops::BackendOps<T> + Default>(input: &Var<T, B>) -> Var<T, B> {
+    coeus_autograd::sub(input, &coeus_autograd::tanh(input))
+}
+
+/// Tanhshrink activation module.
+#[derive(Clone, Debug, Default)]
+pub struct Tanhshrink;
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Tanhshrink {
+    #[inline]
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        vec![]
+    }
+
+    #[inline]
+    fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        tanhshrink(input)
+    }
+}

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -69,11 +69,12 @@ pub mod swiglu;
 pub mod transformer;
 
 pub use activation::{
-    celu, elu, gelu, gelu_tanh, hardshrink, hardsigmoid, hardswish, hardtanh, leaky_relu, mish,
-    prelu, relu, sigmoid, silu, softplus, softshrink, softsign, tanh, threshold, Celu, CeluOp,
-    GeLU, GeLUTanh, Hardshrink, HardshrinkOp, Hardsigmoid, HardsigmoidOp, Hardswish, HardswishOp,
-    Hardtanh, HardtanhOp, LeakyReLU, Mish, PReLU, ReLU, SiLU, Sigmoid, Softplus, Softshrink,
-    SoftshrinkOp, Softsign, SoftsignOp, Tanh, Threshold, ThresholdNode, ELU,
+    celu, elu, gelu, gelu_tanh, hardshrink, hardsigmoid, hardswish, hardtanh, leaky_relu,
+    log_sigmoid, mish, prelu, relu, sigmoid, silu, softplus, softshrink, softsign, tanh,
+    tanhshrink, threshold, Celu, CeluOp, GeLU, GeLUTanh, Hardshrink, HardshrinkOp, Hardsigmoid,
+    HardsigmoidOp, Hardswish, HardswishOp, Hardtanh, HardtanhOp, LeakyReLU, LogSigmoid, Mish,
+    PReLU, ReLU, SiLU, Sigmoid, Softplus, Softshrink, SoftshrinkOp, Softsign, SoftsignOp, Tanh,
+    Tanhshrink, Threshold, ThresholdNode, ELU,
 };
 pub use attention::{
     multi_head_attention_cross, AttentionMask, CausalMask, MhaProjectionParams, MultiHeadAttention,

--- a/coeus-nn/tests/act_extended_tests.rs
+++ b/coeus-nn/tests/act_extended_tests.rs
@@ -12,8 +12,8 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
-    celu, hardshrink, hardsigmoid, hardswish, hardtanh, prelu, softshrink, softsign, threshold,
-    Hardsigmoid, Hardswish, Module, Softsign,
+    celu, hardshrink, hardsigmoid, hardswish, hardtanh, log_sigmoid, prelu, softshrink, softsign,
+    tanhshrink, threshold, Hardsigmoid, Hardswish, Module, Softsign,
 };
 use coeus_tensor::Tensor;
 
@@ -468,6 +468,69 @@ fn softsign_module_forward() {
         "softsign_module_forward",
         output.tensor.as_slice(),
         &expected,
+        1e-12,
+    );
+}
+
+// ── LogSigmoid ───────────────────────────────────────────────────────────────
+
+#[test]
+fn log_sigmoid_forward_and_backward() {
+    // logsigmoid(x) = log(sigmoid(x)) = -log(1 + e^-x);
+    // d/dx = sigmoid(-x) = 1 / (1 + e^x).
+    let data = vec![-4.0_f64, -1.0, 0.0, 1.0, 3.0];
+    let expected: Vec<f64> = data.iter().map(|&x| -(1.0 + (-x).exp()).ln()).collect();
+    let expected_grad: Vec<f64> = data.iter().map(|&x| 1.0 / (1.0 + x.exp())).collect();
+
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([data.len()], &data),
+        true,
+    );
+    let output = log_sigmoid(&input);
+    // Tolerance: stable identity vs coeus's `-softplus(-x)`; agreement is ~1e-15
+    // for moderate x, 1e-10 is a safe margin.
+    assert_close_slice(
+        "log_sigmoid_forward",
+        output.tensor.as_slice(),
+        &expected,
+        1e-10,
+    );
+    output.backward();
+    let grad = input.grad().expect("log_sigmoid requires grad");
+    assert_close_slice(
+        "log_sigmoid_backward",
+        grad.as_slice(),
+        &expected_grad,
+        1e-10,
+    );
+}
+
+// ── Tanhshrink ───────────────────────────────────────────────────────────────
+
+#[test]
+fn tanhshrink_forward_and_backward() {
+    // tanhshrink(x) = x - tanh(x);  d/dx = 1 - sech^2(x) = tanh^2(x).
+    let data = vec![-3.0_f64, -1.0, 0.0, 0.5, 2.0];
+    let expected: Vec<f64> = data.iter().map(|&x| x - x.tanh()).collect();
+    let expected_grad: Vec<f64> = data.iter().map(|&x| x.tanh().powi(2)).collect();
+
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([data.len()], &data),
+        true,
+    );
+    let output = tanhshrink(&input);
+    assert_close_slice(
+        "tanhshrink_forward",
+        output.tensor.as_slice(),
+        &expected,
+        1e-12,
+    );
+    output.backward();
+    let grad = input.grad().expect("tanhshrink requires grad");
+    assert_close_slice(
+        "tanhshrink_backward",
+        grad.as_slice(),
+        &expected_grad,
         1e-12,
     );
 }


### PR DESCRIPTION
## Summary
Two common activations missing from coeus-nn vs torch:

- `log_sigmoid(x) = log(sigmoid(x))`, via the numerically stable `-softplus(-x)` (matches `torch.nn.functional.logsigmoid`);
- `tanhshrink(x) = x - tanh(x)` (matches `torch.nn.functional.tanhshrink`).

Both **compose from existing differentiable autograd ops** (`neg`/`softplus`, `sub`/`tanh`) — no new primitives — shipped as the usual free-fn + ZST `Module` pair, exported from `lib.rs`.

## Verification
- Value-semantic tests: forward vs closed form + analytic gradient (`d/dx logsigmoid = sigmoid(-x)`; `d/dx tanhshrink = tanh²(x)`). **2 passed.**
- fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds two missing activation functions to the neural network library: `LogSigmoid` and `Tanhshrink`. The `log_sigmoid` function implements `log(sigmoid(x))` using the numerically stable `-softplus(-x)` identity, while `tanhshrink` computes `x - tanh(x)`. Both are implemented by composing existing differentiable autograd operations, avoiding the need for new primitives. Each activation is provided as both a functional interface and a zero-sized type (ZST) `Module` implementation for seamless integration. The implementation includes comprehensive forward and backward pass tests validating both the computed values against closed-form expressions and the analytic gradients.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/activation.rs` |
| 2 | `coeus-nn/tests/act_extended_tests.rs` |
| 3 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->