### PR TITLE
feat(nn): Complete SmoothL1Loss + cosine_similarity (fix re-export chain + tests)

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -64,6 +64,7 @@ pub use ops::{
     // Trigonometric
     cos,
     cosine_embedding_loss,
+    cosine_similarity,
     cross_entropy_loss,
     cumprod,
     cumsum,
@@ -149,6 +150,7 @@ pub use ops::{
     // Trigonometric
     sin,
     slice,
+    smooth_l1_loss,
     soft_margin,
     softmax,
     softplus,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -35,11 +35,11 @@ pub use linalg::{matmul, sparse_matmul, sparse_matmul_coo, transpose_2d};
 pub use nn::{
     avg_pool1d, avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, bce_with_logits,
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
-    conv_transpose3d, cosine_embedding_loss, cross_entropy_loss, dropout, fold1d, fold2d,
-    huber_loss, kl_divergence, l1_loss, layernorm, log_softmax, margin_ranking_loss, max_pool1d,
-    max_pool2d, max_pool3d, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm,
-    sdp_attention, soft_margin, softmax, unfold1d, unfold2d, AttentionMask, BatchNormArgs,
-    CausalMask, NullMask,
+    conv_transpose3d, cosine_embedding_loss, cosine_similarity, cross_entropy_loss, dropout,
+    fold1d, fold2d, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
+    margin_ranking_loss, max_pool1d, max_pool2d, max_pool3d, multi_margin, nll_loss,
+    pairwise_distance, poisson_nll, rmsnorm, sdp_attention, smooth_l1_loss, soft_margin, softmax,
+    unfold1d, unfold2d, AttentionMask, BatchNormArgs, CausalMask, NullMask,
 };
 
 pub use embedding::{embedding, embedding_with_padding_idx};

--- a/coeus-autograd/src/ops/nn/loss/cosine_similarity.rs
+++ b/coeus-autograd/src/ops/nn/loss/cosine_similarity.rs
@@ -1,0 +1,240 @@
+//! Row-wise cosine similarity (PyTorch `F.cosine_similarity`).
+//!
+//! For inputs `x1, x2` of shape `[N, D]`, returns a `[N]` vector with
+//!   `out_i = <x1_i, x2_i> / (||x1_i||_2 * ||x2_i||_2 + eps)`
+//! where `eps` is added inside the (positive) denominator to match PyTorch's
+//! numerically stable convention used in
+//! `torch.nn.functional.cosine_similarity`.
+//!
+//! Per-row partials (analytical subgradient):
+//!   d cos_i / d x1_i  = (x2_i / (||x1_i|| * ||x2_i|| + eps))
+//!                      - cos_i * x1_i / ||x1_i||^2
+//!   d cos_i / d x2_i  = (x1_i / (||x1_i|| * ||x2_i|| + eps))
+//!                      - cos_i * x2_i / ||x2_i||^2
+//!
+//! The node caches the row-wise `(dot, n1_sqr, n2_sqr, cos)` tuples plus a
+//! per-element derivative factor so the backward pass is a single
+//! rebroadcast — no extra inner-product recomputed at backward time.
+
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for row-wise cosine similarity.
+pub struct CosineSimilarityNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the output (shape `[N]`).
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Per-element factor `d(loss_k)/d(x1_ik)`, row-major `[N*D]`.
+    pub grad_x1: Vec<T>,
+    /// Per-element factor `d(loss_k)/d(x2_ik)`, row-major `[N*D]`.
+    pub grad_x2: Vec<T>,
+    /// Number of rows `N`.
+    pub rows: usize,
+    /// Feature dimension `D`.
+    pub feat: usize,
+    /// Input shape `[N, D]` for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for CosineSimilarityNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "cosine_similarity"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let temp_grad;
+        let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            temp_grad = grad_out.to_contiguous_on(&backend);
+            &temp_grad
+        };
+        let mut g_rows = vec![T::zero(); self.rows];
+        backend.copy_to_host(grad_cont.storage(), &mut g_rows);
+
+        let want_x1 = matches!(input_grads.first(), Some(Some(_)));
+        let want_x2 = matches!(input_grads.get(1), Some(Some(_)));
+        if !want_x1 && !want_x2 {
+            return;
+        }
+
+        // d/d_x1: grad_unit_x1[n,k] (already computed at forward time).
+        // outer * grad_unit_x1 — applied per-row, broadcasting the row loss
+        // scalar across the feature axis.
+        let mut dx1 = vec![T::zero(); self.rows * self.feat];
+        for i in 0..self.rows {
+            let gi = g_rows[i];
+            let base = i * self.feat;
+            for k in 0..self.feat {
+                dx1[base + k] = gi * self.grad_x1[base + k];
+            }
+        }
+
+        if let Some(Some(ref g)) = input_grads.first() {
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx1, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut dx2 = vec![T::zero(); self.rows * self.feat];
+            for i in 0..self.rows {
+                let gi = g_rows[i];
+                let base = i * self.feat;
+                for k in 0..self.feat {
+                    dx2[base + k] = gi * self.grad_x2[base + k];
+                }
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx2, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked row-wise cosine similarity (PyTorch `F.cosine_similarity`):
+/// for inputs `x1, x2` of shape `[N, D]`, returns a `[N]` vector with
+/// `out_i = <x1_i, x2_i> / (||x1_i||_2 * ||x2_i||_2 + eps)`.
+///
+/// # Panics
+/// Panics when `x1` and `x2` do not share shape, when the inputs are not
+/// 2-D `[N, D]`, or when `D == 0`.
+///
+/// # Numerical contract
+/// - Subgradient at the `eps`-denominator convention is the standard rule
+///   `d/dx1_i (x2_i / denom)`; the cached factor matches PyTorch's autograd
+///   formula at f64 precision up to the `eps` cst-order term.
+/// - When `||x1_i||` or `||x2_i||` is zero, the input gradient remains
+///   bounded via the `eps` shift.
+pub fn cosine_similarity<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x1: &Var<T, B>,
+    x2: &Var<T, B>,
+    dim: usize,
+    eps: T,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        x1.tensor.shape(),
+        x2.tensor.shape(),
+        "cosine_similarity requires x1 and x2 to have identical shapes"
+    );
+    let shape_ref = x1.tensor.shape();
+    assert_eq!(
+        shape_ref.len(),
+        2,
+        "cosine_similarity expects 2D [N, D] inputs"
+    );
+    let rows = shape_ref[0];
+    let feat = shape_ref[1];
+    assert_eq!(
+        dim, 1,
+        "cosine_similarity currently supports dim=1 (row contraction); got dim={dim}"
+    );
+    assert!(feat > 0, "cosine_similarity requires D > 0; got D=0");
+    let n = rows * feat;
+    let shape = x1.tensor.shape_cloned();
+
+    let x1_cont;
+    let x1_raw = if x1.tensor.is_contiguous() && x1.tensor.layout().offset() == 0 {
+        &x1.tensor
+    } else {
+        x1_cont = x1.tensor.to_contiguous_on(&backend);
+        &x1_cont
+    };
+    let x2_cont;
+    let x2_raw = if x2.tensor.is_contiguous() && x2.tensor.layout().offset() == 0 {
+        &x2.tensor
+    } else {
+        x2_cont = x2.tensor.to_contiguous_on(&backend);
+        &x2_cont
+    };
+
+    let x1_host: std::borrow::Cow<[T]> = if let Some(s) = x1_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(x1_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let x2_host: std::borrow::Cow<[T]> = if let Some(s) = x2_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(x2_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let one = T::one();
+    let mut out = vec![T::zero(); rows];
+    let mut grad_x1 = vec![T::zero(); n];
+    let mut grad_x2 = vec![T::zero(); n];
+    for i in 0..rows {
+        let base = i * feat;
+        let mut dot = T::zero();
+        let mut n1_sqr = T::zero();
+        let mut n2_sqr = T::zero();
+        for k in 0..feat {
+            dot = dot + x1_host[base + k] * x2_host[base + k];
+            n1_sqr = n1_sqr + x1_host[base + k] * x1_host[base + k];
+            n2_sqr = n2_sqr + x2_host[base + k] * x2_host[base + k];
+        }
+        let n1 = n1_sqr.sqrt();
+        let n2 = n2_sqr.sqrt();
+        let denom = n1 * n2 + eps;
+        let cos_i = dot / denom;
+        out[i] = cos_i;
+
+        // d cos_i / d x1_ik  =  x2_ik / denom  -  cos_i * x1_ik / n1_sqr
+        // d cos_i / d x2_ik  =  x1_ik / denom  -  cos_i * x2_ik / n2_sqr
+        // Subgradient factor for x1_ik == 0 in a vanishing-norm row is
+        // well-defined (x1_ik = 0 collapses the second term to 0).
+        for k in 0..feat {
+            grad_x1[base + k] = x2_host[base + k] / denom - cos_i * x1_host[base + k] / n1_sqr;
+            grad_x2[base + k] = x1_host[base + k] / denom - cos_i * x2_host[base + k] / n2_sqr;
+        }
+        // Reference unused `one` to silence unused warnings on builds that
+        // skip the Int-bounded code path (`Float` always provides `one()`).
+        let _ = one;
+    }
+
+    let out_tensor = Tensor::from_slice_on([rows], &out, &backend);
+    let requires_grad =
+        crate::grad_mode::should_track_var(x1) || crate::grad_mode::should_track_var(x2);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on(
+            [rows],
+            &backend,
+        ))))
+    } else {
+        None
+    };
+    let creator = grad.as_ref().cloned().map(|output_grad| {
+        Arc::new(CosineSimilarityNode {
+            output_grad,
+            inputs: vec![x1.clone(), x2.clone()],
+            grad_x1,
+            grad_x2,
+            rows,
+            feat,
+            shape,
+        }) as Arc<dyn BackwardNode<T, B>>
+    });
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/loss/mod.rs
+++ b/coeus-autograd/src/ops/nn/loss/mod.rs
@@ -4,6 +4,8 @@ pub mod bce;
 pub mod bce_with_logits;
 /// Cosine embedding loss.
 pub mod cosine;
+/// Row-wise cosine similarity (PyTorch `F.cosine_similarity`).
+pub mod cosine_similarity;
 /// Cross-entropy loss.
 pub mod cross_entropy;
 /// Huber loss.
@@ -22,12 +24,15 @@ pub mod nll;
 pub mod pairwise_distance;
 /// Poisson negative-log-likelihood loss.
 pub mod poisson_nll;
+/// Smooth L1 (Huber-β) loss.
+pub mod smooth_l1;
 /// Soft-margin (logistic) loss.
 pub mod soft_margin;
 
 pub use bce::{binary_cross_entropy, BinaryCrossEntropyNode};
 pub use bce_with_logits::{bce_with_logits, BceWithLogitsNode};
 pub use cosine::{cosine_embedding_loss, CosineEmbeddingLossNode};
+pub use cosine_similarity::{cosine_similarity, CosineSimilarityNode};
 pub use cross_entropy::{cross_entropy_loss, CrossEntropyLossNode};
 pub use huber::{huber_loss, HuberLossNode};
 pub use kl_div::{kl_divergence, KlDivLossNode};
@@ -37,4 +42,5 @@ pub use multi_margin::{multi_margin, MultiMarginNode};
 pub use nll::{nll_loss, NllLossNode};
 pub use pairwise_distance::{pairwise_distance, PairwiseDistanceNode};
 pub use poisson_nll::{poisson_nll, PoissonNllNode};
+pub use smooth_l1::{smooth_l1_loss, SmoothL1LossNode};
 pub use soft_margin::{soft_margin, SoftMarginNode};

--- a/coeus-autograd/src/ops/nn/loss/smooth_l1.rs
+++ b/coeus-autograd/src/ops/nn/loss/smooth_l1.rs
@@ -1,0 +1,215 @@
+//! Smooth L1 (Huber-β) loss autograd node.
+//!
+//! PyTorch contract (`SmoothL1Loss(reduction="mean", beta=1.0)`):
+//!   loss(n) = 0.5 * (z_n)^2 / beta           if |z_n| < beta
+//!           = |z_n| - 0.5 * beta              otherwise
+//!
+//! where `z = pred - target`. The gradient is the standard subgradient
+//! matching PyTorch's `F.smooth_l1_loss`:
+//!   d/dz = z / beta                          if |z| < beta
+//!        = sign(z)                           otherwise
+//!
+//! At the kink (`|z| == beta`) Coeus takes the **right limit** to match
+//! PyTorch's numerically stable reduction (the L1 piece, gradient `sign(z)`).
+//! This avoids an implementation-defined subgradient at the boundary and
+//! is empirically verified via parity tests against `torch.nn.functional.smooth_l1_loss`.
+
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::{Float, Scalar, Storage};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for Smooth L1 loss (mean reduction).
+pub struct SmoothL1LossNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for the scalar output.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Input variables tracked for backward propagation.
+    pub inputs: Vec<Var<T, B>>,
+    /// Element-wise `z = pred - target`, stored for the gradient routing.
+    pub diffs: Vec<T>,
+    /// Threshold β (encoded as `T::from_f64(self.beta_f64)` at construction).
+    pub beta: T,
+    /// Per-element gradient factor `d/d_pred = g_out / n * (z/β if |z|<β else sign(z))`.
+    pub grad_pred: Vec<T>,
+    /// Number of elements in the mean reduction.
+    pub n: usize,
+    /// Original tensor shape for gradient reconstruction.
+    pub shape: coeus_core::Shape,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+    for SmoothL1LossNode<T, B>
+{
+    fn op_name(&self) -> &'static str {
+        "smooth_l1_loss"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+        let grad_cont;
+        let grad_src = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
+            grad_out
+        } else {
+            grad_cont = grad_out.to_contiguous_on(&backend);
+            &grad_cont
+        };
+        let mut host_grad = [T::zero()];
+        backend.copy_to_host(grad_src.storage(), &mut host_grad);
+        let g_out = host_grad[0];
+        let n_t = T::from_f64(self.n as f64);
+        let scale = g_out / n_t;
+
+        // d/d_pred: scale * (z / beta) if |z| < beta, else scale * sign(z).
+        let neg_one = T::zero() - T::one();
+        let inv_beta = T::one() / self.beta;
+        let mut d_pred = vec![T::zero(); self.n];
+        for (i, grad) in d_pred.iter_mut().enumerate() {
+            let z = self.diffs[i];
+            let abs_z = if z < T::zero() { T::zero() - z } else { z };
+            *grad = if abs_z < self.beta {
+                z * inv_beta * scale
+            } else if z > T::zero() {
+                scale
+            } else if z < T::zero() {
+                neg_one * scale
+            } else {
+                // |z| == beta: take the right limit (L1 piece).
+                // sign(0) -> 0 to match PyTorch's reduce-at-zero behavior.
+                T::zero()
+            };
+        }
+
+        if let Some(Some(ref g)) = input_grads.first() {
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_pred, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let mut d_target = d_pred;
+            for grad in &mut d_target {
+                *grad = T::zero() - *grad;
+            }
+            let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        }
+    }
+}
+
+/// Tracked Smooth L1 loss: `mean_i loss_smooth(pred[i] - target[i], beta)`.
+/// `pred` and `target` must share shape. Mirrors PyTorch
+/// `SmoothL1Loss(reduction="mean", beta=float)`.
+pub fn smooth_l1_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    pred: &Var<T, B>,
+    target: &Var<T, B>,
+    beta: T,
+) -> Var<T, B> {
+    let backend = B::default();
+    assert_eq!(
+        pred.tensor.shape(),
+        target.tensor.shape(),
+        "smooth_l1_loss requires pred and target to have identical shapes"
+    );
+    assert!(
+        beta > T::zero(),
+        "smooth_l1_loss requires beta > 0; got beta = 0 (would divide by zero)"
+    );
+    let n = pred.tensor.numel();
+    assert!(n > 0, "smooth_l1_loss requires at least one element");
+    let shape = pred.tensor.shape_cloned();
+
+    let p_cont;
+    let p_raw = if pred.tensor.is_contiguous() && pred.tensor.layout().offset() == 0 {
+        &pred.tensor
+    } else {
+        p_cont = pred.tensor.to_contiguous_on(&backend);
+        &p_cont
+    };
+    let t_cont;
+    let t_raw = if target.tensor.is_contiguous() && target.tensor.layout().offset() == 0 {
+        &target.tensor
+    } else {
+        t_cont = target.tensor.to_contiguous_on(&backend);
+        &t_cont
+    };
+
+    let p_host: std::borrow::Cow<[T]> = if let Some(s) = p_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(p_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+    let t_host: std::borrow::Cow<[T]> = if let Some(s) = t_raw.storage().try_as_slice() {
+        std::borrow::Cow::Borrowed(&s[..n])
+    } else {
+        let mut v = vec![T::zero(); n];
+        backend.copy_to_host(t_raw.storage(), &mut v);
+        std::borrow::Cow::Owned(v)
+    };
+
+    let inv_beta = T::one() / beta;
+    let half = T::from_f64(0.5);
+    let mut diffs = vec![T::zero(); n];
+    let mut grad_pred = vec![T::zero(); n];
+    let mut loss_val = T::zero();
+    for i in 0..n {
+        let z = p_host[i] - t_host[i];
+        diffs[i] = z;
+        let abs_z = if z < T::zero() { T::zero() - z } else { z };
+        let elem = if abs_z < beta {
+            half * z * z * inv_beta
+        } else {
+            abs_z - half * beta
+        };
+        loss_val = loss_val + elem;
+        // Pre-stage the per-element d/d_pred factor (sans the outer
+        // (g_out / n) scale; the node applies the scale at backward time).
+        let unit_grad = if abs_z < beta {
+            z * inv_beta
+        } else if z > T::zero() {
+            T::one()
+        } else if z < T::zero() {
+            T::zero() - T::one()
+        } else {
+            // At |z| == beta: take the right limit (L1 piece); sign(0) = 0.
+            T::zero()
+        };
+        grad_pred[i] = unit_grad;
+    }
+    loss_val = loss_val / T::from_f64(n as f64);
+
+    let out_tensor = Tensor::from_slice_on([1], &[loss_val], &backend);
+    let requires_grad =
+        crate::grad_mode::should_track_var(pred) || crate::grad_mode::should_track_var(target);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on([1], &backend))))
+    } else {
+        None
+    };
+    let creator = grad.as_ref().cloned().map(|output_grad| {
+        let node = SmoothL1LossNode {
+            output_grad,
+            inputs: vec![pred.clone(), target.clone()],
+            diffs,
+            beta,
+            grad_pred,
+            n,
+            shape,
+        };
+        Arc::new(node) as Arc<dyn BackwardNode<T, B>>
+    });
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -25,9 +25,9 @@ pub use conv::{
 pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
-    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, multi_margin, nll_loss, pairwise_distance,
-    poisson_nll, soft_margin,
+    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cosine_similarity,
+    cross_entropy_loss, huber_loss, kl_divergence, l1_loss, margin_ranking_loss, multi_margin,
+    nll_loss, pairwise_distance, poisson_nll, smooth_l1_loss, soft_margin,
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool1d, avg_pool2d, avg_pool3d, max_pool1d, max_pool2d, max_pool3d};

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -92,9 +92,10 @@ pub use init::{kaiming_uniform, xavier_uniform};
 pub use interpolate::{interpolate_1d, interpolate_2d, InterpolateMode};
 pub use linear::Linear;
 pub use loss::{
-    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cross_entropy_loss, huber_loss,
-    kl_divergence, l1_loss, margin_ranking_loss, mse_loss, multi_margin, nll_loss,
-    pairwise_distance, poisson_nll, soft_margin, triplet_margin_loss,
+    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cosine_similarity,
+    cross_entropy_loss, huber_loss, kl_divergence, l1_loss, margin_ranking_loss, mse_loss,
+    multi_margin, nll_loss, pairwise_distance, poisson_nll, smooth_l1_loss, soft_margin,
+    triplet_margin_loss,
 };
 pub use module::Module;
 pub use normalization::{

--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -257,3 +257,31 @@ pub fn cosine_embedding_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
 ) -> Var<T, B> {
     coeus_autograd::cosine_embedding_loss(x1, x2, y, margin)
 }
+
+/// Smooth L1 (Huber-β) loss (PyTorch
+/// `SmoothL1Loss(reduction="mean", beta=float)`). Computes
+/// `mean_i loss_smooth(pred[i] - target[i], beta)` with
+/// `loss_smooth(z, β) = 0.5 z²/β` if `|z| < β`, else `|z| - 0.5 β`.
+/// `pred` and `target` must share shape.
+#[inline]
+pub fn smooth_l1_loss<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    pred: &Var<T, B>,
+    target: &Var<T, B>,
+    beta: T,
+) -> Var<T, B> {
+    coeus_autograd::smooth_l1_loss(pred, target, beta)
+}
+
+/// Row-wise cosine similarity along `dim=1`
+/// (PyTorch `F.cosine_similarity(x1, x2, dim=1, eps=...)`).
+/// `x1` and `x2` must share shape `[N, D]`; returns `[N]` where
+/// `out_i = <x1_i, x2_i> / (||x1_i|| * ||x2_i|| + eps)`.
+#[inline]
+pub fn cosine_similarity<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    x1: &Var<T, B>,
+    x2: &Var<T, B>,
+    dim: usize,
+    eps: T,
+) -> Var<T, B> {
+    coeus_autograd::cosine_similarity(x1, x2, dim, eps)
+}

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -1,9 +1,9 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
-    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, huber_loss, kl_divergence,
-    l1_loss, margin_ranking_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll,
-    soft_margin, triplet_margin_loss,
+    bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cosine_similarity, huber_loss,
+    kl_divergence, l1_loss, margin_ranking_loss, multi_margin, nll_loss, pairwise_distance,
+    poisson_nll, smooth_l1_loss, soft_margin, triplet_margin_loss,
 };
 use coeus_tensor::Tensor;
 
@@ -669,4 +669,93 @@ fn test_cosine_embedding_loss() {
     cosine_embedding_loss(&x1_g, &x2_g, &[1.0_f64], 0.0).backward();
     assert!(x1_g.grad().is_some(), "x1 grad");
     assert!(x2_g.grad().is_some(), "x2 grad");
+}
+
+// ── SmoothL1Loss (Huber-β) ──────────────────────────────────────────────────
+
+#[test]
+fn test_smooth_l1_loss() {
+    // pred - target = z = [0.5, 2.0, -3.0], beta = 1.0.
+    // |z|<β quadratic branch: 0.5·0.5²/1 = 0.125;
+    // |z|≥β linear branch:    |2|-0.5·1 = 1.5,  |−3|-0.5·1 = 2.5.
+    // mean = (0.125 + 1.5 + 2.5) / 3 = 1.375.
+    let pred_data = vec![0.5_f64, 2.0, -3.0];
+    let target_data = vec![0.0_f64, 0.0, 0.0];
+    let pred = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([3], &pred_data),
+        true,
+    );
+    let target = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([3], &target_data),
+        false,
+    );
+
+    let loss = smooth_l1_loss(&pred, &target, 1.0);
+    assert_eq!(loss.tensor.shape(), &[1]);
+    let expected = (0.125 + 1.5 + 2.5) / 3.0;
+    assert!(
+        (loss.tensor.as_slice()[0] - expected).abs() < 1e-12,
+        "smooth_l1 forward: got {}, want {expected}",
+        loss.tensor.as_slice()[0]
+    );
+
+    // d loss / d pred_i = (1/N)·(z/β if |z|<β else sign(z)):
+    //   z=0.5 -> 0.5/1 / 3;  z=2 -> +1 / 3;  z=-3 -> -1 / 3.
+    loss.backward();
+    let grad = pred.grad().expect("smooth_l1 pred grad");
+    let expected_grad = [0.5 / 3.0, 1.0 / 3.0, -1.0 / 3.0];
+    for (g, e) in grad.as_slice().iter().zip(expected_grad.iter()) {
+        assert!((g - e).abs() < 1e-12, "smooth_l1 grad: got {g}, want {e}");
+    }
+}
+
+// ── cosine_similarity (row-wise, dim=1) ─────────────────────────────────────
+
+#[test]
+fn test_cosine_similarity_forward_and_backward() {
+    // [N=2, D=2]; row0 = (3,4)·(4,3) / (5·5) = 24/25 = 0.96;
+    // row1 = (1,0)·(0,1) / (1·1) = 0.  eps is negligible at 1e-12.
+    let x1_data = vec![3.0_f64, 4.0, 1.0, 0.0];
+    let x2_data = vec![4.0_f64, 3.0, 0.0, 1.0];
+    let x1 = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2, 2], &x1_data),
+        true,
+    );
+    let x2 = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2, 2], &x2_data),
+        true,
+    );
+
+    let out = cosine_similarity(&x1, &x2, 1, 1e-12);
+    assert_eq!(out.tensor.shape(), &[2]);
+    let s = out.tensor.as_slice();
+    assert!((s[0] - 0.96).abs() < 1e-9, "row0 cos: got {}", s[0]);
+    assert!(s[1].abs() < 1e-9, "row1 cos: got {}", s[1]);
+
+    // Backward against a central finite-difference reference on sum(cos).
+    out.backward();
+    let analytic: Vec<f64> = x1.grad().expect("cosine x1 grad").as_slice().to_vec();
+    let h = 1e-6;
+    let forward_sum = |d: &[f64]| -> f64 {
+        let xv = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([2, 2], d), false);
+        cosine_similarity(&xv, &x2, 1, 1e-12)
+            .tensor
+            .as_slice()
+            .iter()
+            .sum::<f64>()
+    };
+    for i in 0..x1_data.len() {
+        let mut dp = x1_data.clone();
+        dp[i] += h;
+        let mut dm = x1_data.clone();
+        dm[i] -= h;
+        let numeric = (forward_sum(&dp) - forward_sum(&dm)) / (2.0 * h);
+        assert!(
+            (analytic[i] - numeric).abs() < 1e-5,
+            "cosine dx1[{i}]: analytic {} vs numeric {}",
+            analytic[i],
+            numeric
+        );
+    }
+    assert!(x2.grad().is_some(), "cosine x2 grad");
 }


### PR DESCRIPTION
## Summary
**Completes stalled, uncommitted work** found in the working tree (~2h idle, no active build). The `smooth_l1_loss` and `cosine_similarity` autograd nodes + nn wrappers were fully authored (documented PyTorch contracts + analytic gradients) but **did not compile** — the ops re-export chain was wired only at the `loss/mod.rs` and autograd `lib.rs` levels, missing the intermediate `ops/nn/mod.rs` + `ops/mod.rs` re-exports; and `coeus-nn/lib.rs` never re-exported the two functions.

## Fixes
- Add `cosine_similarity` + `smooth_l1_loss` to `ops/nn/mod.rs` and `ops/mod.rs` re-export lists (unblocks the `coeus-autograd` build).
- Add both to `coeus-nn/src/lib.rs` loss re-exports.
- Drop the stray `CosineSimilarityNode` export from autograd `lib.rs` — no other loss `Node` is re-exported at crate root (convention: functions public, nodes internal); it was the third unresolved import and inconsistent (`SmoothL1LossNode` wasn't exported either).

## Tests added (the missing DoD piece)
- **smooth_l1**: forward `1.375` for `z=[0.5,2,−3]`, `β=1` (both branches); exact analytic input gradient `[0.5,1,−1]/3`.
- **cosine_similarity**: forward `24/25` and `0` for the two rows; input gradient verified against a central finite-difference reference.

Full `nn_loss_tests` 20/20; fmt + clippy clean. `coeus-fft/` skeleton + unrelated `coeus-python/Cargo.toml` line-ending drift deliberately excluded from this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes previously uncommitted work for two PyTorch-compatible loss functions: `smooth_l1_loss` and `cosine_similarity`. The implementations were already written with full documentation and analytical gradients but failed to compile due to missing re-exports in the module hierarchy. The PR fixes the re-export chain across `ops/nn/mod.rs`, `ops/mod.rs`, and `coeus-autograd/lib.rs`, adds proper re-exports in `coeus-nn`, removes an inconsistent `CosineSimilarityNode` export, and adds comprehensive tests covering forward pass correctness and gradient validation via finite differences.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/smooth_l1.rs` |
| 2 | `coeus-autograd/src/ops/nn/loss/cosine_similarity.rs` |
| 3 | `coeus-nn/tests/nn_loss_tests.rs` |
| 4 | `coeus-autograd/src/ops/nn/loss/mod.rs` |
| 5 | `coeus-autograd/src/ops/nn/mod.rs` |
| 6 | `coeus-autograd/src/ops/mod.rs` |
| 7 | `coeus-autograd/src/lib.rs` |
| 8 | `coeus-nn/src/loss.rs` |
| 9 | `coeus-nn/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cosine similarity and Smooth L1 loss in the neural network API.
  * These functions are now available through the main public exports for easier use.

* **Tests**
  * Added coverage for both new operations, including forward results and gradient checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->