### PR TITLE
feat(autograd): Differentiable Unfold2d/Fold1d/Fold2d, fully close G-045

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -81,6 +81,8 @@ pub use ops::{
     exp,
     flip,
     floor,
+    fold1d,
+    fold2d,
     gather,
     gelu,
     gelu_tanh,
@@ -167,6 +169,7 @@ pub use ops::{
     triu,
     trunc,
     unfold1d,
+    unfold2d,
     unsqueeze,
     // Shape ops
     where_cond,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -33,10 +33,11 @@ pub use linalg::{matmul, sparse_matmul, sparse_matmul_coo, transpose_2d};
 pub use nn::{
     avg_pool1d, avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, bce_with_logits,
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
-    conv_transpose3d, cosine_embedding_loss, cross_entropy_loss, dropout, huber_loss,
-    kl_divergence, l1_loss, layernorm, log_softmax, margin_ranking_loss, max_pool1d, max_pool2d,
-    max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention,
-    soft_margin, softmax, unfold1d, AttentionMask, BatchNormArgs, CausalMask, NullMask,
+    conv_transpose3d, cosine_embedding_loss, cross_entropy_loss, dropout, fold1d, fold2d,
+    huber_loss, kl_divergence, l1_loss, layernorm, log_softmax, margin_ranking_loss, max_pool1d,
+    max_pool2d, max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm,
+    sdp_attention, soft_margin, softmax, unfold1d, unfold2d, AttentionMask, BatchNormArgs,
+    CausalMask, NullMask,
 };
 
 pub use embedding::{embedding, embedding_with_padding_idx};

--- a/coeus-autograd/src/ops/nn/conv/mod.rs
+++ b/coeus-autograd/src/ops/nn/conv/mod.rs
@@ -14,5 +14,5 @@ pub use transpose::{
     conv_transpose1d, conv_transpose2d, conv_transpose3d, ConvTranspose1dNode, ConvTranspose2dNode,
     ConvTranspose3dNode,
 };
-pub use unfold_fold::unfold1d;
+pub use unfold_fold::{fold1d, fold2d, unfold1d, unfold2d};
 pub use utils::ConvNode;

--- a/coeus-autograd/src/ops/nn/conv/unfold_fold.rs
+++ b/coeus-autograd/src/ops/nn/conv/unfold_fold.rs
@@ -106,3 +106,305 @@ pub fn unfold1d<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
         creator,
     }
 }
+
+// ── unfold2d (im2col), backward = fold2d (col2im) ──
+
+struct Unfold2dNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    output_grad: Arc<GradBuffer<T, B>>,
+    inputs: Vec<Var<T, B>>,
+    output_h: usize,
+    output_w: usize,
+    kernel_h: usize,
+    kernel_w: usize,
+    stride_h: usize,
+    stride_w: usize,
+    padding_h: usize,
+    padding_w: usize,
+    dilation_h: usize,
+    dilation_w: usize,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Unfold2dNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "unfold2d"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        if let Some(Some(ref g)) = input_grads.first() {
+            let d_input = coeus_ops::fold2d(
+                grad_out,
+                self.output_h,
+                self.output_w,
+                self.kernel_h,
+                self.kernel_w,
+                self.stride_h,
+                self.stride_w,
+                self.padding_h,
+                self.padding_w,
+                self.dilation_h,
+                self.dilation_w,
+                &backend,
+            );
+            coeus_ops::add_assign(g.write(), &d_input, &backend);
+        }
+    }
+}
+
+/// Tracked 2D unfold (im2col) over `[N, C, H, W]`, differentiable through
+/// `input` (backward is the `fold2d` col2im transpose).
+#[must_use]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn unfold2d<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    kernel_h: usize,
+    kernel_w: usize,
+    stride_h: usize,
+    stride_w: usize,
+    padding_h: usize,
+    padding_w: usize,
+    dilation_h: usize,
+    dilation_w: usize,
+) -> Var<T, B> {
+    let backend = B::default();
+    let out_tensor = coeus_ops::unfold2d(
+        &input.tensor,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        dilation_h,
+        dilation_w,
+        &backend,
+    );
+    let requires_grad = crate::grad_mode::should_track_var(input);
+    let grad = requires_grad.then(|| {
+        Arc::new(GradBuffer::new(Tensor::zeros_on(
+            out_tensor.shape_cloned(),
+            &backend,
+        )))
+    });
+    let creator = grad.as_ref().map(|grad| {
+        let shape = input.tensor.shape();
+        Arc::new(Unfold2dNode {
+            output_grad: grad.clone(),
+            inputs: vec![input.clone()],
+            output_h: shape[2],
+            output_w: shape[3],
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            dilation_h,
+            dilation_w,
+        }) as Arc<dyn BackwardNode<T, B>>
+    });
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}
+
+// ── fold1d (col2im), backward = unfold1d (im2col) ──
+
+struct Fold1dNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    output_grad: Arc<GradBuffer<T, B>>,
+    inputs: Vec<Var<T, B>>,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Fold1dNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "fold1d"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        if let Some(Some(ref g)) = input_grads.first() {
+            // Adjoint of col2im is im2col over the output-shaped gradient.
+            let d_input = coeus_ops::unfold1d(
+                grad_out,
+                self.kernel_size,
+                self.stride,
+                self.padding,
+                self.dilation,
+                &backend,
+            );
+            coeus_ops::add_assign(g.write(), &d_input, &backend);
+        }
+    }
+}
+
+/// Tracked 1D fold (col2im): accumulates `[N, C*kernel, L_out]` back into
+/// `[N, C, output_size]`, differentiable through `input` (backward is `unfold1d`).
+#[must_use]
+#[inline]
+pub fn fold1d<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    output_size: usize,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Var<T, B> {
+    let backend = B::default();
+    let out_tensor = coeus_ops::fold1d(
+        &input.tensor,
+        output_size,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        &backend,
+    );
+    let requires_grad = crate::grad_mode::should_track_var(input);
+    let grad = requires_grad.then(|| {
+        Arc::new(GradBuffer::new(Tensor::zeros_on(
+            out_tensor.shape_cloned(),
+            &backend,
+        )))
+    });
+    let creator = grad.as_ref().map(|grad| {
+        Arc::new(Fold1dNode {
+            output_grad: grad.clone(),
+            inputs: vec![input.clone()],
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        }) as Arc<dyn BackwardNode<T, B>>
+    });
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}
+
+// ── fold2d (col2im), backward = unfold2d (im2col) ──
+
+struct Fold2dNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    output_grad: Arc<GradBuffer<T, B>>,
+    inputs: Vec<Var<T, B>>,
+    kernel_h: usize,
+    kernel_w: usize,
+    stride_h: usize,
+    stride_w: usize,
+    padding_h: usize,
+    padding_w: usize,
+    dilation_h: usize,
+    dilation_w: usize,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Fold2dNode<T, B> {
+    fn op_name(&self) -> &'static str {
+        "fold2d"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        if let Some(Some(ref g)) = input_grads.first() {
+            let d_input = coeus_ops::unfold2d(
+                grad_out,
+                self.kernel_h,
+                self.kernel_w,
+                self.stride_h,
+                self.stride_w,
+                self.padding_h,
+                self.padding_w,
+                self.dilation_h,
+                self.dilation_w,
+                &backend,
+            );
+            coeus_ops::add_assign(g.write(), &d_input, &backend);
+        }
+    }
+}
+
+/// Tracked 2D fold (col2im) into `[N, C, output_h, output_w]`, differentiable
+/// through `input` (backward is the `unfold2d` im2col adjoint).
+#[must_use]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn fold2d<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    output_h: usize,
+    output_w: usize,
+    kernel_h: usize,
+    kernel_w: usize,
+    stride_h: usize,
+    stride_w: usize,
+    padding_h: usize,
+    padding_w: usize,
+    dilation_h: usize,
+    dilation_w: usize,
+) -> Var<T, B> {
+    let backend = B::default();
+    let out_tensor = coeus_ops::fold2d(
+        &input.tensor,
+        output_h,
+        output_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        dilation_h,
+        dilation_w,
+        &backend,
+    );
+    let requires_grad = crate::grad_mode::should_track_var(input);
+    let grad = requires_grad.then(|| {
+        Arc::new(GradBuffer::new(Tensor::zeros_on(
+            out_tensor.shape_cloned(),
+            &backend,
+        )))
+    });
+    let creator = grad.as_ref().map(|grad| {
+        Arc::new(Fold2dNode {
+            output_grad: grad.clone(),
+            inputs: vec![input.clone()],
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            dilation_h,
+            dilation_w,
+        }) as Arc<dyn BackwardNode<T, B>>
+    });
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -19,7 +19,8 @@ pub mod softmax;
 
 pub use attention::{sdp_attention, AttentionMask, CausalMask, NullMask};
 pub use conv::{
-    conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_transpose3d, unfold1d,
+    conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d, conv_transpose3d, fold1d, fold2d,
+    unfold1d, unfold2d,
 };
 pub use dropout::dropout;
 pub use log_softmax::log_softmax;

--- a/coeus-nn/src/conv/unfold_fold.rs
+++ b/coeus-nn/src/conv/unfold_fold.rs
@@ -145,17 +145,15 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Fold1d<T
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
-        let backend = B::default();
-        let out_tensor = coeus_ops::fold1d(
-            &input.tensor,
+        // Differentiable col2im: backward is the unfold1d im2col adjoint.
+        coeus_autograd::fold1d(
+            input,
             self.output_size,
             self.kernel_size,
             self.stride,
             self.padding,
             self.dilation,
-            &backend,
-        );
-        Var::new(out_tensor, false)
+        )
     }
 }
 
@@ -245,9 +243,9 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Unfold2d
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
-        let backend = B::default();
-        let out_tensor = coeus_ops::unfold2d(
-            &input.tensor,
+        // Differentiable im2col: backward is the fold2d col2im transpose.
+        coeus_autograd::unfold2d(
+            input,
             self.kernel_h,
             self.kernel_w,
             self.stride_h,
@@ -256,9 +254,7 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Unfold2d
             self.padding_w,
             self.dilation_h,
             self.dilation_w,
-            &backend,
-        );
-        Var::new(out_tensor, false)
+        )
     }
 }
 
@@ -329,9 +325,9 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Fold2d<T
     }
 
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
-        let backend = B::default();
-        let out_tensor = coeus_ops::fold2d(
-            &input.tensor,
+        // Differentiable col2im: backward is the unfold2d im2col adjoint.
+        coeus_autograd::fold2d(
+            input,
             self.output_h,
             self.output_w,
             self.kernel_h,
@@ -342,8 +338,6 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Fold2d<T
             self.padding_w,
             self.dilation_h,
             self.dilation_w,
-            &backend,
-        );
-        Var::new(out_tensor, false)
+        )
     }
 }

--- a/coeus-nn/tests/unfold_fold_parity.rs
+++ b/coeus-nn/tests/unfold_fold_parity.rs
@@ -176,3 +176,58 @@ fn unfold1d_backward_accumulates_window_overlap() {
         "unfold1d gradient is all-zero — backward not propagating"
     );
 }
+
+#[test]
+fn unfold2d_backward_accumulates_window_overlap() {
+    // 2x2 kernel, stride 1 on [1,1,3,3]: the 2D window-overlap counts are the
+    // outer product of the per-axis [1,2,1] counts → [[1,2,1],[2,4,2],[1,2,1]].
+    let m = Unfold2d::<f64, SequentialBackend>::new(2, 1, 0, 1);
+    let data: Vec<f64> = (1..=9).map(|i| i as f64).collect();
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(vec![1, 1, 3, 3], &data),
+        true,
+    );
+    m.forward(&x).backward();
+    let grad = x.grad().expect("unfold2d input gradient");
+    assert_eq!(
+        grad.as_slice(),
+        &[1.0, 2.0, 1.0, 2.0, 4.0, 2.0, 1.0, 2.0, 1.0]
+    );
+}
+
+#[test]
+fn fold1d_backward_is_im2col_of_ones() {
+    // Fold (col2im) is linear; with non-overlapping tiles (stride=kernel, no pad)
+    // each input column maps to exactly one output position, so
+    // d sum(fold(x))/dx = 1 everywhere (= unfold1d of the all-ones output grad).
+    let m = Fold1d::<f64, SequentialBackend>::new(6, 2, 2, 0, 1);
+    let data: Vec<f64> = (1..=6).map(|i| i as f64).collect();
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(vec![1, 2, 3], &data),
+        true,
+    );
+    let y = m.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 1, 6]);
+    y.backward();
+    assert_eq!(
+        x.grad().expect("fold1d input gradient").as_slice(),
+        &[1.0; 6]
+    );
+}
+
+#[test]
+fn fold2d_backward_is_im2col_of_ones() {
+    let m = Fold2d::<f64, SequentialBackend>::new(4, 4, 2, 2, 0, 1);
+    let data: Vec<f64> = (1..=16).map(|i| i as f64).collect();
+    let x = Var::new(
+        Tensor::<f64, SequentialBackend>::from_slice(vec![1, 4, 4], &data),
+        true,
+    );
+    let y = m.forward(&x);
+    assert_eq!(y.tensor.shape(), &[1, 1, 4, 4]);
+    y.backward();
+    assert_eq!(
+        x.grad().expect("fold2d input gradient").as_slice(),
+        &[1.0; 16]
+    );
+}


### PR DESCRIPTION
## Summary
Completes the Unfold/Fold family as tracked autograd ops, each forward delegating to its `coeus_ops` op and **backward to the transpose op**:
- `unfold2d` backward = `fold2d` (col2im);
- `fold1d` backward = `unfold1d` (im2col adjoint);
- `fold2d` backward = `unfold2d`.

All four nn modules now use the differentiable ops instead of `Var::new(out, false)`, so the family is **trainable** (was forward-only, `dx=0` — the last G-045 class). No new tensor op needed: unfold/fold already exist as a transpose pair in `coeus_ops`.

## Verification
- Analytic backward tests: unfold2d gradient = 2D window-overlap counts `[[1,2,1],[2,4,2],[1,2,1]]`; fold1d/fold2d gradient = all-ones. **4/4 pass.**
- fmt + clippy clean.

Closes the forward-only differentiability sweep (G-044 LRN, G-045 AdaptiveAvg/MaxPool + Unfold/Fold all now differentiable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds differentiable backward passes for the `unfold2d`, `fold1d`, and `fold2d` operations, completing the unfold/fold family of operations. Each operation's backward pass is implemented as the transpose operation (unfold2d ↔ fold2d, fold1d ↔ unfold1d), enabling gradient flow through these image-to-column transformations. The neural network modules are updated to use the new differentiable autograd operations instead of creating non-trainable variables with `Var::new(out, false)`, and three new tests verify the gradient behavior matches the expected window-overlap patterns.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/lib.rs` |
| 2 | `coeus-autograd/src/ops/mod.rs` |
| 3 | `coeus-autograd/src/ops/nn/mod.rs` |
| 4 | `coeus-autograd/src/ops/nn/conv/mod.rs` |
| 5 | `coeus-autograd/src/ops/nn/conv/unfold_fold.rs` |
| 6 | `coeus-nn/src/conv/unfold_fold.rs` |
| 7 | `coeus-nn/tests/unfold_fold_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 2D unfold and fold operations, plus a 1D fold operation, with gradient tracking.
  * Expanded convolution-related APIs so these operations are now available through the public interface.
  * Updated neural network layers to use the differentiable versions automatically.

* **Tests**
  * Added coverage for 2D unfold and fold backward behavior, including gradient overlap checks and expected output shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->