### PR TITLE
feat(nn): Differentiable masked/causal softmax

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -51,6 +51,7 @@ pub use ops::{
     // Shape ops
     broadcast_to,
     cat,
+    causal_softmax,
     ceil,
     celu,
     clamp,
@@ -103,6 +104,7 @@ pub use ops::{
     log_sum_exp,
     margin_ranking_loss,
     masked_fill,
+    masked_softmax,
     matmul,
     // New axis reductions
     max_axis,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -34,10 +34,11 @@ pub use nn::{
     avg_pool1d, avg_pool2d, avg_pool3d, batchnorm1d, batchnorm2d, batchnorm3d, bce_with_logits,
     binary_cross_entropy, conv1d, conv2d, conv3d, conv_transpose1d, conv_transpose2d,
     conv_transpose3d, cosine_embedding_loss, cosine_similarity, cross_entropy_loss, ctc_loss,
-    dropout, fold1d, fold2d, huber_loss, kl_divergence, l1_loss, layernorm, log_softmax,
-    margin_ranking_loss, max_pool1d, max_pool2d, max_pool3d, multi_label_margin_loss, multi_margin,
-    nll_loss, pairwise_distance, poisson_nll, rmsnorm, sdp_attention, smooth_l1_loss, soft_margin,
-    softmax, unfold1d, unfold2d, AttentionMask, BatchNormArgs, CausalMask, NullMask,
+    causal_softmax, dropout, fold1d, fold2d, huber_loss, kl_divergence, l1_loss, layernorm,
+    log_softmax, margin_ranking_loss, masked_softmax, max_pool1d, max_pool2d, max_pool3d,
+    multi_label_margin_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm,
+    sdp_attention, smooth_l1_loss, soft_margin, softmax, unfold1d, unfold2d, AttentionMask,
+    BatchNormArgs, CausalMask, NullMask,
 };
 
 pub use embedding::{embedding, embedding_with_padding_idx};

--- a/coeus-autograd/src/ops/nn/masked_softmax.rs
+++ b/coeus-autograd/src/ops/nn/masked_softmax.rs
@@ -1,0 +1,195 @@
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::ops::nn::softmax::accumulate_softmax_grad;
+use crate::var::Var;
+use coeus_core::{CpuAddressableStorage, CpuAddressableStorageMut, Float, Scalar};
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+/// Autograd node for masked and causal softmax.
+///
+/// Stores the (masked) softmax output `y`. The reverse pass is the ordinary softmax
+/// jacobian applied to `y` (see [`accumulate_softmax_grad`]): masked positions hold
+/// `y = 0`, so they receive zero gradient and do not enter the per-row sum, and an
+/// all-masked row propagates zero — no `-inf`/`NaN` is ever formed.
+pub struct MaskedSoftmaxNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+    /// Accumulated gradient buffer for this node's output.
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// Tracked input (the pre-softmax scores).
+    pub inputs: Vec<Var<T, B>>,
+    /// Saved masked-softmax output `y` for backward.
+    pub y_clone: Tensor<T, B>,
+    /// Axis the softmax was reduced over.
+    pub dim_u: usize,
+    /// Trace label (`"masked_softmax"` / `"causal_softmax"`).
+    pub op: &'static str,
+}
+
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for MaskedSoftmaxNode<T, B> {
+    #[inline]
+    fn op_name(&self) -> &'static str {
+        self.op
+    }
+
+    #[inline]
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+
+    #[inline]
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    #[inline]
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        if let Some(Some(ref g_in)) = input_grads.get(0) {
+            accumulate_softmax_grad(grad_out, &self.y_clone, self.dim_u, g_in);
+        }
+    }
+}
+
+fn normalize_dim(dim: isize, ndim: usize, op: &str) -> usize {
+    let dim_u = if dim < 0 { ndim as isize + dim } else { dim };
+    assert!(
+        dim_u >= 0 && (dim_u as usize) < ndim,
+        "{op}: dim {dim} out of bounds for ndim={ndim}"
+    );
+    dim_u as usize
+}
+
+fn build_var<T, B>(input: &Var<T, B>, y_t: Tensor<T, B>, dim_u: usize, op: &'static str) -> Var<T, B>
+where
+    T: Float,
+    B: coeus_ops::BackendOps<T> + Default,
+{
+    let backend = B::default();
+    let requires_grad = crate::grad_mode::should_track_var(input);
+    let grad = requires_grad.then(|| {
+        Arc::new(GradBuffer::new(Tensor::zeros_on(
+            y_t.shape_cloned(),
+            &backend,
+        )))
+    });
+    let creator = grad.as_ref().map(|g| {
+        Arc::new(MaskedSoftmaxNode {
+            output_grad: g.clone(),
+            inputs: vec![input.clone()],
+            y_clone: y_t.clone(),
+            dim_u,
+            op,
+        }) as Arc<dyn BackwardNode<T, B>>
+    });
+    Var {
+        tensor: y_t,
+        grad,
+        creator,
+    }
+}
+
+/// Tracked masked softmax over `dim`.
+///
+/// Computes softmax across positions where `mask != 0`; masked positions (and any
+/// fully-masked row) are zero. Gradient flows to `input` only — `mask` is data.
+///
+/// # Panics
+/// If `dim` is out of range or `input`/`mask` shapes differ.
+#[must_use]
+pub fn masked_softmax<T, B>(input: &Var<T, B>, mask: &Tensor<T, B>, dim: isize) -> Var<T, B>
+where
+    T: Float,
+    B: coeus_ops::BackendOps<T> + Default,
+    B::DeviceBuffer<T>: CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
+{
+    let dim_u = normalize_dim(dim, input.tensor.ndim(), "masked_softmax");
+    let backend = B::default();
+    let y_t = coeus_ops::masked_softmax(&input.tensor, mask, dim_u, &backend);
+    build_var(input, y_t, dim_u, "masked_softmax")
+}
+
+/// Tracked causal (lower-triangular) softmax over `dim`: future positions are masked
+/// before softmax. Gradient flows to `input`.
+///
+/// # Panics
+/// If `dim` is out of range.
+#[must_use]
+pub fn causal_softmax<T, B>(input: &Var<T, B>, dim: isize) -> Var<T, B>
+where
+    T: Float,
+    B: coeus_ops::BackendOps<T> + Default,
+    B::DeviceBuffer<T>: CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
+{
+    let dim_u = normalize_dim(dim, input.tensor.ndim(), "causal_softmax");
+    let backend = B::default();
+    let y_t = coeus_ops::causal_softmax(&input.tensor, dim_u, &backend);
+    build_var(input, y_t, dim_u, "causal_softmax")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coeus_core::MoiraiBackend;
+
+    #[test]
+    fn masked_softmax_forward_and_gradient() {
+        // input=[[1,2,3]], mask=[[1,1,0]], dim=1: softmax over cols 0,1; col 2 -> 0.
+        let input =
+            Var::<f64, MoiraiBackend>::new(Tensor::from_slice([1, 3], &[1.0, 2.0, 3.0]), true);
+        let mask = Tensor::<f64, MoiraiBackend>::from_slice([1, 3], &[1.0, 1.0, 0.0]);
+        let out = masked_softmax(&input, &mask, 1);
+        let (e1, e2) = (1.0_f64.exp(), 2.0_f64.exp());
+        let (y0, y1) = (e1 / (e1 + e2), e2 / (e1 + e2));
+        let y = out.tensor.as_slice();
+        assert!((y[0] - y0).abs() < 1e-12);
+        assert!((y[1] - y1).abs() < 1e-12);
+        assert!(y[2].abs() < 1e-12, "masked position must be 0, got {}", y[2]);
+
+        // Seed grad_out=[1,0,0]: dx_k = y_k*(g_k - sum_j y_j g_j), sum = y0.
+        out.backward_with_seed(Tensor::from_slice([1, 3], &[1.0, 0.0, 0.0]));
+        let g = input.grad().unwrap();
+        let gs = g.as_slice();
+        assert!((gs[0] - y0 * (1.0 - y0)).abs() < 1e-12, "dx0: {}", gs[0]);
+        assert!((gs[1] - y1 * (-y0)).abs() < 1e-12, "dx1: {}", gs[1]);
+        assert!(gs[2].abs() < 1e-12, "masked input grad must be 0, got {}", gs[2]);
+    }
+
+    #[test]
+    fn masked_softmax_all_masked_row_is_zero_no_nan() {
+        // A fully-masked row must yield all-zero output and a finite all-zero gradient.
+        let input =
+            Var::<f64, MoiraiBackend>::new(Tensor::from_slice([1, 3], &[1.0, 2.0, 3.0]), true);
+        let mask = Tensor::<f64, MoiraiBackend>::from_slice([1, 3], &[0.0, 0.0, 0.0]);
+        let out = masked_softmax(&input, &mask, 1);
+        for &v in out.tensor.as_slice() {
+            assert_eq!(v, 0.0, "all-masked output must be 0");
+        }
+        out.backward();
+        for &v in input.grad().unwrap().as_slice() {
+            assert!(v.is_finite() && v == 0.0, "all-masked grad must be finite 0, got {v}");
+        }
+    }
+
+    #[test]
+    fn causal_softmax_is_lower_triangular_and_differentiable() {
+        // 2x2: row0 attends only to col0 (future masked); row1 to cols 0,1.
+        let input = Var::<f64, MoiraiBackend>::new(
+            Tensor::from_slice([2, 2], &[1.0, 2.0, 3.0, 4.0]),
+            true,
+        );
+        let out = causal_softmax(&input, 1);
+        let y = out.tensor.as_slice();
+        assert!((y[0] - 1.0).abs() < 1e-12, "causal row0 col0");
+        assert!(y[1].abs() < 1e-12, "causal row0 col1 must be masked (0)");
+        let (e3, e4) = (3.0_f64.exp(), 4.0_f64.exp());
+        assert!((y[2] - e3 / (e3 + e4)).abs() < 1e-12, "causal row1 col0");
+        assert!((y[3] - e4 / (e3 + e4)).abs() < 1e-12, "causal row1 col1");
+
+        out.backward();
+        assert!(input
+            .grad()
+            .unwrap()
+            .as_slice()
+            .iter()
+            .all(|v| v.is_finite()));
+    }
+}

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -10,6 +10,8 @@ pub mod dropout;
 pub mod log_softmax;
 /// Loss functions (BCE, cross-entropy, NLL, Huber, cosine embedding).
 pub mod loss;
+/// Masked and causal softmax operations.
+pub mod masked_softmax;
 /// Normalization layers (batchnorm, layernorm, rmsnorm).
 pub mod normalization;
 /// Pooling layers (max-pool, avg-pool 1D/2D/3D).
@@ -24,6 +26,7 @@ pub use conv::{
 };
 pub use dropout::dropout;
 pub use log_softmax::log_softmax;
+pub use masked_softmax::{causal_softmax, masked_softmax};
 pub use loss::{
     bce_with_logits, binary_cross_entropy, cosine_embedding_loss, cosine_similarity,
     cross_entropy_loss, ctc_loss, huber_loss, kl_divergence, l1_loss, margin_ranking_loss,

--- a/coeus-autograd/src/ops/nn/softmax.rs
+++ b/coeus-autograd/src/ops/nn/softmax.rs
@@ -35,16 +35,36 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sof
 
     #[inline]
     fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
-        let backend = B::default();
         if let Some(Some(ref g_in)) = input_grads.get(0) {
-            let gy = coeus_ops::mul(grad_out, &self.y_clone, &backend);
-            let sum_gy = coeus_ops::sum_axis(&gy, self.dim_u, &backend);
-            let mut dx = coeus_ops::sub(grad_out, &sum_gy, &backend);
-            coeus_ops::mul_assign(&mut dx, &self.y_clone, &backend);
-            let gl = g_in.write();
-            coeus_ops::add_assign(gl, &dx, &backend);
+            accumulate_softmax_grad(grad_out, &self.y_clone, self.dim_u, g_in);
         }
     }
+}
+
+/// Softmax reverse pass `dx = y * (grad_out - sum_dim(y * grad_out))`, accumulated
+/// into `g_in`.
+///
+/// Shared by [`SoftmaxNode`] and the masked/causal softmax nodes: their gradient is
+/// the same jacobian applied to their (masked) output. Because masked positions hold
+/// `y = 0`, they neither receive gradient (`dx = 0`) nor contribute to the per-row
+/// sum, and an all-masked row (`y` all zero) propagates zero — matching the forward,
+/// with no `-inf`/`NaN` ever formed.
+pub(crate) fn accumulate_softmax_grad<T, B>(
+    grad_out: &Tensor<T, B>,
+    y: &Tensor<T, B>,
+    dim_u: usize,
+    g_in: &Arc<GradBuffer<T, B>>,
+) where
+    T: Float,
+    B: coeus_ops::BackendOps<T> + Default,
+{
+    let backend = B::default();
+    let gy = coeus_ops::mul(grad_out, y, &backend);
+    let sum_gy = coeus_ops::sum_axis(&gy, dim_u, &backend);
+    let mut dx = coeus_ops::sub(grad_out, &sum_gy, &backend);
+    coeus_ops::mul_assign(&mut dx, y, &backend);
+    let gl = g_in.write();
+    coeus_ops::add_assign(gl, &dx, &backend);
 }
 
 /// Tracked Softmax.

--- a/coeus-python/src/activations.rs
+++ b/coeus-python/src/activations.rs
@@ -1,5 +1,4 @@
 use crate::tensor::PyTensor;
-use coeus_core::MoiraiBackend;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -99,10 +98,10 @@ pub fn glu(input: &PyTensor, dim: isize, py: Python<'_>) -> PyResult<PyTensor> {
     Ok(PyTensor::from_var(inner))
 }
 
-/// Masked softmax: replaces `mask==0` positions with `-inf` before softmax.
+/// Masked softmax over `dim`: softmax across positions where `mask != 0`; masked
+/// positions (and any fully-masked row) are zero. Differentiable in `input`.
 ///
-/// `mask` shape must match `input` shape. Equivalent to
-/// `torch.softmax(input.masked_fill(~mask, float('-inf')), dim=dim)`.
+/// `mask` shape must match `input` shape.
 #[pyfunction]
 #[pyo3(signature = (input, mask, dim = -1))]
 pub fn masked_softmax(
@@ -125,21 +124,14 @@ pub fn masked_softmax(
             mask.inner.tensor.shape()
         )));
     }
-    let x = input.inner.tensor.clone();
-    let m = mask.inner.tensor.clone();
-    let ax = axis as usize;
-    let inner = py.allow_threads(move || {
-        let backend = MoiraiBackend::new();
-        coeus_ops::masked_softmax(&x, &m, ax, &backend)
+    let inner = py.allow_threads(|| {
+        coeus_autograd::masked_softmax(&input.inner, &mask.inner.tensor, axis as isize)
     });
-    Ok(PyTensor {
-        inner: coeus_autograd::Var::new(inner, false),
-    })
+    Ok(PyTensor::from_var(inner))
 }
 
-/// Causal (lower-triangular) softmax — masks future positions before softmax.
-///
-/// Equivalent to `torch.softmax(input.masked_fill(upper_tri_mask, -inf), dim)`.
+/// Causal (lower-triangular) softmax over `dim`: future positions are masked before
+/// softmax. Differentiable in `input`.
 #[pyfunction]
 #[pyo3(signature = (input, dim = -1))]
 pub fn causal_softmax(input: &PyTensor, dim: i64, py: Python<'_>) -> PyResult<PyTensor> {
@@ -150,15 +142,8 @@ pub fn causal_softmax(input: &PyTensor, dim: i64, py: Python<'_>) -> PyResult<Py
             "causal_softmax: dim {dim} out of range for rank {ndim}"
         )));
     }
-    let x = input.inner.tensor.clone();
-    let ax = axis as usize;
-    let inner = py.allow_threads(move || {
-        let backend = MoiraiBackend::new();
-        coeus_ops::causal_softmax(&x, ax, &backend)
-    });
-    Ok(PyTensor {
-        inner: coeus_autograd::Var::new(inner, false),
-    })
+    let inner = py.allow_threads(|| coeus_autograd::causal_softmax(&input.inner, axis as isize));
+    Ok(PyTensor::from_var(inner))
 }
 
 // ── G-037 extended activation family ──


### PR DESCRIPTION
## Summary
`masked_softmax`/`causal_softmax` were exposed only as forward-only tensor ops (the Python bindings wrapped them in `Var::new(_, false)`), so gradients **silently didn't flow** — a training-correctness footgun vs torch, whose masked softmax is differentiable.

Adds tracked `coeus_autograd::{masked_softmax, causal_softmax}`.

## Architectural insight (why this is clean)
The masked-softmax gradient **is** the ordinary softmax jacobian applied to the *masked* output `y`: masked positions hold `y = 0`, so they receive zero gradient, don't enter the per-row sum, and an all-masked row propagates zero. So the **exact reference forward** (`coeus_ops::masked_softmax`, no `-inf`/`NaN`) + the **existing softmax backward** is correct — no inverted mask, no `NaN`, no special-case branch.

- Extract the softmax reverse pass into a shared **`accumulate_softmax_grad`** helper; `SoftmaxNode` and the new `MaskedSoftmaxNode` both use it (DRY).
- Python `masked_softmax`/`causal_softmax` now return **differentiable** results and are pure wrapping (validate args → call `coeus_autograd`).

## Verification
3 value-semantic tests: forward matches the reference; **input gradient matches the analytic softmax jacobian**; masked position → 0 grad; **all-masked row → 0 output + finite 0 grad (no NaN)**; causal lower-triangular + differentiable. coeus-autograd + coeus-python build; fmt + clippy `--all-targets -D warnings` clean. Staged surgically — peer's concurrent `moirai.rs`/`dependency_policy.rs`/`nn_bench.rs`/`test_pytorch_parity.py` edits untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes `masked_softmax` and `causal_softmax` differentiable by adding proper autograd support. Previously, these operations were forward-only (wrapped in `Var::new(_, false)`), causing gradients to silently not flow during training. The implementation refactors the softmax backward pass into a shared `accumulate_softmax_grad` helper that both regular and masked softmax nodes use, leveraging the insight that masked positions with `y = 0` naturally receive zero gradient without special handling. The Python bindings are updated to return differentiable results, and comprehensive tests verify forward correctness, gradient computation via the softmax Jacobian, and proper handling of edge cases like all-masked rows.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/softmax.rs` |
| 2 | `coeus-autograd/src/ops/nn/masked_softmax.rs` |
| 3 | `coeus-autograd/src/ops/nn/mod.rs` |
| 4 | `coeus-autograd/src/ops/mod.rs` |
| 5 | `coeus-autograd/src/lib.rs` |
| 6 | `coeus-python/src/activations.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `masked_softmax` and `causal_softmax` to the public API.
  * Both operations are now available through the Python interface as differentiable activations.

* **Bug Fixes**
  * Improved gradient handling for softmax-based operations, including fully masked rows.
  * Masked softmax now returns stable zero outputs when all positions are masked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->