### PR TITLE
feat(python): Bind log_sigmoid + tanhshrink + PyTorch/JAX parity

### DIFF
--- a/coeus-python/src/activations.rs
+++ b/coeus-python/src/activations.rs
@@ -248,3 +248,17 @@ pub fn prelu(input: &PyTensor, alpha: f64, py: Python<'_>) -> PyTensor {
     let inner = py.allow_threads(|| coeus_autograd::prelu(&input.inner, alpha));
     PyTensor::from_var(inner)
 }
+
+/// LogSigmoid activation: `log(sigmoid(x))`, via the stable `-softplus(-x)`.
+#[pyfunction]
+pub fn log_sigmoid(input: &PyTensor, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::log_sigmoid(&input.inner));
+    PyTensor::from_var(inner)
+}
+
+/// Tanhshrink activation: `x - tanh(x)`.
+#[pyfunction]
+pub fn tanhshrink(input: &PyTensor, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_nn::tanhshrink(&input.inner));
+    PyTensor::from_var(inner)
+}

--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -190,6 +190,8 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(activations::threshold, m)?)?;
     m.add_function(wrap_pyfunction!(activations::celu, m)?)?;
     m.add_function(wrap_pyfunction!(activations::prelu, m)?)?;
+    m.add_function(wrap_pyfunction!(activations::log_sigmoid, m)?)?;
+    m.add_function(wrap_pyfunction!(activations::tanhshrink, m)?)?;
 
     m.add_function(wrap_pyfunction!(losses::mse_loss, m)?)?;
     m.add_function(wrap_pyfunction!(losses::cross_entropy_loss, m)?)?;

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -302,6 +302,21 @@ def test_silu_matches_jax() -> None:
     _assert_activation_matches_jax("silu", lambda x: pycoeus.silu(x), jax.nn.silu, _ACT_INPUT)
 
 
+def test_log_sigmoid_matches_jax() -> None:
+    _assert_activation_matches_jax(
+        "log_sigmoid", lambda x: pycoeus.log_sigmoid(x), jax.nn.log_sigmoid, _ACT_INPUT
+    )
+
+
+def test_tanhshrink_matches_jax() -> None:
+    _assert_activation_matches_jax(
+        "tanhshrink",
+        lambda x: pycoeus.tanhshrink(x),
+        lambda x: x - jnp.tanh(x),
+        _ACT_INPUT,
+    )
+
+
 def test_mish_matches_jax() -> None:
     _assert_activation_matches_jax("mish", lambda x: pycoeus.mish(x), jax.nn.mish, _ACT_INPUT)
 

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -1709,6 +1709,24 @@ def test_silu_matches_pytorch() -> None:
     )
 
 
+def test_log_sigmoid_matches_pytorch() -> None:
+    _assert_activation_parity(
+        "log_sigmoid",
+        lambda x: pycoeus.log_sigmoid(x),
+        torch.nn.functional.logsigmoid,
+        _ACTIVATION_INPUT,
+    )
+
+
+def test_tanhshrink_matches_pytorch() -> None:
+    _assert_activation_parity(
+        "tanhshrink",
+        lambda x: pycoeus.tanhshrink(x),
+        torch.nn.functional.tanhshrink,
+        _ACTIVATION_INPUT,
+    )
+
+
 def test_mish_matches_pytorch() -> None:
     _assert_activation_parity(
         "mish", lambda x: pycoeus.mish(x), torch.nn.functional.mish, _ACTIVATION_INPUT


### PR DESCRIPTION
## Summary
Binds the two new activations ([#113](https://github.com/ryancinsight/Coeus/pull/113)) as `pycoeus.log_sigmoid` / `pycoeus.tanhshrink` (thin pyfunctions delegating to `coeus_nn` under `allow_threads`), registered in lib.

## Parity
Forward + gradient via the existing activation-parity helpers:
- **PyTorch**: vs `torch.nn.functional.logsigmoid` / `tanhshrink`;
- **JAX**: vs `jax.nn.log_sigmoid` and a composed `x - jnp.tanh(x)`.

**4 passed.** Completes `log_sigmoid`/`tanhshrink` across Rust + PyTorch + JAX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Python bindings for two new activation functions, `log_sigmoid` and `tanhshrink`, which were previously implemented in Rust (PR #113). The changes expose these activations through the `pycoeus` module and include comprehensive parity tests that verify both forward pass and gradients against PyTorch's `torch.nn.functional.logsigmoid` and `tanhshrink`, as well as JAX's `jax.nn.log_sigmoid` and a composed `x - jnp.tanh(x)` implementation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/activations.rs` |
| 2 | `coeus-python/src/lib.rs` |
| 3 | `coeus-python/tests/test_pytorch_parity.py` |
| 4 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->