### PR TITLE
refactor(nn): Move GLU autograd from Python binding into coeus-nn

### DIFF
--- a/coeus-nn/src/activation.rs
+++ b/coeus-nn/src/activation.rs
@@ -186,6 +186,36 @@ pub fn gelu_tanh<T: Float, B: coeus_ops::BackendOps<T> + Default>(input: &Var<T,
     coeus_autograd::gelu_tanh(input)
 }
 
+/// Functional Gated Linear Unit along `dim` (`torch.nn.functional.glu`).
+///
+/// Splits `input` into two equal halves `[a, b]` along `dim` and gates the first
+/// by the sigmoid of the second: `a * sigmoid(b)`. Differentiable — composed from
+/// tracked `slice`, `sigmoid`, and `mul`, so gradients flow to `input`.
+///
+/// # Panics
+/// If `dim` is out of range or the extent along `dim` is odd.
+pub fn glu<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    dim: usize,
+) -> Var<T, B> {
+    let shape = input.tensor.shape();
+    let ndim = shape.len();
+    assert!(dim < ndim, "glu: dim {dim} out of range for rank {ndim}");
+    let axis = shape[dim];
+    assert!(
+        axis.is_multiple_of(2),
+        "glu: dim {dim} must have even extent, got {axis}"
+    );
+    let half = axis / 2;
+    let mut first: Vec<(usize, usize)> = shape.iter().map(|&extent| (0, extent)).collect();
+    let mut second = first.clone();
+    first[dim] = (0, half);
+    second[dim] = (half, axis);
+    let a = coeus_autograd::slice(input, &first);
+    let b = coeus_autograd::slice(input, &second);
+    coeus_autograd::mul(&a, &coeus_autograd::sigmoid(&b))
+}
+
 /// GELU tanh approximation module.
 #[derive(Clone, Debug, Default)]
 pub struct GeLUTanh;

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -69,7 +69,7 @@ pub mod swiglu;
 pub mod transformer;
 
 pub use activation::{
-    celu, elu, gelu, gelu_tanh, hardshrink, hardsigmoid, hardswish, hardtanh, leaky_relu,
+    celu, elu, gelu, gelu_tanh, glu, hardshrink, hardsigmoid, hardswish, hardtanh, leaky_relu,
     log_sigmoid, mish, prelu, relu, sigmoid, silu, softplus, softshrink, softsign, tanh,
     tanhshrink, threshold, Celu, CeluOp, GeLU, GeLUTanh, Hardshrink, HardshrinkOp, Hardsigmoid,
     HardsigmoidOp, Hardswish, HardswishOp, Hardtanh, HardtanhOp, LeakyReLU, LogSigmoid, Mish,

--- a/coeus-nn/tests/nn_activation_tests.rs
+++ b/coeus-nn/tests/nn_activation_tests.rs
@@ -1,6 +1,8 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
-use coeus_nn::{elu, gelu_tanh, leaky_relu, softplus, GeLUTanh, LeakyReLU, Module, Softplus, ELU};
+use coeus_nn::{
+    elu, gelu_tanh, glu, leaky_relu, softplus, GeLUTanh, LeakyReLU, Module, Softplus, ELU,
+};
 use coeus_tensor::{Tensor, Transpose};
 
 #[test]
@@ -207,4 +209,36 @@ fn test_non_contiguous_activations() {
     assert_eq!(output_leaky.tensor.shape(), &[3, 2]);
     output_leaky.backward();
     assert!(input2.grad().is_some());
+}
+
+#[test]
+fn test_glu_forward_and_gradient() {
+    // input=[1,2,3,4], dim=0 -> halves a=[1,2], b=[3,4]; glu = a * sigmoid(b).
+    // out = [1*sigma(3), 2*sigma(4)].
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([4], &[1.0, 2.0, 3.0, 4.0]),
+        true,
+    );
+    let sig = |x: f64| 1.0 / (1.0 + (-x).exp());
+    let (s3, s4) = (sig(3.0), sig(4.0));
+
+    let out = glu(&input, 0);
+    assert_eq!(out.tensor.shape(), &[2]);
+    let o = out.tensor.as_slice();
+    assert!((o[0] - 1.0 * s3).abs() < 1e-12, "glu[0]: {}", o[0]);
+    assert!((o[1] - 2.0 * s4).abs() < 1e-12, "glu[1]: {}", o[1]);
+
+    // grad of sum(glu): d/da_i = sigma(b_i); d/db_i = a_i * sigma(b_i)(1-sigma(b_i)).
+    out.backward();
+    let g = input.grad().expect("glu input grad");
+    let gs = g.as_slice();
+    let expected = [
+        s3,                    // d/d input[0] (a0)
+        s4,                    // d/d input[1] (a1)
+        1.0 * s3 * (1.0 - s3), // d/d input[2] (b0)
+        2.0 * s4 * (1.0 - s4), // d/d input[3] (b1)
+    ];
+    for (i, (&got, &want)) in gs.iter().zip(expected.iter()).enumerate() {
+        assert!((got - want).abs() < 1e-12, "glu grad[{i}]: {got} vs {want}");
+    }
 }

--- a/coeus-python/src/activations.rs
+++ b/coeus-python/src/activations.rs
@@ -80,39 +80,22 @@ pub fn leaky_relu(input: &PyTensor, negative_slope: f64, py: Python<'_>) -> PyTe
 pub fn glu(input: &PyTensor, dim: isize, py: Python<'_>) -> PyResult<PyTensor> {
     let shape = input.inner.tensor.shape();
     let ndim = shape.len();
-    let dim = if dim < 0 {
-        let normalized = ndim as isize + dim;
-        if normalized < 0 {
-            return Err(PyValueError::new_err(format!(
-                "glu: dim {dim} out of range for rank {ndim}"
-            )));
-        }
-        normalized as usize
-    } else {
-        dim as usize
-    };
-    if dim >= ndim {
+    let normalized = if dim < 0 { ndim as isize + dim } else { dim };
+    if normalized < 0 || normalized as usize >= ndim {
         return Err(PyValueError::new_err(format!(
             "glu: dim {dim} out of range for rank {ndim}"
         )));
     }
-    let axis = shape[dim];
-    if !axis.is_multiple_of(2) {
+    let dim = normalized as usize;
+    if !shape[dim].is_multiple_of(2) {
         return Err(PyValueError::new_err(format!(
-            "glu: dim {dim} must have even size, got {axis}"
+            "glu: dim {dim} must have even size, got {}",
+            shape[dim]
         )));
     }
-    let half = axis / 2;
-    let mut first_ranges: Vec<(usize, usize)> = shape.iter().map(|&extent| (0, extent)).collect();
-    let mut second_ranges = first_ranges.clone();
-    first_ranges[dim] = (0, half);
-    second_ranges[dim] = (half, axis);
-    let inner = py.allow_threads(|| {
-        let first = coeus_autograd::slice(&input.inner, &first_ranges);
-        let second = coeus_autograd::slice(&input.inner, &second_ranges);
-        let gate = coeus_autograd::sigmoid(&second);
-        coeus_autograd::mul(&first, &gate)
-    });
+    // GLU algorithm lives in coeus-nn; the binding only normalizes the Python
+    // negative-dim convention and maps invalid arguments to a Python exception.
+    let inner = py.allow_threads(|| coeus_nn::glu(&input.inner, dim));
     Ok(PyTensor::from_var(inner))
 }
 


### PR DESCRIPTION
## Summary
Differentiable **GLU** existed **only as inline logic in the `coeus-python` binding** (`activations.rs` composed `slice`/`sigmoid`/`mul` on `Var`); coeus proper had no autograd `glu` (coeus-ops has only a tensor-level, non-autograd one). That put domain logic in the PyO3 layer and left GLU absent from the Rust API — violating "coeus-python is purely pyo3 wrapping" and the G-037 activation-parity goal.

- **Add `coeus_nn::glu(input, dim)`** — differentiable, composed from tracked `slice`/`sigmoid`/`mul`: splits along `dim` into `[a, b]`, returns `a * sigmoid(b)`.
- **Repoint the Python binding** to call `coeus_nn::glu`; it now only normalizes the Python negative-dim convention and maps invalid args to a `PyValueError` — pure wrapping, no algorithm.

Closes the GLU portion of G-037 in coeus proper, makes GLU testable/reusable from Rust, and keeps a single definition (DRY / SoC / package-locality — activation math in coeus, not the binding).

## Verification
- `test_glu_forward_and_gradient`: forward `a*sigmoid(b)` + **exact analytic input gradient** (`∂/∂a=σ(b)`, `∂/∂b=a·σ(b)(1−σ(b))`).
- 6/6 `nn_activation_tests` pass; `coeus-python` compiles against the new API; fmt + clippy `--all-targets -D warnings` clean.
- Staged surgically — concurrent peer edits (`moirai.rs`, `nn_bench.rs`, `test_pytorch_parity.py`) left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the Gated Linear Unit (GLU) activation function by moving its differentiable implementation from the Python binding layer (`coeus-python`) into the core `coeus-nn` library. Previously, the GLU logic was inlined in the PyO3 binding, which violated separation of concerns. The new `coeus_nn::glu` function implements the algorithm (splitting input along a dimension and computing `a * sigmoid(b)`), while the Python binding now only handles dimension normalization and error translation. This change makes GLU available to Rust code, improves testability, and ensures proper layering where domain logic lives in the core library rather than the binding layer.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/activation.rs` |
| 2 | `coeus-nn/src/lib.rs` |
| 3 | `coeus-nn/tests/nn_activation_tests.rs` |
| 4 | `coeus-python/src/activations.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GLU activation option for neural network workflows.
  * Exposed the activation in both the Rust and Python APIs.

* **Bug Fixes**
  * Improved input validation for the activation by checking dimension bounds and requiring an even-sized split dimension.
  * Better handles negative dimension values in the Python interface.

* **Tests**
  * Added coverage for forward results and gradient behavior of the new activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->