### PR TITLE
feat(nn): Add softmin (torch.nn.functional.softmin)

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -152,6 +152,7 @@ pub use ops::{
     smooth_l1_loss,
     soft_margin,
     softmax,
+    softmin,
     softplus,
     softshrink,
     softsign,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -37,7 +37,7 @@ pub use nn::{
     causal_softmax, dropout, fold1d, fold2d, huber_loss, kl_divergence, l1_loss, layernorm,
     log_softmax, margin_ranking_loss, masked_softmax, max_pool1d, max_pool2d, max_pool3d,
     multi_label_margin_loss, multi_margin, nll_loss, pairwise_distance, poisson_nll, rmsnorm,
-    sdp_attention, smooth_l1_loss, soft_margin, softmax, unfold1d, unfold2d, AttentionMask,
+    sdp_attention, smooth_l1_loss, soft_margin, softmax, softmin, unfold1d, unfold2d, AttentionMask,
     BatchNormArgs, CausalMask, NullMask,
 };
 

--- a/coeus-autograd/src/ops/nn/mod.rs
+++ b/coeus-autograd/src/ops/nn/mod.rs
@@ -35,4 +35,4 @@ pub use loss::{
 };
 pub use normalization::{batchnorm1d, batchnorm2d, batchnorm3d, layernorm, rmsnorm, BatchNormArgs};
 pub use pool::{avg_pool1d, avg_pool2d, avg_pool3d, max_pool1d, max_pool2d, max_pool3d};
-pub use softmax::softmax;
+pub use softmax::{softmax, softmin};

--- a/coeus-autograd/src/ops/nn/softmax.rs
+++ b/coeus-autograd/src/ops/nn/softmax.rs
@@ -122,3 +122,47 @@ pub fn softmax<T: Float, B: coeus_ops::BackendOps<T> + Default>(
         creator,
     }
 }
+
+/// Tracked Softmin over `dim` — `softmax(-input)` (`torch.nn.functional.softmin`).
+///
+/// Differentiable via composition of the tracked `neg` and [`softmax`].
+#[must_use]
+pub fn softmin<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    dim: isize,
+) -> Var<T, B> {
+    softmax(&crate::ops::neg(input), dim)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coeus_core::MoiraiBackend;
+
+    #[test]
+    fn softmin_equals_softmax_of_negation_and_is_differentiable() {
+        let x = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([3], &[1.0, 2.0, 3.0]), true);
+        let out = softmin(&x, 0);
+
+        let neg =
+            Var::<f64, MoiraiBackend>::new(Tensor::from_slice([3], &[-1.0, -2.0, -3.0]), false);
+        let reference = softmax(&neg, 0);
+        for (i, (&a, &b)) in out
+            .tensor
+            .as_slice()
+            .iter()
+            .zip(reference.tensor.as_slice())
+            .enumerate()
+        {
+            assert!((a - b).abs() < 1e-12, "softmin[{i}]: {a} vs {b}");
+        }
+
+        // Smallest input receives the largest weight; distribution sums to 1.
+        let y = out.tensor.as_slice();
+        assert!(y[0] > y[1] && y[1] > y[2], "softmin must rank inversely to input");
+        assert!((y.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+
+        out.backward();
+        assert!(x.grad().is_some(), "softmin must be differentiable");
+    }
+}

--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -265,6 +265,7 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ops::flip, m)?)?;
     m.add_function(wrap_pyfunction!(ops::where_cond, m)?)?;
     m.add_function(wrap_pyfunction!(ops::softmax, m)?)?;
+    m.add_function(wrap_pyfunction!(ops::softmin, m)?)?;
     // Constructors
     m.add_function(wrap_pyfunction!(ops::randn, m)?)?;
     m.add_function(wrap_pyfunction!(ops::zeros_like, m)?)?;

--- a/coeus-python/src/ops/nn_functional.rs
+++ b/coeus-python/src/ops/nn_functional.rs
@@ -268,6 +268,13 @@ pub fn softmax(input: &PyTensor, dim: usize, py: Python<'_>) -> PyTensor {
     PyTensor::from_var(inner)
 }
 
+/// Softmin over `dim` (`torch.nn.functional.softmin`), i.e. `softmax(-input)`.
+#[pyfunction]
+pub fn softmin(input: &PyTensor, dim: usize, py: Python<'_>) -> PyTensor {
+    let inner = py.allow_threads(|| coeus_autograd::softmin(&input.inner, dim as isize));
+    PyTensor::from_var(inner)
+}
+
 #[pyfunction]
 pub fn einsum(subscript: &str, operands: Vec<pyo3::Py<PyTensor>>, py: Python<'_>) -> PyTensor {
     let rust_vars: Vec<coeus_autograd::Var<f64>> = operands


### PR DESCRIPTION
## Summary
`softmin` was missing from coeus — a torch/jax functional-parity gap. Adds tracked `coeus_autograd::softmin(input, dim)` = `softmax(-input)`, **differentiable for free** via composition of the tracked `neg` and `softmax` (no new node). Exposed to Python as `pycoeus.softmin`.

## Verification
`softmin_equals_softmax_of_negation_and_is_differentiable`: asserts it equals `softmax(-x)`, ranks inversely to the input, sums to 1, and backpropagates. coeus-autograd + coeus-python build; fmt + clippy `--all-targets -D warnings` clean. Staged surgically — peer's concurrent edits untouched.

## Audit note
Remaining torch/jax capability gaps found: special functions (`erf`/`erfc`/`lgamma`/`digamma`) — these belong in **eunomia/leto** (numerical primitives) per package-locality, not coeus; and composable ops (`tensordot`, `kron`, `diff`) — candidates for a future batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the `softmin` function to coeus, closing a functional-parity gap with PyTorch and JAX. The implementation leverages composition by defining `softmin(x, dim)` as `softmax(-x, dim)`, which makes it automatically differentiable through existing tracked operations without requiring a new autograd node. The function is exposed in the Rust autograd API (`coeus_autograd::softmin`) and Python bindings (`pycoeus.softmin`), with a comprehensive test verifying correctness against the reference implementation and gradient propagation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/softmax.rs` |
| 2 | `coeus-autograd/src/ops/nn/mod.rs` |
| 3 | `coeus-autograd/src/ops/mod.rs` |
| 4 | `coeus-autograd/src/lib.rs` |
| 5 | `coeus-python/src/ops/nn_functional.rs` |
| 6 | `coeus-python/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->