### PR TITLE
test(python): Interpolation PyTorch + RotaryEmbedding JAX parity (MS-232)

### DIFF
--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1447,3 +1447,55 @@ def test_batchnorm1d_eval_matches_jax() -> None:
 
     _allclose("bn1d_eval_jax", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-10)
 
+
+
+# ---------------------------------------------------------------------------
+# RotaryEmbedding (RoPE) JAX parity (MS-232)
+# ---------------------------------------------------------------------------
+
+
+def test_rotary_embedding_matches_jax() -> None:
+    """RotaryEmbedding forward parity against inline JAX RoPE formula.
+
+    GPT-NeoX/LLaMA-style RoPE:
+    theta_i = base^(-2i/d) for i in [0, d//2)
+    angle(pos, i) = pos * theta_i
+    cos_table[pos, i] = cos_table[pos, i + d//2] = cos(angle(pos, i))
+    sin_table[pos, i] = sin_table[pos, i + d//2] = sin(angle(pos, i))
+
+    x_rotated = x * cos + rotate_half(x) * sin
+    rotate_half([x1, x2]) = [-x2, x1] (split in halves, not alternating)
+    """
+    if not hasattr(pycoeus, "RotaryEmbedding"):
+        pytest.skip("pycoeus.RotaryEmbedding not available")
+
+    batch, seq, heads, d_head = 1, 4, 2, 8
+    max_len = 16
+    base = 10000.0
+    data = [float(i) * 0.05 - 0.5 for i in range(batch * seq * heads * d_head)]
+
+    rope_pyc = pycoeus.RotaryEmbedding(max_len=max_len, d_head=d_head, base=base)
+    x_pyc = pycoeus.Tensor(data, [batch, seq, heads, d_head])
+    y_pyc = rope_pyc.forward(x_pyc)
+
+    # JAX reference — GPT-NeoX style duplicate cos/sin
+    x_j = jnp.asarray(data, dtype=jnp.float64).reshape(batch, seq, heads, d_head)
+    half = d_head // 2
+    positions = jnp.arange(seq, dtype=jnp.float64)
+    freqs = base ** (-2.0 * jnp.arange(half, dtype=jnp.float64) / d_head)
+    angles = positions[:, None] * freqs[None, :]  # [seq, half]
+    cos_t = jnp.concatenate([jnp.cos(angles), jnp.cos(angles)], axis=-1)  # [seq, d_head]
+    sin_t = jnp.concatenate([jnp.sin(angles), jnp.sin(angles)], axis=-1)
+
+    # reshape for [batch, seq, 1, d_head] broadcast
+    cos_t = cos_t[None, :, None, :]  # [1, seq, 1, d_head]
+    sin_t = sin_t[None, :, None, :]
+
+    # rotate_half: [x[:half], x[half:]] → [-x[half:], x[:half]]
+    x_first = x_j[..., :half]
+    x_second = x_j[..., half:]
+    x_rot = jnp.concatenate([-x_second, x_first], axis=-1)
+
+    y_j = x_j * cos_t + x_rot * sin_t
+
+    _allclose("rope", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-9)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -3360,3 +3360,56 @@ def test_sinusoidal_encoding_matches_pytorch() -> None:
 
     _allclose("sinusoidal_encoding", list(y_pyc.data), expected, atol=1e-10)
 
+
+
+# ---------------------------------------------------------------------------
+# Interpolation parity (MS-232)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "interpolate"),
+    reason="pycoeus.interpolate not available in this build",
+)
+def test_interpolate_nearest_1d_matches_pytorch() -> None:
+    """Nearest-neighbour 1D interpolation on [2, 3, 4] → [2, 3, 8].
+
+    Uses torch.nn.functional.interpolate with mode='nearest' at f64.
+    """
+    import torch.nn.functional as F_
+
+    n, c, l = 2, 3, 4
+    new_l = 8
+    data = [float(i) * 0.1 - 0.5 for i in range(n * c * l)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, l])
+    y_pyc = pycoeus.interpolate(x_pyc, [new_l], mode="nearest")
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, l)
+    y_t = F_.interpolate(x_t, size=new_l, mode="nearest")
+
+    _allclose("interpolate_nearest_1d", list(y_pyc.data), y_t.flatten().tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "interpolate"),
+    reason="pycoeus.interpolate not available in this build",
+)
+def test_interpolate_nearest_2d_matches_pytorch() -> None:
+    """Nearest-neighbour 2D interpolation on [1, 2, 3, 3] → [1, 2, 6, 6].
+
+    Uses torch.nn.functional.interpolate with mode='nearest' at f64.
+    """
+    import torch.nn.functional as F_
+
+    n, c, h, w = 1, 2, 3, 3
+    new_h, new_w = 6, 6
+    data = [float(i) * 0.25 - 1.0 for i in range(n * c * h * w)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w])
+    y_pyc = pycoeus.interpolate(x_pyc, [new_h, new_w], mode="nearest")
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, h, w)
+    y_t = F_.interpolate(x_t, size=(new_h, new_w), mode="nearest")
+
+    _allclose("interpolate_nearest_2d", list(y_pyc.data), y_t.flatten().tolist(), atol=1e-10)


### PR DESCRIPTION
2 PyTorch interpolation parity tests (nearest 1D/2D upsampling at f64) + 1 JAX RoPE parity test (GPT-NeoX style). 88 PyTorch + 47 JAX tests total.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds three new parity tests to verify framework compatibility: two tests for PyTorch nearest-neighbor interpolation (1D and 2D upsampling) at float64 precision, and one test for JAX Rotary Position Embedding (RoPE) using GPT-NeoX style implementation. The tests ensure that the `pycoeus` library's `interpolate` function and `RotaryEmbedding` module produce identical outputs to their PyTorch and JAX reference implementations respectively.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->