### PR TITLE
test(python): 4 loss + 2 activation parity tests (MS-229)

### DIFF
--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1321,3 +1321,61 @@ def test_cosine_similarity_matches_jax() -> None:
     _allclose("cos_out_jax", list(out_pyc.data), list(out_j), atol=1e-10)
     _allclose("cos_dx1_jax", list(x1_pyc.grad), list(g_x1.flatten()), atol=1e-10)
     _allclose("cos_dx2_jax", list(x2_pyc.grad), list(g_x2.flatten()), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Mish activation parity (MS-228)
+# ---------------------------------------------------------------------------
+
+
+def test_mish_matches_jax() -> None:
+    """Mish forward and gradient parity: x * tanh(softplus(x)).
+
+    JAX reference: x * jnp.tanh(jnp.log1p(jnp.exp(x))) at f64.
+    Input spans positive, negative, and zero to cover all regions.
+    """
+    x_data = [-2.0, -0.5, 0.0, 0.5, 1.5, 3.0]
+
+    x_pyc = pycoeus.Tensor(x_data, [6], requires_grad=True)
+    y_pyc = pycoeus.mish(x_pyc)
+    # backward via sum
+    y_pyc.backward()
+
+    x_j = jnp.asarray(x_data, dtype=jnp.float64)
+
+    def mish_j(x):
+        return jnp.sum(x * jnp.tanh(jnp.log1p(jnp.exp(x))))
+
+    val_j, dx_j = jax.value_and_grad(mish_j)(x_j)
+
+    # forward: compare element-wise
+    def mish_scalar(x):
+        return x * jnp.tanh(jnp.log1p(jnp.exp(x)))
+
+    y_j = jax.vmap(mish_scalar)(x_j)
+    _allclose("mish_forward", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-9)
+    _allclose("mish_grad", list(x_pyc.grad), dx_j.flatten().tolist(), atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Dropout eval identity parity (MS-228)
+# ---------------------------------------------------------------------------
+
+
+def test_dropout_eval_matches_jax() -> None:
+    """Dropout in eval mode is an identity: output == input.
+
+    Both pycoeus and JAX dropout (with rate=0 i.e. deterministic eval) should
+    produce outputs equal to the input at any dtype.
+    """
+    if not hasattr(pycoeus, "Dropout"):
+        pytest.skip("pycoeus.Dropout not available")
+
+    x_data = [-1.0, 0.5, 2.0, -0.3, 1.1]
+    x_pyc = pycoeus.Tensor(x_data, [5])
+    m = pycoeus.Dropout(p=0.5)
+    y_pyc = m.forward(x_pyc)
+
+    x_j = jnp.asarray(x_data, dtype=jnp.float64)
+    # Eval mode: no dropout applied → output == input
+    _allclose("dropout_eval", list(y_pyc.data), x_j.flatten().tolist(), atol=1e-15)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -3132,3 +3132,110 @@ def test_ctc_loss_matches_pytorch() -> None:
         f"CTC loss mismatch: pycoeus={loss_pyc.data[0]:.8g}, "
         f"pytorch={loss_t.item():.8g}, diff={diff:.3e}"
     )
+
+
+# ---------------------------------------------------------------------------
+# MS-219 loss family PyTorch parity (smooth_l1, hinge_embedding, gaussian_nll,
+# multi_label_soft_margin)
+# ---------------------------------------------------------------------------
+
+
+def test_smooth_l1_loss_beta05_matches_pytorch() -> None:
+    """Smooth L1 loss with beta=0.5 on 1D input [4].
+
+    oracle: |diff| < 0.5 → 0.5*diff^2/beta, else |diff|-0.5*beta
+    """
+    import torch.nn.functional as F_
+
+    x_data = [0.5, -1.2, 2.0, -0.3]
+    t_data = [0.0, 0.0, 1.0, 1.0]
+    beta = 0.5
+
+    x_pyc = pycoeus.Tensor(x_data, [4], requires_grad=True)
+    loss_pyc = pycoeus.smooth_l1_loss(x_pyc, pycoeus.Tensor(t_data, [4]), beta=beta)
+    loss_pyc.backward()
+
+    x_t = torch.tensor(x_data, dtype=torch.float64, requires_grad=True)
+    t_t = torch.tensor(t_data, dtype=torch.float64)
+    loss_t = F_.smooth_l1_loss(x_t, t_t, beta=beta)
+    loss_t.backward()
+
+    _allclose("smooth_l1_beta05", [loss_pyc.data[0]], [loss_t.item()], atol=1e-10)
+    _allclose("smooth_l1_beta05_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-10)
+
+
+def test_hinge_embedding_loss_matches_pytorch() -> None:
+    """HingeEmbeddingLoss on [4] with margin=1.0.
+
+    target[i] = +1: loss = x[i]; target[i] = -1: loss = max(0, margin - x[i])
+    mean reduction.
+    """
+    import torch.nn.functional as F_
+
+    x_data = [0.8, 1.5, -0.5, 0.2]
+    targets = [1.0, -1.0, 1.0, -1.0]
+
+    x_pyc = pycoeus.Tensor(x_data, [4], requires_grad=True)
+    loss_pyc = pycoeus.hinge_embedding_loss(x_pyc, targets, margin=1.0)
+    loss_pyc.backward()
+
+    x_t = torch.tensor(x_data, dtype=torch.float64, requires_grad=True)
+    t_t = torch.tensor(targets, dtype=torch.float64)
+    loss_t = F_.hinge_embedding_loss(x_t, t_t, margin=1.0)
+    loss_t.backward()
+
+    _allclose("hinge_embedding", [loss_pyc.data[0]], [loss_t.item()], atol=1e-10)
+    _allclose("hinge_embedding_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-10)
+
+
+def test_gaussian_nll_loss_matches_pytorch() -> None:
+    """GaussianNLLLoss on [2, 3] (input, target, var), full=False.
+
+    var kept > 0 to avoid log(0).
+    """
+    import torch.nn.functional as F_
+
+    inp = [0.5, -0.5, 1.0, 0.2, -0.3, 0.8]
+    tgt = [0.0, 0.0, 1.0, 0.5, -0.5, 1.0]
+    var = [0.5, 0.3, 0.8, 0.4, 0.6, 0.9]
+
+    x_pyc = pycoeus.Tensor(inp, [2, 3], requires_grad=True)
+    t_pyc = pycoeus.Tensor(tgt, [2, 3])
+    v_pyc = pycoeus.Tensor(var, [2, 3])
+    loss_pyc = pycoeus.gaussian_nll_loss(x_pyc, t_pyc, v_pyc)
+    loss_pyc.backward()
+
+    x_t = torch.tensor(inp, dtype=torch.float64, requires_grad=True)
+    t_t = torch.tensor(tgt, dtype=torch.float64)
+    v_t = torch.tensor(var, dtype=torch.float64)
+    loss_t = F_.gaussian_nll_loss(x_t, t_t, v_t)
+    loss_t.backward()
+
+    _allclose("gaussian_nll", [loss_pyc.data[0]], [loss_t.item()], atol=1e-8)
+    _allclose("gaussian_nll_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-8)
+
+
+def test_multi_label_soft_margin_matches_pytorch() -> None:
+    """MultiLabelSoftMarginLoss on [2, 4] — delegates to BCE-with-logits internally."""
+    import torch.nn.functional as F_
+
+    x_data = [0.5, -1.2, 2.0, -0.3, 1.0, 0.8, -0.5, 0.3]
+    t_data = [1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0]
+
+    x_pyc = pycoeus.Tensor(x_data, [2, 4], requires_grad=True)
+    t_pyc = pycoeus.Tensor(t_data, [2, 4])
+    loss_pyc = pycoeus.multi_label_soft_margin_loss(x_pyc, t_pyc)
+    loss_pyc.backward()
+
+    x_t = torch.tensor(x_data, dtype=torch.float64, requires_grad=True)
+    t_t = torch.tensor(t_data, dtype=torch.float64).reshape(2, 4)
+    loss_t = F_.multilabel_soft_margin_loss(x_t.reshape(2, 4), t_t)
+    loss_t.backward()
+
+    _allclose("multi_label_soft_margin", [loss_pyc.data[0]], [loss_t.item()], atol=1e-10)
+    _allclose(
+        "multi_label_soft_margin_dx",
+        list(x_pyc.grad),
+        x_t.grad.flatten().tolist(),
+        atol=1e-10,
+    )


### PR DESCRIPTION
Adds 4 PyTorch parity tests (smooth_l1/beta=0.5, hinge_embedding, gaussian_nll, multi_label_soft_margin) + 2 JAX tests (Mish fwd+grad, Dropout eval identity). 83 PyTorch + 35 JAX tests total.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds six new parity tests for the pycoeus library, comparing its implementations against reference frameworks. Four new loss function tests (`smooth_l1_loss` with beta=0.5, `hinge_embedding_loss`, `gaussian_nll_loss`, and `multi_label_soft_margin_loss`) verify PyTorch parity, while two activation/regularization tests (`Mish` forward and gradient, and `Dropout` eval mode identity) verify JAX parity. The tests ensure numerical consistency with tolerances ranging from 1e-8 to 1e-15, bringing the total test suite to 83 PyTorch tests and 35 JAX tests.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->