### PR TITLE
perf(nn): 38x faster global adaptive pool via mean_axis/max_axis fast path (MS-227)

### DIFF
--- a/coeus-nn/src/pool/adaptive.rs
+++ b/coeus-nn/src/pool/adaptive.rs
@@ -208,6 +208,13 @@ where
         let (oh, ow) = (self.out_h, self.out_w);
         let backend = B::default();
 
+        // Fast path for global (1×1) pooling: sequential mean_axis reductions
+        // avoid allocating the O(H*W) averaging matrix.
+        if oh == 1 && ow == 1 {
+            let after_h = coeus_autograd::mean_axis(input, 2); // [N, C, 1, W]
+            return coeus_autograd::mean_axis(&after_h, 3); // [N, C, 1, 1]
+        }
+
         // Pool W: [N, C, H, W] -> [N*C*H, W] @ PW_T[W, OW] -> [N, C, H, OW].
         let pw_t = avg_pool_matrix_t::<T, B>(w, ow, &backend);
         let yw = coeus_autograd::matmul(&coeus_autograd::reshape(input, [n * c * h, w]), &pw_t);
@@ -311,6 +318,12 @@ where
         let (n, c, h, w) = (shape[0], shape[1], shape[2], shape[3]);
         let (oh, ow) = (self.out_h, self.out_w);
         let backend = B::default();
+
+        // Fast path for global (1×1) max pooling: sequential max_axis reductions.
+        if oh == 1 && ow == 1 {
+            let after_h = coeus_autograd::max_axis(input, 2); // [N, C, 1, W]
+            return coeus_autograd::max_axis(&after_h, 3); // [N, C, 1, 1]
+        }
 
         // Pool W: [N, C, H, W] -> [N*C*H, W] -> [N*C*H, OW] -> [N, C, H, OW].
         let xw = coeus_autograd::reshape(input, [n * c * h, w]);


### PR DESCRIPTION
Fast path for out=(1,1): uses mean_axis/max_axis instead of separable matmul. Sequential ~88us (from ~3200us), Moirai ~90us. Burn~27us vs Coeus~88us (3x gap, down from 107x). All 13 tests pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a fast path optimization for global adaptive pooling (output size 1×1) in both average and max pooling operations. Instead of using the general-purpose separable matmul approach, it leverages sequential `mean_axis` and `max_axis` reductions, achieving a 38x speedup (from ~3200us to ~88us). The optimization detects when output dimensions are (1,1) and bypasses the expensive matrix allocation, significantly reducing the performance gap with Burn from 107x to 3x.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/pool/adaptive.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->