### PR TITLE
perf(optim): Sequential fast-path for all optimizers via shared dispatch

### DIFF
--- a/coeus-ops/src/backend_ops/cpu_impl/optim/adam_adamw.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/optim/adam_adamw.rs
@@ -1,3 +1,4 @@
+use super::dispatch;
 use crate::ptr::{MutPtr, Ptr};
 use coeus_core::FloatOps;
 use coeus_core::{Backend, CpuAddressableStorage, CpuAddressableStorageMut, Layout, Scalar};
@@ -49,7 +50,7 @@ pub fn adam_step<T: Scalar + FloatOps, B: Backend>(
         && v_layout.is_contiguous();
 
     if is_contiguous {
-        backend.parallel_for(0, numel, move |i| unsafe {
+        dispatch(backend, numel, move |i| unsafe {
             let g = g_ptr.read(g_off + i);
             let m_val = m_ptr.read(m_off + i) * beta1 + (T::one() - beta1) * g;
             let v_val = v_ptr.read(v_off + i) * beta2 + (T::one() - beta2) * g * g;
@@ -73,7 +74,7 @@ pub fn adam_step<T: Scalar + FloatOps, B: Backend>(
         let v_shape = v_layout.shape_cloned();
         let v_strides = v_layout.strides_cloned();
 
-        backend.parallel_for(0, numel, move |i| {
+        dispatch(backend, numel, move |i| {
             let mut temp = i;
             let mut coords = smallvec::SmallVec::<[usize; 4]>::from_elem(0, ndim);
             for d in (0..ndim).rev() {
@@ -169,7 +170,7 @@ pub fn adamw_step<T: Scalar + FloatOps, B: Backend>(
         && v_layout.is_contiguous();
 
     if is_contiguous {
-        backend.parallel_for(0, numel, move |i| unsafe {
+        dispatch(backend, numel, move |i| unsafe {
             let g = g_ptr.read(g_off + i);
             let m_val = m_ptr.read(m_off + i) * beta1 + one_minus_b1 * g;
             let v_val = v_ptr.read(v_off + i) * beta2 + one_minus_b2 * g * g;
@@ -193,7 +194,7 @@ pub fn adamw_step<T: Scalar + FloatOps, B: Backend>(
         let v_shape = v_layout.shape_cloned();
         let v_strides = v_layout.strides_cloned();
 
-        backend.parallel_for(0, numel, move |i| {
+        dispatch(backend, numel, move |i| {
             let mut temp = i;
             let mut coords = smallvec::SmallVec::<[usize; 4]>::from_elem(0, ndim);
             for d in (0..ndim).rev() {

--- a/coeus-ops/src/backend_ops/cpu_impl/optim/mod.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/optim/mod.rs
@@ -3,3 +3,41 @@ mod sgd_adagrad_rmsprop;
 
 pub use adam_adamw::{adam_step, adamw_step};
 pub use sgd_adagrad_rmsprop::{adagrad_step, rmsprop_step, sgd_step};
+
+use coeus_core::Backend;
+
+/// Element count at or below which an optimizer update runs sequentially instead
+/// of dispatching across the Moirai pool.
+///
+/// Optimizer steps are light, memory-bandwidth-bound element-wise updates (a few
+/// FLOPs per element), so for small parameter tensors a single auto-vectorized
+/// loop beats the thread dispatch/join cost. This is deliberately the op-layer's
+/// threshold: `coeus-ops` knows the per-element work is cheap, so it raises the
+/// bar above Moirai's general-purpose `Adaptive` threshold (1024) before handing
+/// off to the pool.
+///
+/// Note: benchmark evidence (`coeus-optim/benches/optim_bench.rs`) indicates the
+/// parallel path stays slower than sequential well past this value for these
+/// ops; tuning `SEQUENTIAL_THRESHOLD` upward is tracked as a follow-up requiring a
+/// derived sequential-vs-parallel crossover measurement across sizes.
+const SEQUENTIAL_THRESHOLD: usize = 4096;
+
+/// Apply `f(i)` for every `i in 0..numel`, sequentially below
+/// [`SEQUENTIAL_THRESHOLD`] (no dispatch/join overhead) or across Moirai's pool
+/// above it. The same per-element closure serves both regimes, so each optimizer
+/// keeps a single update body rather than duplicating a sequential and a parallel
+/// variant.
+#[inline]
+fn dispatch<B, F>(backend: &B, numel: usize, f: F)
+where
+    B: Backend,
+    F: Fn(usize) + Send + Sync + 'static,
+{
+    if numel <= SEQUENTIAL_THRESHOLD {
+        for i in 0..numel {
+            f(i);
+        }
+    } else {
+        backend.parallel_for(0, numel, f);
+    }
+}

--- a/coeus-ops/src/backend_ops/cpu_impl/optim/sgd_adagrad_rmsprop.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/optim/sgd_adagrad_rmsprop.rs
@@ -1,9 +1,6 @@
+use super::dispatch;
 use crate::ptr::{MutPtr, Ptr};
 use coeus_core::{Backend, CpuAddressableStorage, CpuAddressableStorageMut, Layout, Scalar};
-
-/// Size threshold below which we run the optimizer update sequentially (no
-/// thread-launch overhead) instead of distributing across the Moirai thread pool.
-const SEQUENTIAL_THRESHOLD: usize = 4096;
 
 pub fn sgd_step<T: Scalar, B: Backend>(
     backend: &B,
@@ -34,32 +31,11 @@ pub fn sgd_step<T: Scalar, B: Backend>(
         && grad_layout.is_contiguous()
         && velocity_layout.is_contiguous();
 
-    if is_contiguous && p_off == 0 && g_off == 0 && v_off == 0 {
-        if numel <= SEQUENTIAL_THRESHOLD {
-            // Small parameter tensors: avoid thread-scheduling overhead with a
-            // sequential loop that auto-vectorizes via LLVM on release builds.
-            for i in 0..numel {
-                let g = g_slice[i];
-                let v = v_slice[i] * momentum + g;
-                v_slice[i] = v;
-                p_slice[i] = p_slice[i] - lr * v;
-            }
-        } else {
-            let p_ptr = MutPtr(p_slice.as_mut_ptr());
-            let g_ptr = Ptr(g_slice.as_ptr());
-            let v_ptr = MutPtr(v_slice.as_mut_ptr());
-            backend.parallel_for(0, numel, move |i| unsafe {
-                let g = g_ptr.read(i);
-                let v = v_ptr.read(i) * momentum + g;
-                v_ptr.write(i, v);
-                p_ptr.write(i, p_ptr.read(i) - lr * v);
-            });
-        }
-    } else if is_contiguous {
+    if is_contiguous {
         let p_ptr = MutPtr(p_slice.as_mut_ptr());
         let g_ptr = Ptr(g_slice.as_ptr());
         let v_ptr = MutPtr(v_slice.as_mut_ptr());
-        backend.parallel_for(0, numel, move |i| unsafe {
+        dispatch(backend, numel, move |i| unsafe {
             let g = g_ptr.read(g_off + i);
             let v = v_ptr.read(v_off + i) * momentum + g;
             v_ptr.write(v_off + i, v);
@@ -77,7 +53,7 @@ pub fn sgd_step<T: Scalar, B: Backend>(
         let v_shape = velocity_layout.shape_cloned();
         let v_strides = velocity_layout.strides_cloned();
 
-        backend.parallel_for(0, numel, move |i| {
+        dispatch(backend, numel, move |i| {
             let mut temp = i;
             let mut coords = smallvec::SmallVec::<[usize; 4]>::from_elem(0, ndim);
             for d in (0..ndim).rev() {
@@ -145,7 +121,7 @@ pub fn rmsprop_step<T: Scalar, B: Backend>(
         param_layout.is_contiguous() && grad_layout.is_contiguous() && v_layout.is_contiguous();
 
     if is_contiguous {
-        backend.parallel_for(0, numel, move |i| unsafe {
+        dispatch(backend, numel, move |i| unsafe {
             let g = g_ptr.read(g_off + i);
             let v_val = v_ptr.read(v_off + i) * alpha + (T::one() - alpha) * g * g;
             v_ptr.write(v_off + i, v_val);
@@ -162,7 +138,7 @@ pub fn rmsprop_step<T: Scalar, B: Backend>(
         let v_shape = v_layout.shape_cloned();
         let v_strides = v_layout.strides_cloned();
 
-        backend.parallel_for(0, numel, move |i| {
+        dispatch(backend, numel, move |i| {
             let mut temp = i;
             let mut coords = smallvec::SmallVec::<[usize; 4]>::from_elem(0, ndim);
             for d in (0..ndim).rev() {
@@ -232,7 +208,7 @@ pub fn adagrad_step<T: Scalar, B: Backend>(
         && history_layout.is_contiguous();
 
     if is_contiguous {
-        backend.parallel_for(0, numel, move |i| unsafe {
+        dispatch(backend, numel, move |i| unsafe {
             let g = g_ptr.read(g_off + i);
             let h = h_ptr.read(h_off + i) + g * g;
             h_ptr.write(h_off + i, h);
@@ -250,7 +226,7 @@ pub fn adagrad_step<T: Scalar, B: Backend>(
         let h_shape = history_layout.shape_cloned();
         let h_strides = history_layout.strides_cloned();
 
-        backend.parallel_for(0, numel, move |i| {
+        dispatch(backend, numel, move |i| {
             let mut temp = i;
             let mut coords = smallvec::SmallVec::<[usize; 4]>::from_elem(0, ndim);
             for d in (0..ndim).rev() {


### PR DESCRIPTION
## Summary
Only `sgd_step` guarded against Moirai thread-dispatch overhead for small tensors — **adam/adamw/adagrad/rmsprop called `parallel_for` unconditionally**, paying dispatch/join cost even on tiny parameter tensors (Adam @1024 elems measured at **5.9µs**).

- Consolidate the sequential-vs-parallel decision into one `dispatch` helper in the optim module (removing the pattern duplicated across five step functions — DRY) and route **all** optimizers through it.
- Below `SEQUENTIAL_THRESHOLD` the same per-element closure runs in a plain auto-vectorized loop; above it, across the Moirai pool. SGD's two contiguous branches collapse into one offset-general path.
- The threshold decision stays in `coeus-ops` (the op layer knows optimizer updates are light, memory-bound element-wise work) and uses Moirai's `parallel_for` as the mechanism — **no change to Moirai's general `Adaptive` threshold** (avoids regressing heavier workloads).

## Verification
- **Correctness**: identical arithmetic + iteration order → **203/203** coeus-optim + coeus-ops tests pass.
- **Perf**: Adam @1024 elems **5.9µs → 559ns (~10.5×)**.
- fmt + clippy `--all-targets -D warnings` clean. Package-local to `coeus-ops`; disjoint from concurrent `coeus-nn` bench work.

## Follow-up (documented, not silent)
Bench evidence shows the parallel path stays slower than sequential well past 4096 for these light ops — raising `SEQUENTIAL_THRESHOLD` is tracked as a follow-up requiring a derived sequential-vs-parallel crossover measurement across sizes (kept separate to avoid an unverified threshold change here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a performance optimization for optimizer step functions (SGD, Adam, AdamW, Adagrad, RMSprop) by consolidating the sequential-vs-parallel dispatch logic into a single shared `dispatch` helper. Previously, only SGD had a fast-path for small tensors while other optimizers unconditionally used thread dispatch, incurring overhead even on tiny parameter tensors. The new approach runs optimizer updates sequentially (using auto-vectorization) for tensors with 4096 or fewer elements and only dispatches to the Moirai thread pool for larger tensors, achieving a ~10.5× speedup for small tensor updates (e.g., Adam at 1024 elements: 5.9µs → 559ns) while maintaining identical arithmetic and correctness.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-ops/src/backend_ops/cpu_impl/optim/mod.rs` |
| 2 | `coeus-ops/src/backend_ops/cpu_impl/optim/sgd_adagrad_rmsprop.rs` |
| 3 | `coeus-ops/src/backend_ops/cpu_impl/optim/adam_adamw.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimizer updates on CPU now use smarter execution for small and large tensors, which can improve training speed and consistency.
  * Several common optimizers benefit from a shared update path across tensor layouts, helping reduce overhead and improve behavior for both contiguous and non-contiguous parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->