### PR TITLE
MS-237: zero-copy alloc_on for unfold/pool/topk + tril/triu/roll/flip parity tests

### DIFF
--- a/coeus-ops/src/adaptive_pool.rs
+++ b/coeus-ops/src/adaptive_pool.rs
@@ -51,7 +51,8 @@ where
     let c = input.shape()[1];
     let l = input.shape()[2];
 
-    let mut out = Tensor::zeros_on([n, c, output_size], backend);
+    // alloc_on: every [ni, ci, oi] is written via set — no zero-init needed.
+    let mut out = Tensor::alloc_on([n, c, output_size], backend);
 
     for ni in 0..n {
         for ci in 0..c {
@@ -89,7 +90,8 @@ where
     let c = input.shape()[1];
     let l = input.shape()[2];
 
-    let mut out = Tensor::zeros_on([n, c, output_size], backend);
+    // alloc_on: every [ni, ci, oi] is written via set — no zero-init needed.
+    let mut out = Tensor::alloc_on([n, c, output_size], backend);
 
     for ni in 0..n {
         for ci in 0..c {
@@ -130,7 +132,7 @@ where
     let h = input.shape()[2];
     let w = input.shape()[3];
 
-    // Contiguous fast-path: raw pointer arithmetic via parallel_for.
+    // alloc_on: parallel_for writes every out position — no zero-init needed.
     let inp_cont;
     let inp = if input.is_contiguous() && input.layout().offset() == 0 {
         input
@@ -140,7 +142,7 @@ where
     };
 
     use crate::ptr::{MutPtr, Ptr};
-    let mut out = Tensor::zeros_on([n, c, out_h, out_w], backend);
+    let mut out = Tensor::alloc_on([n, c, out_h, out_w], backend);
     let inp_ptr = Ptr(inp.storage().as_slice().as_ptr());
     let out_ptr = MutPtr(out.storage_mut().as_mut_slice().as_mut_ptr());
 
@@ -201,7 +203,8 @@ where
     };
 
     use crate::ptr::{MutPtr, Ptr};
-    let mut out = Tensor::zeros_on([n, c, out_h, out_w], backend);
+    // alloc_on: parallel_for writes every out position — no zero-init needed.
+    let mut out = Tensor::alloc_on([n, c, out_h, out_w], backend);
     let inp_ptr = Ptr(inp.storage().as_slice().as_ptr());
     let out_ptr = MutPtr(out.storage_mut().as_mut_slice().as_mut_ptr());
 

--- a/coeus-ops/src/lib.rs
+++ b/coeus-ops/src/lib.rs
@@ -108,7 +108,8 @@ pub fn unfold1d<T: coeus_core::Scalar, B: BackendOps<T> + Default>(
     let (n, c, l) = (shape[0], shape[1], shape[2]);
     let l_out = (l + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
     let ck = c * kernel_size;
-    let mut out = coeus_tensor::Tensor::zeros_on([n, ck, l_out], backend);
+    // alloc_on: unfold1d kernel writes every output position — no zero-init needed.
+    let mut out = coeus_tensor::Tensor::alloc_on([n, ck, l_out], backend);
     let (out_storage, out_layout) = out.storage_mut_and_layout();
     backend.unfold1d(
         input.storage(),
@@ -176,7 +177,8 @@ pub fn unfold2d<T: coeus_core::Scalar, B: BackendOps<T> + Default>(
     let w_out = (w + 2 * padding_w - dilation_w * (kernel_w - 1) - 1) / stride_w + 1;
     let ckk = c * kernel_h * kernel_w;
     let l_out = h_out * w_out;
-    let mut out = coeus_tensor::Tensor::zeros_on([n, ckk, l_out], backend);
+    // alloc_on: unfold2d kernel writes every output position — no zero-init needed.
+    let mut out = coeus_tensor::Tensor::alloc_on([n, ckk, l_out], backend);
     let (out_storage, out_layout) = out.storage_mut_and_layout();
     backend.unfold2d(
         input.storage(),

--- a/coeus-ops/src/reduction/cumsum.rs
+++ b/coeus-ops/src/reduction/cumsum.rs
@@ -23,7 +23,8 @@ pub fn cumsum<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + Default>(
 
     let backend = B::default();
     let shape = x.shape_cloned();
-    let mut out = Tensor::zeros_on(shape, &backend);
+    // alloc_on: the cumsum kernel writes every output element in order — no zeros needed.
+    let mut out = Tensor::alloc_on(shape, &backend);
     let (out_storage, out_layout) = out.storage_mut_and_layout();
     backend.cumsum(x.storage(), x.layout(), dim, out_storage, out_layout);
     out
@@ -48,7 +49,8 @@ pub fn suffix_sum<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + Default>(
 
     let backend = B::default();
     let shape = x.shape_cloned();
-    let mut out = Tensor::zeros_on(shape, &backend);
+    // alloc_on: suffix_sum writes every element — no zeros needed.
+    let mut out = Tensor::alloc_on(shape, &backend);
     let (out_storage, out_layout) = out.storage_mut_and_layout();
     backend.suffix_sum(x.storage(), x.layout(), dim, out_storage, out_layout);
     out

--- a/coeus-ops/src/reduction/topk.rs
+++ b/coeus-ops/src/reduction/topk.rs
@@ -109,8 +109,9 @@ pub fn topk<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + D
     let mut out_shape = x.shape_cloned();
     out_shape[dim] = k;
 
-    let mut val_tensor = Tensor::zeros_on(out_shape.clone(), &backend);
-    let mut idx_tensor = Tensor::zeros_on(out_shape, &backend);
+    // alloc_on: backend.topk writes every val/idx position — no zero-init needed.
+    let mut val_tensor = Tensor::alloc_on(out_shape.clone(), &backend);
+    let mut idx_tensor = Tensor::alloc_on(out_shape, &backend);
 
     {
         let (val_storage, val_layout) = val_tensor.storage_mut_and_layout();
@@ -142,7 +143,8 @@ pub fn argmax<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> +
     let backend = B::default();
     let mut out_shape = x.shape_cloned();
     out_shape[dim] = 1;
-    let mut out = Tensor::zeros_on(out_shape, &backend);
+    // alloc_on: backend.argmax writes every position — no zero-init needed.
+    let mut out = Tensor::alloc_on(out_shape, &backend);
     let (out_storage, out_layout) = out.storage_mut_and_layout();
     backend.argmax(x.storage(), x.layout(), dim, out_storage, out_layout);
     out
@@ -159,7 +161,8 @@ pub fn argmin<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> +
     let backend = B::default();
     let mut out_shape = x.shape_cloned();
     out_shape[dim] = 1;
-    let mut out = Tensor::zeros_on(out_shape, &backend);
+    // alloc_on: backend.argmin writes every position — no zero-init needed.
+    let mut out = Tensor::alloc_on(out_shape, &backend);
     let (out_storage, out_layout) = out.storage_mut_and_layout();
     backend.argmin(x.storage(), x.layout(), dim, out_storage, out_layout);
     out

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1575,3 +1575,52 @@ def test_cumsum_matches_jax() -> None:
 
     _allclose("cumsum_jax_fwd", list(y_pyc.data), y_j.flatten().tolist(), atol=1e-10)
     _allclose("cumsum_jax_dx", list(x_pyc.grad), dx_j.flatten().tolist(), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# tril / triu / roll / flip parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "tril"), reason="pycoeus.tril not available")
+def test_tril_matches_jax() -> None:
+    """jnp.tril(x) vs pycoeus.tril(x, 0)."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=False)
+    got = pycoeus.tril(x_pyc, 0)
+    t = jnp.array(data, dtype=jnp.float64).reshape(4, 4)
+    exp = jnp.tril(t)
+    _allclose("tril", list(got.data), jnp.ravel(exp).tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "triu"), reason="pycoeus.triu not available")
+def test_triu_matches_jax() -> None:
+    """jnp.triu(x) vs pycoeus.triu(x, 0)."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=False)
+    got = pycoeus.triu(x_pyc, 0)
+    t = jnp.array(data, dtype=jnp.float64).reshape(4, 4)
+    exp = jnp.triu(t)
+    _allclose("triu", list(got.data), jnp.ravel(exp).tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "roll"), reason="pycoeus.roll not available")
+def test_roll_matches_jax() -> None:
+    """jnp.roll(x, shift=1, axis=0) vs pycoeus.roll(x, [1], [0])."""
+    data = [float(i) for i in range(9)]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=False)
+    got = pycoeus.roll(x_pyc, [1], [0])
+    t = jnp.array(data, dtype=jnp.float64).reshape(3, 3)
+    exp = jnp.roll(t, 1, axis=0)
+    _allclose("roll", list(got.data), jnp.ravel(exp).tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "flip"), reason="pycoeus.flip not available")
+def test_flip_matches_jax() -> None:
+    """jnp.flip(x, axis=0) vs pycoeus.flip(x, 0)."""
+    data = [float(i) for i in range(9)]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=False)
+    got = pycoeus.flip(x_pyc, 0)
+    t = jnp.array(data, dtype=jnp.float64).reshape(3, 3)
+    exp = jnp.flip(t, axis=0)
+    _allclose("flip", list(got.data), jnp.ravel(exp).tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -3690,3 +3690,92 @@ def test_nanmean_matches_pytorch() -> None:
     assert abs(list(y_pyc.data)[0] - y_t.item()) < 1e-10, (
         f"nanmean: got {list(y_pyc.data)[0]:.8g}, expected {y_t.item():.8g}"
     )
+
+
+# ---------------------------------------------------------------------------
+# tril / triu / roll / flip parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "tril"),
+    reason="pycoeus.tril not available",
+)
+def test_tril_main_diag_matches_pytorch() -> None:
+    """torch.tril(x, diagonal=0) vs pycoeus.tril(x, 0)."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=False)
+    got = pycoeus.tril(x_pyc, 0)
+    t = torch.tensor(data, dtype=torch.float64).reshape(4, 4)
+    exp = torch.tril(t, diagonal=0)
+    _allclose("tril(diag=0)", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "tril"),
+    reason="pycoeus.tril not available",
+)
+def test_tril_above_diag_matches_pytorch() -> None:
+    """torch.tril(x, diagonal=1) vs pycoeus.tril(x, 1)."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=False)
+    got = pycoeus.tril(x_pyc, 1)
+    t = torch.tensor(data, dtype=torch.float64).reshape(4, 4)
+    exp = torch.tril(t, diagonal=1)
+    _allclose("tril(diag=1)", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "triu"),
+    reason="pycoeus.triu not available",
+)
+def test_triu_main_diag_matches_pytorch() -> None:
+    """torch.triu(x, diagonal=0) vs pycoeus.triu(x, 0)."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=False)
+    got = pycoeus.triu(x_pyc, 0)
+    t = torch.tensor(data, dtype=torch.float64).reshape(4, 4)
+    exp = torch.triu(t, diagonal=0)
+    _allclose("triu(diag=0)", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "triu"),
+    reason="pycoeus.triu not available",
+)
+def test_triu_below_diag_matches_pytorch() -> None:
+    """torch.triu(x, diagonal=-1) vs pycoeus.triu(x, -1)."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=False)
+    got = pycoeus.triu(x_pyc, -1)
+    t = torch.tensor(data, dtype=torch.float64).reshape(4, 4)
+    exp = torch.triu(t, diagonal=-1)
+    _allclose("triu(diag=-1)", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "roll"),
+    reason="pycoeus.roll not available",
+)
+def test_roll_dim0_matches_pytorch() -> None:
+    """torch.roll(x, shifts=1, dims=0) vs pycoeus.roll(x, [1], [0])."""
+    data = [float(i) for i in range(9)]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=False)
+    got = pycoeus.roll(x_pyc, [1], [0])
+    t = torch.tensor(data, dtype=torch.float64).reshape(3, 3)
+    exp = torch.roll(t, 1, 0)
+    _allclose("roll(shifts=[1], dims=[0])", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(
+    not hasattr(pycoeus, "flip"),
+    reason="pycoeus.flip not available",
+)
+def test_flip_axis0_matches_pytorch() -> None:
+    """torch.flip(x, dims=[0]) vs pycoeus.flip(x, axis=0)."""
+    data = [float(i) for i in range(9)]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=False)
+    got = pycoeus.flip(x_pyc, 0)
+    t = torch.tensor(data, dtype=torch.float64).reshape(3, 3)
+    exp = torch.flip(t, dims=[0])
+    _allclose("flip(axis=0)", list(got.data), exp.flatten().tolist())


### PR DESCRIPTION
Replace zeros_on with alloc_on in kernels that write every output position (unfold1d/2d, cumsum, suffix_sum, adaptive_avg/max_pool1d/2d, topk, argmax, argmin). fold1d/fold2d/conv_transpose/embedding_backward stay zeros_on (accumulate). Added 10 new parity tests: tril/triu/roll/flip for both PyTorch and JAX. PyTorch parity: 105, JAX parity: 55. All 399+73 tests pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes memory allocation by replacing `zeros_on` with `alloc_on` (zero-copy allocation) for operations that write to every output position, including unfold1d/2d, cumsum, suffix_sum, adaptive pooling, topk, argmax, and argmin. The change eliminates unnecessary zero-initialization for performance gains. Additionally, the PR adds 10 new parity tests covering `tril`, `triu`, `roll`, and `flip` operations for both PyTorch and JAX frameworks, bringing PyTorch parity to 105 tests and JAX parity to 55 tests, with all 472 tests passing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-ops/src/lib.rs` |
| 2 | `coeus-ops/src/adaptive_pool.rs` |
| 3 | `coeus-ops/src/reduction/cumsum.rs` |
| 4 | `coeus-ops/src/reduction/topk.rs` |
| 5 | `coeus-python/tests/test_pytorch_parity.py` |
| 6 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->