### PR TITLE
MS-241: bmm/pad/log_sum_exp/gather parity tests (PyTorch 122, JAX 62)

### DIFF
--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1688,3 +1688,33 @@ def test_clamp_matches_jax() -> None:
     t = jnp.array(data, dtype=jnp.float64)
     exp = jnp.clip(t, -1.0, 2.0)
     _allclose("clamp", list(got.data), exp.tolist())
+
+# ---------------------------------------------------------------------------
+# bmm / log_sum_exp parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "bmm"), reason="pycoeus.bmm not available")
+def test_bmm_matches_jax() -> None:
+    """jnp.matmul(a, b) on batch vs pycoeus.bmm — [2,3,4] x [2,4,5]."""
+    a_data = [float(i) * 0.1 for i in range(2 * 3 * 4)]
+    b_data = [float(i) * 0.05 for i in range(2 * 4 * 5)]
+    a_pyc = pycoeus.Tensor(a_data, [2, 3, 4], requires_grad=False)
+    b_pyc = pycoeus.Tensor(b_data, [2, 4, 5], requires_grad=False)
+    out_pyc = pycoeus.bmm(a_pyc, b_pyc)
+    a_j = jnp.array(a_data, dtype=jnp.float64).reshape(2, 3, 4)
+    b_j = jnp.array(b_data, dtype=jnp.float64).reshape(2, 4, 5)
+    exp = jnp.matmul(a_j, b_j)
+    _allclose("bmm", list(out_pyc.data), jnp.ravel(exp).tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log_sum_exp"), reason="pycoeus.log_sum_exp not available")
+def test_log_sum_exp_matches_jax() -> None:
+    """jax.scipy.special.logsumexp(x, axis=1) vs pycoeus.log_sum_exp(x, 1)."""
+    import jax.scipy.special as jsp
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=False)
+    out_pyc = pycoeus.log_sum_exp(x_pyc, 1)
+    t = jnp.array(data, dtype=jnp.float64).reshape(3, 3)
+    exp = jsp.logsumexp(t, axis=1)
+    _allclose("logsumexp", list(out_pyc.data), exp.tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -3930,3 +3930,76 @@ def test_masked_fill_matches_pytorch() -> None:
     mask_t = torch.tensor(mask_data, dtype=torch.bool).reshape(3, 3)
     exp = t.masked_fill(mask_t, -1e9)
     _allclose("masked_fill", list(got.data), exp.flatten().tolist(), atol=1.0)
+
+# ---------------------------------------------------------------------------
+# bmm / pad / log_sum_exp / gather / scatter_add parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "bmm"), reason="pycoeus.bmm not available")
+def test_bmm_forward_matches_pytorch() -> None:
+    """torch.bmm(a, b) vs pycoeus.bmm(a, b), [2,3,4] x [2,4,5]."""
+    import random
+    random.seed(42)
+    a_data = [float(i) * 0.1 for i in range(2 * 3 * 4)]
+    b_data = [float(i) * 0.05 for i in range(2 * 4 * 5)]
+    a_pyc = pycoeus.Tensor(a_data, [2, 3, 4], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b_data, [2, 4, 5], requires_grad=True)
+    out_pyc = pycoeus.bmm(a_pyc, b_pyc)
+    out_pyc.backward()
+
+    a_t = torch.tensor(a_data, dtype=torch.float64).reshape(2, 3, 4).requires_grad_(True)
+    b_t = torch.tensor(b_data, dtype=torch.float64).reshape(2, 4, 5).requires_grad_(True)
+    out_t = torch.bmm(a_t, b_t)
+    out_t.sum().backward()
+
+    _allclose("bmm_fwd", list(out_pyc.data), out_t.detach().flatten().tolist())
+    _allclose("bmm_bwd_a", list(a_pyc.grad), a_t.grad.flatten().tolist())
+    _allclose("bmm_bwd_b", list(b_pyc.grad), b_t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "pad"), reason="pycoeus.pad not available")
+def test_pad_constant_matches_pytorch() -> None:
+    """torch.nn.functional.pad(x, (1,1,1,1), value=0.0) vs pycoeus.pad."""
+    data = [float(i) for i in range(9)]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=False)
+    # pycoeus pad takes list of (before, after) per dim; outermost dim first
+    got = pycoeus.pad(x_pyc, [(1, 1), (1, 1)], 0.0)
+    t = torch.tensor(data, dtype=torch.float64).reshape(3, 3)
+    exp = torch.nn.functional.pad(t, (1, 1, 1, 1), value=0.0)
+    _allclose("pad_const", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log_sum_exp"), reason="pycoeus.log_sum_exp not available")
+def test_log_sum_exp_matches_pytorch() -> None:
+    """torch.logsumexp(x, dim=1) vs pycoeus.log_sum_exp(x, axis=1)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=True)
+    out_pyc = pycoeus.log_sum_exp(x_pyc, 1)
+    out_pyc.backward()
+
+    t = torch.tensor(data, dtype=torch.float64).reshape(3, 3).requires_grad_(True)
+    out_t = torch.logsumexp(t, dim=1)
+    out_t.sum().backward()
+
+    _allclose("logsumexp_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("logsumexp_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "gather"), reason="pycoeus.gather not available")
+def test_gather_dim1_matches_pytorch() -> None:
+    """torch.gather(x, dim=1, index) vs pycoeus.gather(x, 1, index)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    idx_data = [2.0, 0.0, 1.0, 1.0, 2.0, 0.0]  # stored as float64 in pycoeus
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=True)
+    idx_pyc = pycoeus.Tensor(idx_data, [2, 3], requires_grad=False)
+    out_pyc = pycoeus.gather(x_pyc, 1, idx_pyc)
+    out_pyc.backward()
+
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3).requires_grad_(True)
+    idx_t = torch.tensor([[2, 0, 1], [1, 2, 0]], dtype=torch.int64)
+    out_t = torch.gather(t, 1, idx_t)
+    out_t.sum().backward()
+
+    _allclose("gather_fwd", list(out_pyc.data), out_t.detach().flatten().tolist())
+    _allclose("gather_bwd", list(x_pyc.grad), t.grad.flatten().tolist())


### PR DESCRIPTION
Adds bmm fwd+bwd, constant pad, logsumexp fwd+bwd, and gather fwd+bwd PyTorch parity tests. JAX: bmm and logsumexp. PyTorch: 122, JAX: 62. Full workspace check clean.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds parity tests for four tensor operations (`bmm`, `pad`, `log_sum_exp`, and `gather`) comparing the custom `pycoeus` library against JAX and PyTorch. The JAX tests verify forward-pass equivalence for `bmm` and `log_sum_exp`, while the PyTorch tests validate both forward and backward passes for `bmm`, `log_sum_exp`, and `gather`, plus forward-only for constant padding. This brings the total test count to 122 for PyTorch and 62 for JAX parity coverage.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_jax_parity.py` |
| 2 | `coeus-python/tests/test_pytorch_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->