### PR TITLE
bench+test(nn): GLU/Softmin bench + movedim/swapaxes/flatten/softmin parity (MS-235)

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -1996,6 +1996,78 @@ fn bench_softplus_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_glu_forward(c: &mut Criterion) {
+    // GLU = x[:, :H] * sigmoid(x[:, H:]) — input [128, 512] → output [128, 256].
+    // Burn has no explicit GLU module; compare against manually assembled
+    // Burn tensor ops (mul + sigmoid).
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES * 2))
+        .map(|i| (i as f32 * 0.0027).sin())
+        .collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES * 2]),
+        &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES * 2], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES * 2], &input_data),
+        false,
+    );
+    let mut group = c.benchmark_group("Burn vs Coeus — GLU forward (128x512 → 128x256)");
+    group.bench_function("Burn NdArray (manual split+mul+sigmoid)", |b| {
+        b.iter(|| {
+            let chunks = black_box(x_burn.clone()).chunk(2, 1);
+            let a = chunks[0].clone();
+            let b_ = chunks[1].clone();
+            black_box(a * burn::tensor::activation::sigmoid(b_))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_nn::glu(black_box(&x_seq), 1)))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_nn::glu(black_box(&x_moirai), 1)))
+    });
+    group.finish();
+}
+
+fn bench_softmin_forward(c: &mut Criterion) {
+    // Softmin = softmax(-x), (128x256, dim=1).
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0031).sin())
+        .collect();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &NdArrayDevice::default(),
+    );
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let mut group = c.benchmark_group("Burn vs Coeus — Softmin forward (128x256, dim=1)");
+    group.bench_function("Burn NdArray (softmax(-x))", |b| {
+        b.iter(|| {
+            black_box(burn::tensor::activation::softmax(
+                black_box(x_burn.clone()).neg(),
+                1,
+            ))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::softmin(black_box(&x_seq), 1)))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::softmin(black_box(&x_moirai), 1)))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -2022,6 +2094,8 @@ criterion_group!(
     bench_lstm_forward,
     bench_gru_forward,
     bench_swiglu_forward,
+    bench_glu_forward,
+    bench_softmin_forward,
     bench_softmax_forward,
     bench_adaptive_avg_pool2d_forward,
     bench_instancenorm2d_forward,

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1499,3 +1499,42 @@ def test_rotary_embedding_matches_jax() -> None:
     y_j = x_j * cos_t + x_rot * sin_t
 
     _allclose("rope", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Shape ops JAX parity (MS-235): movedim / flatten
+# ---------------------------------------------------------------------------
+
+
+def test_movedim_matches_jax() -> None:
+    """jnp.moveaxis parity on [2, 3, 4]: move axis 0 to axis 2."""
+    n, c, d = 2, 3, 4
+    data = [float(i) * 0.1 for i in range(n * c * d)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, d], requires_grad=True)
+    y_pyc = pycoeus.movedim(x_pyc, 0, 2)
+    y_pyc.backward()
+
+    x_j = jnp.asarray(data, dtype=jnp.float64).reshape(n, c, d)
+    y_j = jnp.moveaxis(x_j, 0, 2)
+    dx_j = jax.grad(lambda x: jnp.sum(jnp.moveaxis(x, 0, 2)))(x_j)
+
+    _allclose("movedim_fwd_jax", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-10)
+    _allclose("movedim_dx_jax", list(x_pyc.grad), dx_j.flatten().tolist(), atol=1e-10)
+
+
+def test_flatten_matches_jax() -> None:
+    """jnp.reshape parity: flatten [2,3,4] → [2,12] (flatten(1,2))."""
+    n, c, d = 2, 3, 4
+    data = [float(i) * 0.1 for i in range(n * c * d)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, d], requires_grad=True)
+    y_pyc = pycoeus.flatten(x_pyc, 1, 2)
+    y_pyc.backward()
+
+    x_j = jnp.asarray(data, dtype=jnp.float64).reshape(n, c, d)
+    y_j = x_j.reshape(n, c * d)
+    dx_j = jax.grad(lambda x: jnp.sum(x.reshape(n, c * d)))(x_j)
+
+    _allclose("flatten_fwd_jax", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-10)
+    _allclose("flatten_dx_jax", list(x_pyc.grad), dx_j.flatten().tolist(), atol=1e-10)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -3478,3 +3478,80 @@ def test_bidirectional_shape_and_stability() -> None:
             assert not (v != v), "Bidirectional output must not contain NaN"
     except AttributeError:
         pytest.skip("pycoeus.Bidirectional or pycoeus.Gru not available")
+
+
+# ---------------------------------------------------------------------------
+# Shape ops parity (MS-235): movedim / swapaxes / flatten
+# ---------------------------------------------------------------------------
+
+
+def test_movedim_matches_pytorch() -> None:
+    """torch.movedim parity on [2, 3, 4]: move dim 0 to dim 2."""
+    n, c, d = 2, 3, 4
+    data = [float(i) * 0.1 for i in range(n * c * d)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, d], requires_grad=True)
+    y_pyc = pycoeus.movedim(x_pyc, 0, 2)
+    y_pyc.backward()
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, d).requires_grad_(True)
+    y_t = torch.movedim(x_t, 0, 2)
+    y_t.sum().backward()
+
+    _allclose("movedim_fwd", list(y_pyc.data), y_t.detach().flatten().tolist(), atol=1e-10)
+    _allclose("movedim_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-10)
+
+
+def test_swapaxes_matches_pytorch() -> None:
+    """torch.swapaxes parity on [2, 3, 4]: swap axes 0 and 2."""
+    n, c, d = 2, 3, 4
+    data = [float(i) * 0.1 for i in range(n * c * d)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, d], requires_grad=True)
+    y_pyc = pycoeus.swapaxes(x_pyc, 0, 2)
+    y_pyc.backward()
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, d).requires_grad_(True)
+    y_t = torch.swapaxes(x_t, 0, 2)
+    y_t.sum().backward()
+
+    _allclose("swapaxes_fwd", list(y_pyc.data), y_t.detach().flatten().tolist(), atol=1e-10)
+    _allclose("swapaxes_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-10)
+
+
+def test_flatten_matches_pytorch() -> None:
+    """torch.flatten parity on [2, 3, 4]: flatten(1, 2) → [2, 12]."""
+    n, c, d = 2, 3, 4
+    data = [float(i) * 0.1 for i in range(n * c * d)]
+
+    x_pyc = pycoeus.Tensor(data, [n, c, d], requires_grad=True)
+    y_pyc = pycoeus.flatten(x_pyc, 1, 2)
+    y_pyc.backward()
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(n, c, d).requires_grad_(True)
+    y_t = torch.flatten(x_t, 1, 2)
+    y_t.sum().backward()
+
+    _allclose("flatten_fwd", list(y_pyc.data), y_t.detach().flatten().tolist(), atol=1e-10)
+    _allclose("flatten_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Softmin parity (MS-235)
+# ---------------------------------------------------------------------------
+
+
+def test_softmin_matches_pytorch() -> None:
+    """softmin = softmax(-x). parity on [3, 4] dim=1."""
+    data = [0.5, -1.2, 2.0, -0.3, 1.0, 0.8, -0.5, 0.3, -2.0, 0.1, 1.5, 0.6]
+
+    x_pyc = pycoeus.Tensor(data, [3, 4], requires_grad=True)
+    y_pyc = pycoeus.softmin(x_pyc, 1)
+    y_pyc.backward()
+
+    x_t = torch.tensor(data, dtype=torch.float64).reshape(3, 4).requires_grad_(True)
+    y_t = torch.nn.functional.softmin(x_t, dim=1)
+    y_t.sum().backward()
+
+    _allclose("softmin_fwd", list(y_pyc.data), y_t.detach().flatten().tolist(), atol=1e-10)
+    _allclose("softmin_dx", list(x_pyc.grad), x_t.grad.flatten().tolist(), atol=1e-10)


### PR DESCRIPTION
2 bench rows (GLU, Softmin — G-043 to 47 rows). 4 PyTorch parity tests (movedim/swapaxes/flatten fwd+bwd, softmin fwd+bwd). 2 JAX parity tests (movedim/flatten fwd+grad). 94 PyTorch + 49 JAX total.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds benchmark functions for `GLU` and `Softmin` operations and implements parity tests for shape manipulation operations (`movedim`, `swapaxes`, `flatten`) and `softmin` activation. The changes include 2 new Rust benchmark functions comparing Coeus against Burn framework performance, 4 PyTorch parity tests covering forward and backward passes for shape operations and softmin, and 2 JAX parity tests for movedim and flatten operations. The implementation ensures numerical consistency across frameworks (PyTorch, JAX) with strict tolerance thresholds.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark coverage for two tensor operations, comparing Coeus against Burn in performance tests.
  * Expanded Python parity tests to cover more shape/transform operations and softmin behavior.

* **Tests**
  * Added JAX parity checks for movedim and flatten, including forward results and input gradients.
  * Added PyTorch parity checks for movedim, swapaxes, flatten, and softmin, validating both outputs and gradients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->