### PR TITLE
feat(python): Bind Fold1d + Unfold/Fold dx parity vs PyTorch

### DIFF
--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -160,6 +160,7 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<nn::PyUnfold2d>()?;
     m.add_class::<nn::PyFold2d>()?;
     m.add_class::<nn::PyUnfold1d>()?;
+    m.add_class::<nn::PyFold1d>()?;
     m.add_class::<PyLocalCommunicator>()?;
     m.add_class::<PyTcpMesh>()?;
     m.add_class::<PyTcpCommunicator>()?;

--- a/coeus-python/src/nn/mod.rs
+++ b/coeus-python/src/nn/mod.rs
@@ -56,4 +56,4 @@ pub use pool::{
 pub use regularization::PyLocalResponseNorm;
 pub use rnn::{PyBidirectional, PyGRUCell, PyLSTMCell, PyRNNCell};
 pub use sequential::PySequential;
-pub use unfold_fold::{PyFold2d, PyUnfold1d, PyUnfold2d};
+pub use unfold_fold::{PyFold1d, PyFold2d, PyUnfold1d, PyUnfold2d};

--- a/coeus-python/src/nn/unfold_fold.rs
+++ b/coeus-python/src/nn/unfold_fold.rs
@@ -233,3 +233,74 @@ impl PyUnfold1d {
     /// Zero gradients (no-op — Unfold1d has no parameters).
     pub fn zero_grad(&self) {}
 }
+
+/// Python-exposed Fold1d (col2im) layer — the 1D inverse of Unfold1d.
+///
+/// Accumulates `[N, C*kernel_size, L_out]` back into `[N, C, output_size]`,
+/// summing overlapping contributions. Differentiable (backward is unfold1d).
+#[pyclass(name = "Fold1d")]
+pub struct PyFold1d {
+    /// Target output length.
+    #[pyo3(get)]
+    pub output_size: usize,
+    /// Sliding window length.
+    #[pyo3(get)]
+    pub kernel_size: usize,
+    /// Window stride.
+    #[pyo3(get)]
+    pub stride: usize,
+    /// Zero-padding on each side.
+    #[pyo3(get)]
+    pub padding: usize,
+    /// Dilation factor.
+    #[pyo3(get)]
+    pub dilation: usize,
+}
+
+#[pymethods]
+impl PyFold1d {
+    #[new]
+    #[pyo3(signature = (output_size, kernel_size, stride = 1, padding = 0, dilation = 1))]
+    /// Create a `Fold1d` layer.
+    pub fn new(
+        output_size: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+    ) -> Self {
+        Self {
+            output_size,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        }
+    }
+
+    /// Forward pass: `[N, C*kernel_size, L_out]` → `[N, C, output_size]`.
+    pub fn forward(&self, input: &PyTensor, py: Python<'_>) -> PyResult<PyTensor> {
+        use coeus_nn::Module;
+        let input_var = input.inner.clone();
+        let (os, k, s, p, d) = (
+            self.output_size,
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.dilation,
+        );
+        let m = coeus_nn::Fold1d::<f64, coeus_core::MoiraiBackend>::new(os, k, s, p, d);
+        let inner = py.allow_threads(move || m.forward(&input_var));
+        Ok(PyTensor::from_var(inner))
+    }
+
+    /// Return an empty state dict (no learnable parameters).
+    pub fn state_dict(&self) -> crate::tensor::PyStateDict {
+        crate::tensor::PyStateDict {
+            inner: coeus_tensor::checkpoint::StateDict::new(),
+        }
+    }
+
+    /// Zero gradients (no-op — Fold1d has no parameters).
+    pub fn zero_grad(&self) {}
+}

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -2642,6 +2642,83 @@ def test_unfold2d_matches_pytorch() -> None:
     )
 
 
+def test_unfold2d_backward_matches_pytorch() -> None:
+    """Forward + gradient parity vs torch.nn.Unfold (Unfold2d is now
+    differentiable: backward is the fold2d col2im transpose)."""
+    n, c, h, w = 1, 2, 5, 5
+    kernel, stride, padding = 3, 1, 0
+    h_out = (h + 2 * padding - kernel) // stride + 1
+    w_out = (w + 2 * padding - kernel) // stride + 1
+    out_ch, length = c * kernel * kernel, h_out * w_out
+    data = [math.sin(i * 0.1) for i in range(n * c * h * w)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w], requires_grad=True)
+    y_pyc = pycoeus.Unfold2d(kernel, stride, padding, 1).forward(x_pyc)
+    tgt_pyc = pycoeus.Tensor([0.1] * (n * out_ch * length), [n, out_ch, length])
+    pycoeus.mse_loss(y_pyc, tgt_pyc).backward()
+
+    x_t = (
+        torch.tensor(data, dtype=torch.float64)
+        .reshape(n, c, h, w)
+        .requires_grad_(True)
+    )
+    y_t = torch.nn.Unfold(kernel_size=kernel, stride=stride, padding=padding)(x_t)
+    tgt_t = torch.full((n, out_ch, length), 0.1, dtype=torch.float64)
+    torch.nn.functional.mse_loss(y_t, tgt_t).backward()
+
+    _allclose("unfold2d_forward", list(y_pyc.data), y_t.detach().flatten().tolist())
+    _allclose("unfold2d_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())
+
+
+def test_fold2d_backward_matches_pytorch() -> None:
+    """Forward + gradient parity vs torch.nn.Fold (Fold2d is differentiable:
+    backward is the unfold2d im2col adjoint)."""
+    n, c = 1, 2
+    oh, ow = 5, 5
+    kernel, stride, padding = 3, 1, 0
+    h_out = (oh + 2 * padding - kernel) // stride + 1
+    length = h_out * h_out
+    in_ch = c * kernel * kernel
+    data = [math.sin(i * 0.1) for i in range(n * in_ch * length)]
+
+    x_pyc = pycoeus.Tensor(data, [n, in_ch, length], requires_grad=True)
+    y_pyc = pycoeus.Fold2d(oh, ow, kernel, stride, padding, 1).forward(x_pyc)
+    tgt_pyc = pycoeus.Tensor([0.1] * (n * c * oh * ow), [n, c, oh, ow])
+    pycoeus.mse_loss(y_pyc, tgt_pyc).backward()
+
+    x_t = (
+        torch.tensor(data, dtype=torch.float64)
+        .reshape(n, in_ch, length)
+        .requires_grad_(True)
+    )
+    y_t = torch.nn.Fold(
+        output_size=(oh, ow), kernel_size=kernel, stride=stride, padding=padding
+    )(x_t)
+    tgt_t = torch.full((n, c, oh, ow), 0.1, dtype=torch.float64)
+    torch.nn.functional.mse_loss(y_t, tgt_t).backward()
+
+    _allclose("fold2d_forward", list(y_pyc.data), y_t.detach().flatten().tolist())
+    _allclose("fold2d_dx", list(x_pyc.grad), x_t.grad.flatten().tolist())
+
+
+def test_fold1d_forward_and_backward() -> None:
+    """Fold1d binding smoke test: torch has no 1D Fold, so this verifies the
+    newly-bound layer reconstructs the non-overlapping tiling and propagates a
+    gradient, matching the Rust analytic test."""
+    # output_size=6, kernel=2, stride=2 (non-overlapping); input [1, C*k=2, blocks=3].
+    m = pycoeus.Fold1d(6, 2, 2, 0, 1)
+    data = [float(i + 1) for i in range(6)]
+    x = pycoeus.Tensor(data, [1, 2, 3], requires_grad=True)
+    y = m.forward(x)
+    # Non-overlapping fold reorders the 6 input values into [1, 1, 6].
+    assert sorted(list(y.data)) == sorted(data)
+    pycoeus.mse_loss(y, pycoeus.Tensor([0.0] * 6, [1, 1, 6])).backward()
+    grad = list(x.grad)
+    assert len(grad) == 6
+    assert all(math.isfinite(g) for g in grad)
+    assert any(abs(g) > 1e-12 for g in grad), "Fold1d gradient is all-zero"
+
+
 # ---------------------------------------------------------------------------
 # Unfold1d parity (MS-214)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`PyFold1d` was the one **unbound** member of the Unfold/Fold family (PyUnfold1d/2d, PyFold2d existed). Binds it (modeled on PyUnfold1d + output_size), registered in nn + lib.

Now that the family is differentiable ([#115](https://github.com/ryancinsight/Coeus/pull/115)–[#116](https://github.com/ryancinsight/Coeus/pull/116)), adds gradient parity:
- **unfold2d**: forward + `dx` vs `torch.nn.Unfold`;
- **fold2d**: forward + `dx` vs `torch.nn.Fold`;
- **fold1d**: binding smoke test (torch has no 1D Fold) — verifies the layer reconstructs the non-overlapping tiling and propagates a finite non-zero gradient, complementing the Rust analytic test.

## Verification
- `pytest` — **3 passed** (maturin rebuild). fmt + clippy clean.

The Unfold/Fold family is now fully bound and cross-framework gradient-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes the Python bindings for the Unfold/Fold family by adding the previously missing `PyFold1d` layer, and establishes gradient parity with PyTorch for `Unfold2d` and `Fold2d`. The implementation adds a new `Fold1d` class that performs the inverse operation of `Unfold1d` (col2im in 1D), accumulating sliding windows back into a sequence with overlapping contributions summed. Three new tests verify gradient correctness: `unfold2d` and `fold2d` are validated against `torch.nn.Unfold` and `torch.nn.Fold` respectively for both forward and backward passes, while `fold1d` gets a binding smoke test (since PyTorch lacks a 1D fold operation) that confirms proper reconstruction and finite gradient propagation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/nn/unfold_fold.rs` |
| 2 | `coeus-python/src/nn/mod.rs` |
| 3 | `coeus-python/src/lib.rs` |
| 4 | `coeus-python/tests/test_pytorch_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->