### PR TITLE
bench(nn): LogSigmoid + Softplus benchmark rows (MS-233, G-043 to 44 rows)

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -1862,6 +1862,75 @@ fn bench_softmax_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_log_sigmoid_forward(c: &mut Criterion) {
+    // LogSigmoid = log(sigmoid(x)) = -softplus(-x).
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0031).sin())
+        .collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let mut group = c.benchmark_group("Burn vs Coeus — LogSigmoid forward (128x256)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn::tensor::activation::log_sigmoid(black_box(
+                x_burn.clone(),
+            )))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_nn::log_sigmoid(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_nn::log_sigmoid(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
+fn bench_softplus_forward(c: &mut Criterion) {
+    // Softplus = log(1 + exp(x)), beta=1 (Burn's default).
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0031).sin())
+        .collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let mut group = c.benchmark_group("Burn vs Coeus — Softplus forward (128x256, beta=1)");
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| {
+            black_box(burn::tensor::activation::softplus(
+                black_box(x_burn.clone()),
+                1.0,
+            ))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_nn::softplus(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_nn::softplus(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -1901,6 +1970,8 @@ criterion_group!(
     bench_silu_forward,
     bench_leaky_relu_forward,
     bench_mish_forward,
+    bench_log_sigmoid_forward,
+    bench_softplus_forward,
     bench_dropout_forward,
     bench_maxpool1d_forward,
     bench_avgpool1d_forward,


### PR DESCRIPTION
Two activation benchmark rows: LogSigmoid and Softplus. G-043 matrix grows to 44 rows.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds benchmark rows for two activation functions: `LogSigmoid` and `Softplus`. Both benchmarks compare performance across three implementations (Burn NdArray, Coeus Sequential, and Coeus Moirai) using 128x256 input tensors. The benchmarks follow the established pattern of other activation function benchmarks in the file, expanding the benchmark matrix to 44 rows as noted in the PR description.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->