### PR TITLE
fix(autograd): add missing ctc_loss re-export in ops::nn

### DIFF
--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -26,7 +26,7 @@ pub use dropout::dropout;
 pub use log_softmax::log_softmax;
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cosine_similarity,
-    cross_entropy_loss, huber_loss, kl_divergence, l1_loss, margin_ranking_loss,
+    cross_entropy_loss, ctc_loss, huber_loss, kl_divergence, l1_loss, margin_ranking_loss,
     multi_label_margin_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll,
     smooth_l1_loss, soft_margin,
 };


### PR DESCRIPTION
Restores ctc_loss to ops::nn re-export list. Regression from MS-225 local revert.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a regression by restoring the missing `ctc_loss` function to the `ops::nn` module's public re-export list. The function was inadvertently removed during a local revert of MS-225 and is now being added back to the appropriate position in the alphabetically-ordered export list.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->