### PR TITLE
feat(shape): Add diff — n-th order discrete difference (torch.diff)

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -73,6 +73,7 @@ pub use ops::{
     // Diagonal ops
     diag,
     diagonal,
+    diff,
     div,
     dropout,
     // Index ops

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -43,7 +43,7 @@ pub use nn::{
 
 pub use embedding::{embedding, embedding_with_padding_idx};
 pub use shape::{
-    broadcast_to, cat, contiguous, cumprod, cumsum, diag, diagonal, einsum, einsum3, flatten, flip,
-    gather, index_select, masked_fill, movedim, pad, permute, reshape, roll, slice, split, squeeze,
-    stack, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,
+    broadcast_to, cat, contiguous, cumprod, cumsum, diag, diagonal, diff, einsum, einsum3, flatten,
+    flip, gather, index_select, masked_fill, movedim, pad, permute, reshape, roll, slice, split,
+    squeeze, stack, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,
 };

--- a/coeus-autograd/src/ops/shape/mod.rs
+++ b/coeus-autograd/src/ops/shape/mod.rs
@@ -16,4 +16,4 @@ pub use transform::{
     broadcast_to, diag, diagonal, flatten, flip, movedim, pad, permute, reshape, roll, slice,
     squeeze, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,
 };
-pub use util::{contiguous, cumprod, cumsum, einsum, einsum3};
+pub use util::{contiguous, cumprod, cumsum, diff, einsum, einsum3};

--- a/coeus-autograd/src/ops/shape/util/diff.rs
+++ b/coeus-autograd/src/ops/shape/util/diff.rs
@@ -1,0 +1,90 @@
+use crate::var::Var;
+use coeus_core::Scalar;
+
+/// N-th order discrete difference along `dim` (`torch.diff`).
+///
+/// Each pass computes `out[i] = x[i + 1] - x[i]` along `dim`, shrinking that
+/// dimension's extent by one; applied `n` times. `n == 0` returns `x` unchanged.
+/// The inverse of [`cumsum`](super::cumsum). Differentiable via composition of the
+/// tracked `slice` and `sub`.
+///
+/// # Panics
+/// If `dim` is out of range, or the extent along `dim` is exhausted before `n`
+/// differences complete.
+#[must_use]
+pub fn diff<T, B>(x: &Var<T, B>, n: usize, dim: usize) -> Var<T, B>
+where
+    T: Scalar,
+    B: coeus_ops::BackendOps<T> + Default,
+{
+    let ndim = x.tensor.ndim();
+    assert!(dim < ndim, "diff: dim {dim} out of range for rank {ndim}");
+    let mut result = x.clone();
+    for _ in 0..n {
+        let dims: Vec<usize> = result.tensor.shape().to_vec();
+        let len = dims[dim];
+        assert!(
+            len >= 1,
+            "diff: dimension {dim} exhausted before {n} differences"
+        );
+        let ranges = |shift: bool| -> Vec<(usize, usize)> {
+            dims.iter()
+                .enumerate()
+                .map(|(d, &e)| {
+                    if d != dim {
+                        (0, e)
+                    } else if shift {
+                        (1, e)
+                    } else {
+                        (0, e - 1)
+                    }
+                })
+                .collect()
+        };
+        let front = crate::ops::slice(&result, &ranges(true));
+        let back = crate::ops::slice(&result, &ranges(false));
+        result = crate::ops::sub(&front, &back);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coeus_core::MoiraiBackend;
+    use coeus_tensor::Tensor;
+
+    #[test]
+    fn diff_first_and_second_order_and_gradient() {
+        let x =
+            Var::<f64, MoiraiBackend>::new(Tensor::from_slice([4], &[1.0, 3.0, 6.0, 10.0]), true);
+
+        // n=1: [3-1, 6-3, 10-6] = [2, 3, 4].
+        let d1 = diff(&x, 1, 0);
+        assert_eq!(d1.tensor.shape(), &[3]);
+        assert_eq!(d1.tensor.as_slice(), &[2.0, 3.0, 4.0]);
+
+        // n=2: diff([2,3,4]) = [1, 1].
+        let d2 = diff(&x, 2, 0);
+        assert_eq!(d2.tensor.as_slice(), &[1.0, 1.0]);
+
+        // n=0 is the identity.
+        assert_eq!(diff(&x, 0, 0).tensor.as_slice(), x.tensor.as_slice());
+
+        // Gradient of sum(diff): dx = [-1, 0, 0, 1] (telescoping cancellation).
+        d1.backward();
+        assert_eq!(x.grad().unwrap().as_slice(), &[-1.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn diff_along_inner_dim() {
+        // [2,3] rows [1,2,4] and [0,10,30]; diff dim=1 -> [[1,2],[10,20]].
+        let x = Var::<f64, MoiraiBackend>::new(
+            Tensor::from_slice([2, 3], &[1.0, 2.0, 4.0, 0.0, 10.0, 30.0]),
+            false,
+        );
+        let d = diff(&x, 1, 1);
+        assert_eq!(d.tensor.shape(), &[2, 2]);
+        assert_eq!(d.tensor.to_contiguous().as_slice(), &[1.0, 2.0, 10.0, 20.0]);
+    }
+}

--- a/coeus-autograd/src/ops/shape/util/mod.rs
+++ b/coeus-autograd/src/ops/shape/util/mod.rs
@@ -1,9 +1,11 @@
 mod contiguous;
 mod cumprod;
 mod cumsum;
+mod diff;
 mod einsum;
 
 pub use contiguous::contiguous;
 pub use cumprod::cumprod;
 pub use cumsum::cumsum;
+pub use diff::diff;
 pub use einsum::{einsum, einsum3};

--- a/coeus-python/src/lib.rs
+++ b/coeus-python/src/lib.rs
@@ -255,6 +255,7 @@ pub fn pycoeus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ops::permute, m)?)?;
     m.add_function(wrap_pyfunction!(ops::movedim, m)?)?;
     m.add_function(wrap_pyfunction!(ops::swapaxes, m)?)?;
+    m.add_function(wrap_pyfunction!(ops::diff, m)?)?;
     m.add_function(wrap_pyfunction!(ops::t, m)?)?;
     m.add_function(wrap_pyfunction!(ops::pow, m)?)?;
     // Trigonometric

--- a/coeus-python/src/ops/shape.rs
+++ b/coeus-python/src/ops/shape.rs
@@ -51,6 +51,27 @@ pub fn swapaxes(
     Ok(PyTensor::from_var(inner))
 }
 
+/// N-th order discrete difference along `dim` (`torch.diff`; negative dim allowed).
+#[pyfunction]
+#[pyo3(signature = (input, n = 1, dim = -1))]
+pub fn diff(input: &PyTensor, n: usize, dim: isize, py: Python<'_>) -> PyResult<PyTensor> {
+    let ndim = input.inner.tensor.ndim() as isize;
+    let axis = if dim < 0 { ndim + dim } else { dim };
+    if axis < 0 || axis >= ndim {
+        return Err(PyValueError::new_err(format!(
+            "diff: dim {dim} out of range for rank {ndim}"
+        )));
+    }
+    let extent = input.inner.tensor.shape()[axis as usize];
+    if n > extent {
+        return Err(PyValueError::new_err(format!(
+            "diff: order n={n} exceeds dimension {axis} extent {extent}"
+        )));
+    }
+    let inner = py.allow_threads(|| coeus_autograd::diff(&input.inner, n, axis as usize));
+    Ok(PyTensor::from_var(inner))
+}
+
 #[pyfunction]
 pub fn t(input: &PyTensor, py: Python<'_>) -> PyTensor {
     let inner = py.allow_threads(|| coeus_autograd::transpose_2d(&input.inner));


### PR DESCRIPTION
## Summary
Fills the `torch.diff` / `np.diff` gap. `diff(x, n, dim)` composes tracked `slice` + `sub` (no new node) — differentiable, reducing the target dim's extent by `n`. It's the inverse direction of `cumsum` and lives alongside it in `ops/shape/util`. Exposed to Python as `pycoeus.diff(input, n=1, dim=-1)`.

## Verification
Value-semantic tests: first/second-order values (`[1,3,6,10]→[2,3,4]→[1,1]`), `n=0` identity, telescoping gradient `dx=[-1,0,0,1]`, and an inner-dim case. coeus-autograd + coeus-python build; fmt + clippy `--all-targets -D warnings` clean. Staged surgically (peer's `docs/backlog.md` untouched).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds support for the `diff` operation (equivalent to `torch.diff` and `np.diff`), which computes the n-th order discrete difference along a specified dimension. The implementation composes existing tracked `slice` and `sub` operations to create a differentiable operation that reduces the target dimension's extent by n. The feature is exposed at both the Rust autograd layer (`coeus_autograd::diff`) and the Python binding layer (`pycoeus.diff`), with comprehensive unit tests covering first/second-order differences, gradient verification, and multi-dimensional cases.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/shape/util/diff.rs` |
| 2 | `coeus-autograd/src/ops/shape/util/mod.rs` |
| 3 | `coeus-autograd/src/ops/shape/mod.rs` |
| 4 | `coeus-python/src/ops/shape.rs` |
| 5 | `coeus-python/src/lib.rs` |
| 6 | `coeus-autograd/src/ops/mod.rs` |
| 7 | `coeus-autograd/src/lib.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->