### PR TITLE
feat(autograd): Differentiable unfold1d (im2col), close G-045 Unfold1d

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -166,6 +166,7 @@ pub use ops::{
     tril,
     triu,
     trunc,
+    unfold1d,
     unsqueeze,
     // Shape ops
     where_cond,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -36,7 +36,7 @@ pub use nn::{
     conv_transpose3d, cosine_embedding_loss, cross_entropy_loss, dropout, huber_loss,
     kl_divergence, l1_loss, layernorm, log_softmax, margin_ranking_loss, max_pool1d, max_pool2d,
     max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention,
-    soft_margin, softmax, AttentionMask, BatchNormArgs, CausalMask, NullMask,
+    soft_margin, softmax, unfold1d, AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 
 pub use embedding::{embedding, embedding_with_padding_idx};

--- a/coeus-autograd/src/ops/nn/conv/mod.rs
+++ b/coeus-autograd/src/ops/nn/conv/mod.rs
@@ -4,6 +4,7 @@ mod conv1d;
 mod conv2d;
 mod conv3d;
 mod transpose;
+mod unfold_fold;
 mod utils;
 
 pub use conv1d::conv1d;
@@ -13,4 +14,5 @@ pub use transpose::{
     conv_transpose1d, conv_transpose2d, conv_transpose3d, ConvTranspose1dNode, ConvTranspose2dNode,
     ConvTranspose3dNode,
 };
+pub use unfold_fold::unfold1d;
 pub use utils::ConvNode;

--- a/coeus-autograd/src/ops/nn/conv/unfold_fold.rs
+++ b/coeus-autograd/src/ops/nn/conv/unfold_fold.rs
@@ -1,0 +1,108 @@
+// ── Tracked unfold (im2col) op ──
+//
+// unfold1d(input, kernel, stride, padding, dilation):
+//   [N, C, L] → [N, C*kernel, L_out], extracting sliding windows.
+//
+// Backward:
+//   d_input = fold1d(grad_out, output_size = L, kernel, stride, padding, dilation)
+//   i.e. col2im — the exact transpose of im2col (each input position accumulates
+//   the gradient of every window it participated in).
+
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::Scalar;
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+struct Unfold1dNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    output_grad: Arc<GradBuffer<T, B>>,
+    inputs: Vec<Var<T, B>>,
+    /// Original input length `L`, used as `fold1d`'s `output_size` in backward.
+    output_size: usize,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Unfold1dNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "unfold1d"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        if let Some(Some(ref g)) = input_grads.first() {
+            // col2im: fold the windowed gradient back onto the input positions.
+            let d_input = coeus_ops::fold1d(
+                grad_out,
+                self.output_size,
+                self.kernel_size,
+                self.stride,
+                self.padding,
+                self.dilation,
+                &backend,
+            );
+            coeus_ops::add_assign(g.write(), &d_input, &backend);
+        }
+    }
+}
+
+/// Tracked 1D unfold (im2col): extracts sliding windows from `[N, C, L]` into
+/// `[N, C*kernel_size, L_out]`, differentiable through `input` (backward is the
+/// `fold1d` col2im transpose).
+#[must_use]
+#[inline]
+pub fn unfold1d<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Var<T, B> {
+    let backend = B::default();
+    let out_tensor = coeus_ops::unfold1d(
+        &input.tensor,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        &backend,
+    );
+
+    let requires_grad = crate::grad_mode::should_track_var(input);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on(
+            out_tensor.shape_cloned(),
+            &backend,
+        ))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let node = Unfold1dNode {
+            output_grad: grad.as_ref().unwrap().clone(),
+            inputs: vec![input.clone()],
+            output_size: input.tensor.shape()[2],
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -18,7 +18,9 @@ pub mod pool;
 pub mod softmax;
 
 pub use attention::{sdp_attention, AttentionMask, CausalMask, NullMask};
-pub use conv::{conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_transpose3d};
+pub use conv::{
+    conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_transpose3d, unfold1d,
+};
 pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{

--- a/coeus-nn/src/conv/unfold_fold.rs
+++ b/coeus-nn/src/conv/unfold_fold.rs
@@ -79,16 +79,14 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Unfold1d
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
-        let backend = B::default();
-        let out_tensor = coeus_ops::unfold1d(
-            &input.tensor,
+        // Differentiable im2col: backward is the fold1d col2im transpose.
+        coeus_autograd::unfold1d(
+            input,
             self.kernel_size,
             self.stride,
             self.padding,
             self.dilation,
-            &backend,
-        );
-        Var::new(out_tensor, false)
+        )
     }
 }
 

--- a/coeus-nn/tests/unfold_fold_parity.rs
+++ b/coeus-nn/tests/unfold_fold_parity.rs
@@ -153,3 +153,26 @@ fn fold2d_unfold2d_roundtrip_no_overlap() {
         assert!((*a - e).abs() < 1e-10, "roundtrip: got {a}, expected {e}");
     }
 }
+
+// ── Unfold1d differentiability (G-045) ───────────────────────────────────────
+
+#[test]
+fn unfold1d_backward_accumulates_window_overlap() {
+    // Unfold (im2col) is linear, so d sum(unfold(x)) / d x_i equals the number of
+    // windows containing position i. kernel=3, stride=1 on length 5 yields the
+    // overlap counts [1, 2, 3, 2, 1]; the col2im (fold1d) backward must produce
+    // exactly that (previously this layer was forward-only with dx=0).
+    let m = Unfold1d::<f64, SequentialBackend>::new(3, 1, 0, 1);
+    let data = [10.0_f64, 20.0, 30.0, 40.0, 50.0];
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(vec![1, 1, 5], &data),
+        true,
+    );
+    m.forward(&x).backward();
+    let grad = x.grad().expect("unfold1d input gradient");
+    assert_eq!(grad.as_slice(), &[1.0, 2.0, 3.0, 2.0, 1.0]);
+    assert!(
+        grad.as_slice().iter().any(|&g| g > 0.0),
+        "unfold1d gradient is all-zero — backward not propagating"
+    );
+}


### PR DESCRIPTION
## Summary
Adds `coeus_autograd::unfold1d` as a tracked im2col op: forward delegates to `coeus_ops::unfold1d`, **backward is the `fold1d` (col2im) transpose** — each input position accumulates the gradient of every sliding window it participated in. `nn::Unfold1d` now uses it instead of `Var::new(out, false)`, so the layer is **differentiable** (was forward-only with `dx=0` — the last G-045 class).

The op needs no Cpu-storage bound (`fold1d`/`add_assign` don't, matching `conv1d`), so wiring requires no nn bound change.

## Verification
- Unfold is linear, so `d·sum(unfold(x))/dx_i` = the window-overlap count; kernel=3/stride=1 on length 5 gives exactly `[1,2,3,2,1]` (analytic, verified). All 5 unfold1d tests pass.
- fmt + clippy clean.

`Unfold2d`/`Fold1d`/`Fold2d` remain forward-only (identical autograd-node pattern — follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes the `unfold1d` operation (im2col) differentiable by adding autograd support. Previously, the `Unfold1d` neural network layer was forward-only with zero gradients; now the backward pass correctly implements the transpose operation using `fold1d` (col2im), where each input position accumulates gradients from all sliding windows it participated in. The implementation adds a new tracked `unfold1d` function in `coeus-autograd` with a corresponding `Unfold1dNode` that computes gradients, updates the `nn::Unfold1d` layer to use the tracked version, and includes a test verifying that gradient accumulation matches the analytical window-overlap counts.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/conv/unfold_fold.rs` |
| 2 | `coeus-nn/src/conv/unfold_fold.rs` |
| 3 | `coeus-nn/tests/unfold_fold_parity.rs` |
| 4 | `coeus-autograd/src/ops/nn/conv/mod.rs` |
| 5 | `coeus-autograd/src/ops/nn/mod.rs` |
| 6 | `coeus-autograd/src/ops/mod.rs` |
| 7 | `coeus-autograd/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->