### PR TITLE
test(fft): Cover f32 FftScalar path + add coeus-fft benchmark

### DIFF
--- a/coeus-fft/Cargo.toml
+++ b/coeus-fft/Cargo.toml
@@ -14,5 +14,13 @@ coeus-tensor   = { workspace = true }
 coeus-autograd = { workspace = true, default-features = false }
 apollo-fft     = { workspace = true }
 
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "fft_bench"
+path = "benches/fft_bench.rs"
+harness = false
+
 [features]
 default = []

--- a/coeus-fft/benches/fft_bench.rs
+++ b/coeus-fft/benches/fft_bench.rs
@@ -1,0 +1,47 @@
+//! Benchmarks for `coeus-fft`: Apollo-backed FFT forward throughput and the
+//! autograd forward+backward round-trip (measuring the reverse-mode overhead
+//! over the raw transform).
+
+use coeus_autograd::Var;
+use coeus_core::{Complex, MoiraiBackend};
+use coeus_fft::{fft_1d, fft_1d_var};
+use coeus_tensor::Tensor;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+/// Deterministic non-trivial real signal of length `n`.
+fn signal_data(n: usize) -> Vec<f64> {
+    (0..n).map(|i| ((i as f64) * 0.1).sin() + 0.5).collect()
+}
+
+const SIZES: [usize; 3] = [256, 1024, 4096];
+
+fn bench_fft_forward(c: &mut Criterion) {
+    let mut group = c.benchmark_group("coeus-fft fft_1d forward");
+    for &n in &SIZES {
+        let signal = Tensor::<f64, MoiraiBackend>::from_slice([n], &signal_data(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &signal, |b, s| {
+            b.iter(|| black_box(fft_1d(black_box(s))));
+        });
+    }
+    group.finish();
+}
+
+fn bench_fft_autograd_roundtrip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("coeus-fft fft_1d_var forward+backward");
+    for &n in &SIZES {
+        let data = signal_data(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &data, |b, d| {
+            b.iter(|| {
+                let x = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([d.len()], d), true);
+                let y = fft_1d_var(black_box(&x));
+                let seed = Tensor::from_slice([d.len()], &vec![Complex::new(1.0, 0.0); d.len()]);
+                y.backward_with_seed(seed);
+                black_box(x.grad());
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_fft_forward, bench_fft_autograd_roundtrip);
+criterion_main!(benches);

--- a/coeus-fft/tests/fft.rs
+++ b/coeus-fft/tests/fft.rs
@@ -59,6 +59,57 @@ fn fft_1d_var_accumulates_input_gradient_from_complex_seed() {
 }
 
 #[test]
+fn fft_1d_f32_matches_hand_dft_and_roundtrips() {
+    // Exercises the `impl FftScalar for f32` path. Same closed-form DFT as the
+    // f64 case; tolerance scaled to f32: eps_f32 ~= 1.19e-7, radix error ~O(logN*eps),
+    // 1e-4 is a safe margin that still rejects real defects.
+    let tol = 1e-4_f32;
+    let signal = Tensor::<f32, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]);
+    let spectrum = fft_1d(&signal);
+    let expected = [
+        Complex::new(10.0_f32, 0.0),
+        Complex::new(-2.0, 2.0),
+        Complex::new(-2.0, 0.0),
+        Complex::new(-2.0, -2.0),
+    ];
+    for (index, (&actual, &want)) in spectrum.as_slice().iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (actual.re - want.re).abs() < tol && (actual.im - want.im).abs() < tol,
+            "f32 fft[{index}]: got {actual:?}, want {want:?}"
+        );
+    }
+    let reconstructed = ifft_1d(&spectrum);
+    for (index, (&actual, &want)) in reconstructed
+        .as_slice()
+        .iter()
+        .zip(signal.as_slice())
+        .enumerate()
+    {
+        assert!(
+            (actual - want).abs() < tol,
+            "f32 ifft[{index}]: got {actual}, want {want}"
+        );
+    }
+}
+
+#[test]
+fn fft_1d_f32_agrees_with_f64_reference() {
+    // Differential check: the f32 backend must agree with the f64 reference
+    // within f32 precision (per numerical_discipline reduction-order bounds).
+    let data = [0.25, -1.0, 0.5, 2.0, -0.75, 1.25, -0.5, 0.125];
+    let data32: Vec<f32> = data.iter().map(|&v| v as f32).collect();
+    let ref64 = fft_1d(&Tensor::<f64, MoiraiBackend>::from_slice([8], &data));
+    let got32 = fft_1d(&Tensor::<f32, MoiraiBackend>::from_slice([8], &data32));
+    let tol = 1e-4_f32;
+    for (index, (&r, &g)) in ref64.as_slice().iter().zip(got32.as_slice()).enumerate() {
+        assert!(
+            (r.re as f32 - g.re).abs() < tol && (r.im as f32 - g.im).abs() < tol,
+            "f32 vs f64 bin {index}: f32={g:?}, f64={r:?}"
+        );
+    }
+}
+
+#[test]
 fn fft_energy_gradient_matches_parseval_oracle() {
     let data = [0.25, -1.0, 0.5, 2.0, -0.75, 1.25, -0.5, 0.125];
     let x = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([8], &data), true);


### PR DESCRIPTION
## Summary
Hardens the `coeus-fft` crate (created earlier this session). Its test suite covered only f64, so the `impl FftScalar for f32` Apollo path was **entirely unverified**. Adds f32 coverage and a benchmark.

- **`fft_1d_f32_matches_hand_dft_and_roundtrips`** — closed-form DFT of `[1,2,3,4]` + ifft roundtrip in single precision (tol `1e-4`, derived from f32 epsilon × O(logN) radix error growth).
- **`fft_1d_f32_agrees_with_f64_reference`** — differential check: the f32 backend matches the f64 reference within f32 precision (per `numerical_discipline` reduction-order bounds).
- **`benches/fft_bench.rs`** (criterion) — `fft_1d` forward throughput + `fft_1d_var` forward+backward round-trip at N=256/1024/4096, measuring reverse-mode overhead over the raw Apollo transform.

## Verification
5/5 `coeus-fft` tests pass; `fmt` + `clippy --all-targets -D warnings` clean (bench target included). Fully disjoint from concurrent work (coeus-fft crate only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds missing test coverage for the `f32` implementation of `FftScalar` in the `coeus-fft` crate, which was previously only tested with `f64`. Two new test cases verify the f32 path: one validates against a hand-computed DFT with appropriate single-precision tolerance, and another performs a differential check against the f64 reference implementation. Additionally, a Criterion-based benchmark suite is introduced to measure FFT forward throughput and autograd forward+backward round-trip overhead at various sizes (256, 1024, 4096).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-fft/tests/fft.rs` |
| 2 | `coeus-fft/benches/fft_bench.rs` |
| 3 | `coeus-fft/Cargo.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FFT benchmarking support for common input sizes, including forward and autograd round-trip performance measurements.
* **Tests**
  * Expanded FFT coverage for `f32` inputs with round-trip correctness checks.
  * Added cross-precision validation to confirm `f32` results stay aligned with `f64` reference output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->