### PR TITLE
feat(fft): Add coeus-fft tensor-level FFT crate (Apollo-backed, no autograd)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "coeus-cuda",
     "coeus-dist",
     "coeus-leto",
+    "coeus-fft",
 ]
 
 [workspace.package]
@@ -64,6 +65,7 @@ coeus-nn       = { path = "coeus-nn", default-features = false }
 coeus-optim    = { path = "coeus-optim", default-features = false }
 coeus-sparse   = { path = "coeus-sparse" }
 coeus-dist     = { path = "coeus-dist", default-features = false }
+coeus-fft      = { path = "coeus-fft" }
 
 [patch."https://github.com/ryancinsight/Mnemosyne.git"]
 mnemosyne = { path = "../mnemosyne/crates/mnemosyne" }

--- a/backlog.md
+++ b/backlog.md
@@ -1,0 +1,36 @@
+# Coeus Backlog
+
+Ready (Definition-of-Ready) items. Each carries a change-class tag, a testable
+acceptance criterion, and identified dependencies/blockers.
+
+## G-FFT-CONSOLIDATE — invert FFT tensor-bridge ownership `[arch]`
+
+**Status:** todo · **Blocker:** `coeus-autograd` under active concurrent editing (loss
+re-export work) at the time `coeus-fft` landed — refactoring `coeus-autograd/ops/fft.rs`
+while a peer mutates sibling modules risks verifying/committing against a transiently
+broken crate.
+
+**Context:** The Apollo→Coeus tensor FFT primitive (`FftScalar` trait + tensor-level
+`fft_1d`/`ifft_1d`) currently exists in **two** places: the SSOT in
+[`coeus-fft`](coeus-fft/src/lib.rs) (non-autograd, deps `coeus-core`/`coeus-tensor`/`apollo-fft`)
+and a duplicate in [`coeus-autograd/ops/fft.rs`](coeus-autograd/src/ops/fft.rs) (which also
+hosts the `Var`-level nodes). This is a transient DRY violation accepted only because the
+autograd crate was blocked; it must be consolidated.
+
+**Task:** Make `coeus-autograd` depend on `coeus-fft`:
+1. Add `coeus-fft = { workspace = true }` to `coeus-autograd/Cargo.toml`.
+2. In `coeus-autograd/ops/fft.rs`, delete the local `FftScalar`/`fft_1d`/`ifft_1d`
+   definitions and replace with `pub use coeus_fft::{FftScalar, fft_1d, ifft_1d};`
+   (keeps `ops::mod`/`lib.rs` re-export names stable — no downstream call-site churn).
+   Retain only the `Var`-level nodes (`Fft1DNode`, `Ifft1DNode`, `fft_energy`, `*_var`).
+
+**Acceptance criteria:**
+- No duplicate `FftScalar`/`fft_1d`/`ifft_1d` definitions remain in the workspace
+  (single grep hit each, in `coeus-fft`).
+- `cargo nextest run -p coeus-autograd` and `-p coeus-nn` pass unchanged (Var-level FFT
+  autograd behavior and gradients identical).
+- `cargo doc --no-deps` warning-clean; the `coeus-fft` module doc's forward reference to
+  this item is satisfied.
+
+**Change-class:** `[arch]` (crate dependency-direction change; no public API surface change,
+so no version-major implication — re-export names are preserved).

--- a/coeus-fft/Cargo.toml
+++ b/coeus-fft/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "coeus-fft"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+coeus-core   = { workspace = true }
+coeus-tensor = { workspace = true }
+apollo-fft   = { workspace = true }
+
+[features]
+default = []

--- a/coeus-fft/src/lib.rs
+++ b/coeus-fft/src/lib.rs
@@ -1,0 +1,219 @@
+//! Tensor-level 1-D FFT for Coeus, routed through the Atlas-owned Apollo FFT library.
+//!
+//! This crate is the **non-autograd** signal-processing seam: it operates directly on
+//! [`Tensor`] values (no [`coeus_autograd::Var`] graph, no reverse-mode bookkeeping) and
+//! depends only on `coeus-core`, `coeus-tensor`, and `apollo-fft`. It is the SSOT for the
+//! Apollo -> Coeus tensor FFT bridge; the differentiable `Var`-level FFT nodes in
+//! `coeus-autograd` build on this primitive rather than re-deriving it (see backlog
+//! `G-FFT-CONSOLIDATE`: `coeus-autograd/ops/fft.rs` is scheduled to depend on this crate).
+//!
+//! No dependency on `rustfft`: all transforms execute through `apollo-fft`, keeping signal
+//! processing inside the Atlas ecosystem.
+//!
+//! # Numerical contract
+//! [`fft_1d`] computes the unnormalized forward DFT `X[k] = sum_n x[n] * exp(-2i*pi*k*n/N)`.
+//! [`ifft_1d`] applies the `1/N`-normalized inverse, so `ifft_1d(fft_1d(x)) == x` up to
+//! floating-point rounding.
+
+// ── Coeus FFT ──
+// Tensor-level FFT bridge over Apollo.
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+use coeus_core::{Complex, ComputeBackend, Float, Scalar};
+use coeus_tensor::Tensor;
+
+/// Scalar types with an Apollo-backed 1-D FFT implementation.
+///
+/// Implemented for the IEEE-754 binary floating-point types Apollo plans natively.
+pub trait FftScalar: Float {
+    /// Forward FFT of a contiguous real signal, producing its complex spectrum.
+    fn fft_1d_impl(signal: &[Self]) -> Vec<Complex<Self>>;
+
+    /// Inverse (`1/N`-normalized) FFT of a contiguous complex spectrum.
+    fn ifft_1d_impl(spectrum: &[Complex<Self>]) -> Vec<Self>;
+}
+
+impl FftScalar for f32 {
+    #[inline]
+    fn fft_1d_impl(signal: &[Self]) -> Vec<Complex<Self>> {
+        apollo_fft::fft_1d_slice_typed::<f32>(signal)
+    }
+
+    #[inline]
+    fn ifft_1d_impl(spectrum: &[Complex<Self>]) -> Vec<Self> {
+        apollo_fft::ifft_1d_slice_typed::<f32>(spectrum)
+    }
+}
+
+impl FftScalar for f64 {
+    #[inline]
+    fn fft_1d_impl(signal: &[Self]) -> Vec<Complex<Self>> {
+        apollo_fft::fft_1d_slice_typed::<f64>(signal)
+    }
+
+    #[inline]
+    fn ifft_1d_impl(spectrum: &[Complex<Self>]) -> Vec<Self> {
+        apollo_fft::ifft_1d_slice_typed::<f64>(spectrum)
+    }
+}
+
+/// Copy a tensor's logical elements into a contiguous host `Vec` in row-major order.
+fn tensor_to_vec<T, B>(tensor: &Tensor<T, B>) -> Vec<T>
+where
+    T: Scalar,
+    B: ComputeBackend + Default,
+{
+    let backend = B::default();
+    let contiguous = tensor.to_contiguous();
+    let mut host = vec![T::zero(); contiguous.numel()];
+    backend.copy_to_host(contiguous.storage(), &mut host);
+    host
+}
+
+/// Apollo-backed 1-D forward FFT of a real-valued tensor.
+///
+/// # Arguments
+/// * `signal` — 1-D tensor of shape `[N]`.
+///
+/// # Returns
+/// Complex tensor of shape `[N]` holding the frequency spectrum.
+///
+/// # Panics
+/// If `signal` is not 1-D.
+///
+/// # Examples
+/// ```
+/// use coeus_fft::fft_1d;
+/// use coeus_tensor::Tensor;
+///
+/// let signal = Tensor::<f64>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]);
+/// let spectrum = fft_1d(&signal);
+/// assert_eq!(spectrum.numel(), 4);
+/// ```
+#[must_use]
+pub fn fft_1d<T, B>(signal: &Tensor<T, B>) -> Tensor<Complex<T>, B>
+where
+    T: FftScalar,
+    B: ComputeBackend + Default,
+{
+    assert_eq!(signal.ndim(), 1, "fft_1d requires 1-D input");
+    let backend = B::default();
+    let input = tensor_to_vec(signal);
+    let spectrum = T::fft_1d_impl(&input);
+    Tensor::from_slice_on(signal.shape_cloned(), &spectrum, &backend)
+}
+
+/// Apollo-backed 1-D inverse FFT, reconstructing a real-valued tensor.
+///
+/// # Arguments
+/// * `spectrum` — 1-D complex tensor of shape `[N]`.
+///
+/// # Returns
+/// Real tensor of shape `[N]`; `ifft_1d(fft_1d(x)) == x` up to floating-point rounding.
+///
+/// # Panics
+/// If `spectrum` is not 1-D.
+///
+/// # Examples
+/// ```
+/// use coeus_fft::{fft_1d, ifft_1d};
+/// use coeus_tensor::Tensor;
+///
+/// let signal = Tensor::<f64>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]);
+/// let reconstructed = ifft_1d(&fft_1d(&signal));
+/// for (r, x) in reconstructed.as_slice().iter().zip([1.0, 2.0, 3.0, 4.0]) {
+///     assert!((r - x).abs() < 1e-12);
+/// }
+/// ```
+#[must_use]
+pub fn ifft_1d<T, B>(spectrum: &Tensor<Complex<T>, B>) -> Tensor<T, B>
+where
+    T: FftScalar,
+    B: ComputeBackend + Default,
+{
+    assert_eq!(spectrum.ndim(), 1, "ifft_1d requires 1-D input");
+    let backend = B::default();
+    let input = tensor_to_vec(spectrum);
+    let signal = T::ifft_1d_impl(&input);
+    Tensor::from_slice_on(spectrum.shape_cloned(), &signal, &backend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coeus_core::MoiraiBackend;
+
+    /// Tolerance for `N = 4`, f64 radix FFT: worst-case error grows as
+    /// `O(log2(N) * eps_f64) = 2 * 2.22e-16 ~= 4.4e-16`; `1e-12` is a safe
+    /// analytic margin (>3 orders of magnitude) that still rejects real defects.
+    const TOL: f64 = 1e-12;
+
+    fn assert_complex_close(got: Complex<f64>, want: Complex<f64>, ctx: &str) {
+        assert!(
+            (got.re - want.re).abs() < TOL && (got.im - want.im).abs() < TOL,
+            "{ctx}: got {got:?}, want {want:?}"
+        );
+    }
+
+    #[test]
+    fn fft_matches_analytic_dft() {
+        // x = [1,2,3,4]. Closed-form DFT (X[k] = sum_n x[n] exp(-2i*pi*k*n/4)):
+        //   X0 = 10, X1 = -2 + 2i, X2 = -2, X3 = -2 - 2i.
+        let signal = Tensor::<f64, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]);
+        let spectrum = fft_1d(&signal);
+        let out = spectrum.to_contiguous();
+        let vals = out.as_slice();
+        assert_complex_close(vals[0], Complex::new(10.0, 0.0), "X0");
+        assert_complex_close(vals[1], Complex::new(-2.0, 2.0), "X1");
+        assert_complex_close(vals[2], Complex::new(-2.0, 0.0), "X2");
+        assert_complex_close(vals[3], Complex::new(-2.0, -2.0), "X3");
+    }
+
+    #[test]
+    fn constant_signal_has_dc_only_spectrum() {
+        // A constant signal c*[1,1,1,1] concentrates all energy at DC: X = [4c, 0, 0, 0].
+        let c = 2.5;
+        let signal = Tensor::<f64, MoiraiBackend>::from_slice([4], &[c, c, c, c]);
+        let vals_t = fft_1d(&signal).to_contiguous();
+        let vals = vals_t.as_slice();
+        assert_complex_close(vals[0], Complex::new(4.0 * c, 0.0), "DC");
+        for (k, v) in vals.iter().enumerate().skip(1) {
+            assert_complex_close(*v, Complex::new(0.0, 0.0), &format!("bin {k}"));
+        }
+    }
+
+    #[test]
+    fn ifft_inverts_fft() {
+        // Round-trip identity verifies Apollo's 1/N inverse normalization.
+        let data = [0.5, -1.25, 3.0, 2.0, -0.75, 4.5, 1.0, -2.5];
+        let signal = Tensor::<f64, MoiraiBackend>::from_slice([8], &data);
+        let recon = ifft_1d(&fft_1d(&signal));
+        let recon_c = recon.to_contiguous();
+        for (r, x) in recon_c.as_slice().iter().zip(data) {
+            assert!((r - x).abs() < TOL, "round-trip: got {r}, want {x}");
+        }
+    }
+
+    #[test]
+    fn f32_fft_matches_analytic_dft() {
+        // Same closed form in single precision; tolerance scaled to f32 epsilon
+        // (eps_f32 ~= 1.19e-7, margin to 1e-4).
+        let signal = Tensor::<f32, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]);
+        let out = fft_1d(&signal).to_contiguous();
+        let vals = out.as_slice();
+        let tol = 1e-4_f32;
+        let want = [
+            Complex::new(10.0_f32, 0.0),
+            Complex::new(-2.0, 2.0),
+            Complex::new(-2.0, 0.0),
+            Complex::new(-2.0, -2.0),
+        ];
+        for (k, (g, w)) in vals.iter().zip(want).enumerate() {
+            assert!(
+                (g.re - w.re).abs() < tol && (g.im - w.im).abs() < tol,
+                "f32 X{k}: got {g:?}, want {w:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Completes the previously-orphaned `coeus-fft/` skeleton (untracked, non-member, importing a nonexistent `apollo_fft::coeus` module) into a real, registered workspace member: a **tensor-level, non-autograd** FFT seam routed through Atlas-owned Apollo (no `rustfft`).

- Owns the Apollo→Coeus tensor FFT primitive — `FftScalar` trait + `fft_1d`/`ifft_1d` — depending only on `coeus-core`/`coeus-tensor`/`apollo-fft`. Plain-`Tensor` FFT no longer requires the reverse-mode autograd engine.
- Canonical `fft_1d`/`ifft_1d` names (consistent with `coeus-autograd`'s `Var`-level FFT); dropped the redundant `fft`/`ifft` aliases the skeleton carried.
- `#![forbid(unsafe_code)]`, `#![deny(missing_docs)]`, full rustdoc + runnable doctests.

## Verification (value-semantic, analytic oracles)
- Forward DFT of `[1,2,3,4]` == `[10, −2+2i, −2, −2−2i]` (f64 tol `1e-12`, f32 tol `1e-4`), tolerance derived from `O(log₂N·ε)`.
- Constant signal `c·[1,1,1,1]` → DC-only spectrum `[4c,0,0,0]`.
- `ifft_1d(fft_1d(x)) == x` round-trip (confirms Apollo's `1/N` inverse normalization).
- **4/4 nextest + 2/2 doctests pass; `fmt` + `clippy -D warnings` clean.**

## Follow-up (filed, not deferred silently)
The tensor bridge is transiently duplicated with `coeus-autograd/ops/fft.rs`. Consolidation is **blocked** only because that crate was under concurrent editing when this landed — refactoring it would mean verifying against a peer's mid-flight state. Tracked as `backlog.md#G-FFT-CONSOLIDATE` `[arch]`: invert ownership so `coeus-autograd` depends on `coeus-fft` (re-export names preserved → zero call-site churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces `coeus-fft` as a new workspace member, providing tensor-level FFT operations (`fft_1d` and `ifft_1d`) that route through Apollo instead of rustfft. The implementation is non-autograd focused, depending only on core tensor primitives, and includes the `FftScalar` trait for f32/f64 types. The crate is fully documented with rustdoc, forbids unsafe code, and includes comprehensive tests verifying FFT correctness against analytic DFT formulas and round-trip invariants. A backlog item tracks future consolidation to eliminate duplication with `coeus-autograd/ops/fft.rs`.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `coeus-fft/Cargo.toml` |
| 3 | `coeus-fft/src/lib.rs` |
| 4 | `backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FFT component to the workspace, enabling 1-D forward and inverse FFT operations.
  * Introduced tensor-based FFT support for real and complex data, with results returned on the original backend.
  * Included validation coverage for common FFT behaviors, such as round-trip accuracy and constant-signal spectra.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->