### PR TITLE
feat(nn): Add GLU activation Module for Sequential composition

### DIFF
--- a/coeus-nn/src/activation.rs
+++ b/coeus-nn/src/activation.rs
@@ -216,6 +216,35 @@ pub fn glu<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     coeus_autograd::mul(&a, &coeus_autograd::sigmoid(&b))
 }
 
+/// Gated Linear Unit module gating along a fixed `dim` (see [`glu`]).
+///
+/// Parameter-free; the split dimension is captured at construction so `GLU` can
+/// participate in a [`Sequential`](crate::Sequential) stack like other activations.
+#[derive(Clone, Copy, Debug)]
+pub struct GLU {
+    dim: usize,
+}
+
+impl GLU {
+    /// Create a GLU module that gates along `dim`.
+    #[inline]
+    #[must_use]
+    pub fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for GLU {
+    #[inline]
+    fn parameters(&self) -> Vec<Var<T, B>> {
+        vec![]
+    }
+    #[inline]
+    fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
+        glu(input, self.dim)
+    }
+}
+
 /// GELU tanh approximation module.
 #[derive(Clone, Debug, Default)]
 pub struct GeLUTanh;

--- a/coeus-nn/src/lib.rs
+++ b/coeus-nn/src/lib.rs
@@ -72,7 +72,7 @@ pub use activation::{
     celu, elu, gelu, gelu_tanh, glu, hardshrink, hardsigmoid, hardswish, hardtanh, leaky_relu,
     log_sigmoid, mish, prelu, relu, sigmoid, silu, softplus, softshrink, softsign, tanh,
     tanhshrink, threshold, Celu, CeluOp, GeLU, GeLUTanh, Hardshrink, HardshrinkOp, Hardsigmoid,
-    HardsigmoidOp, Hardswish, HardswishOp, Hardtanh, HardtanhOp, LeakyReLU, LogSigmoid, Mish,
+    HardsigmoidOp, Hardswish, HardswishOp, Hardtanh, HardtanhOp, LeakyReLU, LogSigmoid, Mish, GLU,
     PReLU, ReLU, SiLU, Sigmoid, Softplus, Softshrink, SoftshrinkOp, Softsign, SoftsignOp, Tanh,
     Tanhshrink, Threshold, ThresholdNode, ELU,
 };

--- a/coeus-nn/tests/nn_activation_tests.rs
+++ b/coeus-nn/tests/nn_activation_tests.rs
@@ -1,7 +1,7 @@
 use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
-    elu, gelu_tanh, glu, leaky_relu, softplus, GeLUTanh, LeakyReLU, Module, Softplus, ELU,
+    elu, gelu_tanh, glu, leaky_relu, softplus, GeLUTanh, LeakyReLU, Module, Softplus, ELU, GLU,
 };
 use coeus_tensor::{Tensor, Transpose};
 
@@ -240,5 +240,27 @@ fn test_glu_forward_and_gradient() {
     ];
     for (i, (&got, &want)) in gs.iter().zip(expected.iter()).enumerate() {
         assert!((got - want).abs() < 1e-12, "glu grad[{i}]: {got} vs {want}");
+    }
+}
+
+#[test]
+fn test_glu_module_matches_function() {
+    // The GLU module (parameter-free) must forward identically to the `glu` function.
+    let data = [0.5f64, -1.0, 2.0, 0.25, 3.0, -0.5];
+    let input = Var::new(Tensor::<f64, MoiraiBackend>::from_slice([6], &data), true);
+    let module = GLU::new(0);
+    assert!(Module::<f64, MoiraiBackend>::parameters(&module).is_empty());
+
+    let via_module = module.forward(&input);
+    let via_fn = glu(&input, 0);
+    assert_eq!(via_module.tensor.shape(), via_fn.tensor.shape());
+    for (i, (&m, &f)) in via_module
+        .tensor
+        .as_slice()
+        .iter()
+        .zip(via_fn.tensor.as_slice())
+        .enumerate()
+    {
+        assert!((m - f).abs() < 1e-15, "GLU module vs fn [{i}]: {m} vs {f}");
     }
 }


### PR DESCRIPTION
## Summary
The `glu` function (added in #138) landed without the `Module` wrapper that every other activation has (`ReLU`/`GeLU`/`LeakyReLU`/…), so GLU couldn't participate in a `Sequential` stack.

- Adds a parameter-free **`GLU`** module capturing the split `dim` at construction; its `forward` delegates to `glu` — single implementation, no duplication.

## Verification
`test_glu_module_matches_function` asserts the module forwards **bit-identically** to the `glu` function and exposes no parameters; 7/7 `nn_activation_tests` pass; fmt + clippy `-D warnings` clean. Package-local (`coeus-nn`), disjoint from concurrent peer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a parameter-free `GLU` module wrapper around the existing `glu` function to enable its use in `Sequential` compositions, matching the pattern used by other activation functions like `ReLU`, `GeLU`, and `LeakyReLU`. The module captures the split dimension at construction and delegates its `forward` method to the underlying `glu` function, ensuring no code duplication. A new test verifies that the module produces identical results to the function.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/src/activation.rs` |
| 2 | `coeus-nn/src/lib.rs` |
| 3 | `coeus-nn/tests/nn_activation_tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->