### PR TITLE
test(fft): Cover arbitrary (non-power-of-2) FFT lengths

### DIFF
--- a/coeus-fft/tests/fft.rs
+++ b/coeus-fft/tests/fft.rs
@@ -12,6 +12,39 @@ fn assert_close(actual: f64, expected: f64, label: &str) {
 }
 
 #[test]
+fn fft_1d_prime_length_matches_dft() {
+    // Non-power-of-2 (prime N=3) exercises Apollo's mixed-radix/Bluestein path.
+    // Closed-form DFT of [1,2,3]: X0=6, X1=-1.5 + (sqrt3/2)i, X2=conj(X1).
+    let s3 = 3.0_f64.sqrt() / 2.0;
+    let signal = Tensor::<f64, MoiraiBackend>::from_slice([3], &[1.0, 2.0, 3.0]);
+    let spectrum = fft_1d(&signal);
+    let expected = [
+        Complex::new(6.0, 0.0),
+        Complex::new(-1.5, s3),
+        Complex::new(-1.5, -s3),
+    ];
+    for (i, (&got, &want)) in spectrum.as_slice().iter().zip(expected.iter()).enumerate() {
+        assert_close(got.re, want.re, &format!("N3 X{i}.re"));
+        assert_close(got.im, want.im, &format!("N3 X{i}.im"));
+    }
+}
+
+#[test]
+fn fft_1d_arbitrary_length_roundtrips() {
+    // ifft(fft(x)) == x for a range of non-power-of-2 lengths (prime, composite),
+    // confirming Apollo handles arbitrary N and that the 1/N inverse normalization
+    // holds regardless of factorization.
+    for n in [3usize, 5, 6, 7, 9, 15] {
+        let data: Vec<f64> = (0..n).map(|i| (i as f64 * 0.37).sin() - 0.2).collect();
+        let signal = Tensor::<f64, MoiraiBackend>::from_slice([n], &data);
+        let recon = ifft_1d(&fft_1d(&signal));
+        for (i, (&r, &x)) in recon.as_slice().iter().zip(data.iter()).enumerate() {
+            assert_close(r, x, &format!("N{n} roundtrip[{i}]"));
+        }
+    }
+}
+
+#[test]
 fn fft_1d_matches_hand_dft_and_roundtrips() {
     let signal = Tensor::<f64, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]);
     let spectrum = fft_1d(&signal);


### PR DESCRIPTION
## Summary
All `coeus-fft` tests used power-of-2 lengths (N=4/8), leaving Apollo's mixed-radix/Bluestein path for **arbitrary N** unverified — a real correctness property with no coverage.

- **`fft_1d_prime_length_matches_dft`** — closed-form DFT of `[1,2,3]` (prime N=3): X0=6, X1=−1.5+(√3/2)i, X2=conj(X1).
- **`fft_1d_arbitrary_length_roundtrips`** — `ifft(fft(x)) == x` for N ∈ {3,5,6,7,9,15} (prime + composite), confirming arbitrary-N support and that the 1/N inverse normalization holds regardless of factorization.

Both pass → confirms and locks in non-power-of-2 correctness. **7/7** coeus-fft tests pass; fmt + clippy `-D warnings` clean. Package-local (`coeus-fft`), disjoint from concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds test coverage for non-power-of-2 FFT lengths in the `coeus-fft` module. Previously, all tests only exercised power-of-2 lengths (N=4/8), leaving the mixed-radix and Bluestein algorithm paths for arbitrary N values untested. Two new tests are introduced: `fft_1d_prime_length_matches_dft` validates correctness against a closed-form DFT for prime length N=3, while `fft_1d_arbitrary_length_roundtrips` confirms that `ifft(fft(x)) == x` holds for various non-power-of-2 lengths including primes (3, 5, 7) and composites (6, 9, 15). This establishes correctness guarantees for arbitrary-length FFTs and ensures proper inverse normalization across different factorizations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-fft/tests/fft.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->