### PR TITLE
perf(optim): Raise SEQUENTIAL_THRESHOLD 4096->65536 from measured crossover

### DIFF
--- a/coeus-ops/src/backend_ops/cpu_impl/optim/mod.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/optim/mod.rs
@@ -9,18 +9,21 @@ use coeus_core::Backend;
 /// Element count at or below which an optimizer update runs sequentially instead
 /// of dispatching across the Moirai pool.
 ///
-/// Optimizer steps are light, memory-bandwidth-bound element-wise updates (a few
-/// FLOPs per element), so for small parameter tensors a single auto-vectorized
-/// loop beats the thread dispatch/join cost. This is deliberately the op-layer's
-/// threshold: `coeus-ops` knows the per-element work is cheap, so it raises the
-/// bar above Moirai's general-purpose `Adaptive` threshold (1024) before handing
-/// off to the pool.
+/// Optimizer steps are light, memory-bandwidth-bound element-wise updates, so the
+/// parallel path's fixed thread dispatch/join cost (~20 µs, measured) dominates
+/// until the tensor is large. This is deliberately the op-layer's threshold:
+/// `coeus-ops` knows the per-element work is cheap, so it sets the bar far above
+/// Moirai's general-purpose `Adaptive` threshold (1024) before handing to the pool.
 ///
-/// Note: benchmark evidence (`coeus-optim/benches/optim_bench.rs`) indicates the
-/// parallel path stays slower than sequential well past this value for these
-/// ops; tuning `SEQUENTIAL_THRESHOLD` upward is tracked as a follow-up requiring a
-/// derived sequential-vs-parallel crossover measurement across sizes.
-const SEQUENTIAL_THRESHOLD: usize = 4096;
+/// Derived from `coeus-optim/benches/optim_bench.rs` sequential-vs-parallel
+/// crossover measurements (f32, MoiraiBackend). Per-op sequential wins hold up to
+/// roughly SGD ~425K elements, Adam ~130K (heavier per element → lower crossover).
+/// A single shared threshold must not regress the heaviest op, so it sits below the
+/// *minimum* crossover (Adam's) with margin: at 65_536 both are decisively
+/// sequential (SGD 10.7 vs 38 µs; Adam 33 vs 57 µs, non-overlapping CIs) — a 16×
+/// lift over the previous 4096 across the common small/medium range. Above it both
+/// dispatch to the pool (parallel wins for SGD by ~1M, Adam by ~260K).
+const SEQUENTIAL_THRESHOLD: usize = 65_536;
 
 /// Apply `f(i)` for every `i in 0..numel`, sequentially below
 /// [`SEQUENTIAL_THRESHOLD`] (no dispatch/join overhead) or across Moirai's pool

--- a/coeus-optim/benches/optim_bench.rs
+++ b/coeus-optim/benches/optim_bench.rs
@@ -10,7 +10,7 @@ use coeus_tensor::Tensor;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 /// Representative parameter tensor sizes: small layer, medium, large embedding.
-const SIZES: [usize; 3] = [1_024, 16_384, 262_144];
+const SIZES: [usize; 5] = [4_096, 16_384, 65_536, 262_144, 1_048_576];
 
 fn make_param(n: usize) -> Var<f32, MoiraiBackend> {
     let data: Vec<f32> = (0..n).map(|i| (i % 7) as f32 * 0.1 - 0.3).collect();


### PR DESCRIPTION
## Summary
Completes the documented follow-up to the optimizer sequential fast-path (#129): replaces the placeholder `SEQUENTIAL_THRESHOLD = 4096` with a value **derived from benchmarked sequential-vs-parallel crossovers**.

## Measured crossover (`coeus-optim/benches/optim_bench.rs`, f32/MoiraiBackend), seq vs parallel

| size | SGD seq | SGD par | Adam seq | Adam par |
|---|---|---|---|---|
| 16384 | 2.26µs | 22µs | 7.6µs | 38µs |
| 65536 | 10.7µs | 38µs | 33µs | 57µs |
| 262144 | 46µs | 90µs | 125µs | **98µs** |
| 1048576 | 651µs | **483µs** | 548µs | 267µs |

Sequential wins up to ~425K (SGD) and ~130K (Adam — heavier per element, lower crossover). The parallel path carries a fixed **~20µs dispatch/join overhead** that dominates until the tensor is large.

## Choice
A single shared threshold must not regress the heaviest op, so it sits **below the minimum crossover (Adam's ~130K) with margin: 65536**, where both are decisively sequential (non-overlapping CIs). Net wins over 4096: **SGD 16384 ~10×, 65536 ~3.6×; Adam 16384 ~5×, 65536 ~1.7×**. Above 65536 both dispatch to the pool unchanged → **no regression for large tensors**.

## Verification
Correctness is dispatch-only (identical arithmetic) — **14/14 coeus-optim tests pass**; fmt + clippy `-D warnings` clean. Package-local to `coeus-ops`; the threshold decision stays in the op layer (which knows the per-element cost), using moirai's `parallel_for` mechanism unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR raises the `SEQUENTIAL_THRESHOLD` constant from 4096 to 65536 for optimizer operations based on empirical benchmark data. The change optimizes performance by keeping sequential execution for larger tensors where the fixed ~20µs thread dispatch overhead makes parallelization slower. The new threshold is derived from measured crossover points where SGD wins sequentially up to ~425K elements and Adam up to ~130K elements, with 65536 chosen conservatively below the minimum (Adam's crossover) to avoid regressions. The benchmark test suite is expanded to include more representative tensor sizes (4096, 16384, 65536, 262144, and 1048576) to validate these measurements.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-optim/benches/optim_bench.rs` |
| 2 | `coeus-ops/src/backend_ops/cpu_impl/optim/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->