### PR TITLE
MS-243-247: alloc_on audit (attention/sparse) + parity batch + bench 57 rows

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2372,6 +2372,122 @@ fn bench_log_sum_exp_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_sdp_attention_forward(c: &mut Criterion) {
+    // Scaled dot-product attention: [4, 8, 64] Q×K×V (4 heads, seq=8, d_k=64).
+    // The output alloc uses alloc_on: every position written by the kernel.
+    const SA_B: usize = 4;
+    const SA_S: usize = 8;
+    const SA_D: usize = 64;
+    let q_data: Vec<f32> = (0..(SA_B * SA_S * SA_D))
+        .map(|i| (i as f32 * 0.001).sin())
+        .collect();
+    let k_data = q_data.clone();
+    let v_data: Vec<f32> = (0..(SA_B * SA_S * SA_D))
+        .map(|i| (i as f32 * 0.001).cos())
+        .collect();
+
+    let backend_seq = SequentialBackend::default();
+    let q_seq = coeus_tensor::Tensor::<f32, SequentialBackend>::from_slice(
+        vec![SA_B, SA_S, SA_D],
+        &q_data,
+    );
+    let k_seq = q_seq.clone();
+    let v_seq = coeus_tensor::Tensor::<f32, SequentialBackend>::from_slice(
+        vec![SA_B, SA_S, SA_D],
+        &v_data,
+    );
+
+    let backend_moirai = MoiraiBackend::default();
+    let q_moirai =
+        coeus_tensor::Tensor::<f32, MoiraiBackend>::from_slice(vec![SA_B, SA_S, SA_D], &q_data);
+    let k_moirai = q_moirai.clone();
+    let v_moirai =
+        coeus_tensor::Tensor::<f32, MoiraiBackend>::from_slice(vec![SA_B, SA_S, SA_D], &v_data);
+
+    let scale = 1.0f32 / (SA_D as f32).sqrt();
+
+    // Burn: MultiHeadAttention with SA_B heads is a superset; use raw matmul chain
+    let device = NdArrayDevice::default();
+    let q_burn: BurnTensor<BurnB, 3> =
+        BurnTensor::from_data(TensorData::new(q_data.clone(), [SA_B, SA_S, SA_D]), &device);
+    let kt_burn: BurnTensor<BurnB, 3> =
+        BurnTensor::from_data(TensorData::new(k_data.clone(), [SA_B, SA_D, SA_S]), &device);
+    let v_burn: BurnTensor<BurnB, 3> =
+        BurnTensor::from_data(TensorData::new(v_data.clone(), [SA_B, SA_S, SA_D]), &device);
+
+    let mut group =
+        c.benchmark_group("Burn vs Coeus — sdp_attention forward (4x8x64)");
+    group.bench_function("Burn NdArray (QK^T/scale@V proxy)", |b| {
+        b.iter(|| {
+            let scores = black_box(q_burn.clone()).matmul(black_box(kt_burn.clone()))
+                * (scale as f32);
+            let weights = burn::tensor::activation::softmax(scores, 2);
+            black_box(weights.matmul(black_box(v_burn.clone())))
+        })
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| {
+            black_box(coeus_ops::scaled_dot_product_attention(
+                black_box(&q_seq),
+                black_box(&k_seq),
+                black_box(&v_seq),
+                None,
+                false,
+                scale,
+                &backend_seq,
+            ))
+        })
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| {
+            black_box(coeus_ops::scaled_dot_product_attention(
+                black_box(&q_moirai),
+                black_box(&k_moirai),
+                black_box(&v_moirai),
+                None,
+                false,
+                scale,
+                &backend_moirai,
+            ))
+        })
+    });
+    group.finish();
+}
+
+fn bench_nanmean_forward(c: &mut Criterion) {
+    // nanmean: [128, 256] with 5% NaN injection.
+    let mut input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0029).sin())
+        .collect();
+    for i in (0..input_data.len()).step_by(20) {
+        input_data[i] = f32::NAN;
+    }
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let device = NdArrayDevice::default();
+    // Filter NaN before passing to Burn (Burn sum is the proxy).
+    let clean: Vec<f32> = input_data.iter().map(|&x| if x.is_nan() { 0.0 } else { x }).collect();
+    let x_burn: BurnTensor<BurnB, 2> =
+        BurnTensor::from_data(TensorData::new(clean, [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus — nanmean forward (128x256, 5% NaN)");
+    group.bench_function("Burn NdArray (mean of pre-cleaned, no NaN guard)", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).mean()))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::nanmean(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::nanmean(black_box(&x_moirai))))
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -2427,6 +2543,8 @@ criterion_group!(
     bench_cumsum_forward,
     bench_roll_forward,
     bench_bmm_forward,
-    bench_log_sum_exp_forward
+    bench_log_sum_exp_forward,
+    bench_sdp_attention_forward,
+    bench_nanmean_forward
 );
 criterion_main!(benches);

--- a/coeus-ops/src/attention.rs
+++ b/coeus-ops/src/attention.rs
@@ -6,12 +6,25 @@ use coeus_tensor::Tensor;
 
 /// Compute scaled dot-product attention.
 ///
+/// Implements `Attention(Q, K, V) = softmax(Q·Kᵀ · scale) · V` with optional
+/// causal or key-padding masking.
+///
 /// # Shapes
 /// - `query`:  `[batch, seq_q, d_k]`
 /// - `key`:    `[batch, seq_k, d_k]`
 /// - `value`:  `[batch, seq_k, d_v]`
 ///
 /// Returns `(output [batch, seq_q, d_v], attn_weights [batch, seq_q, seq_k])`.
+///
+/// # Memory
+/// Both output buffers are allocated uninitialized (`alloc_on`); the CPU kernel
+/// writes every position exactly once before returning, so no zero-initialization
+/// overhead is incurred.
+///
+/// # Performance
+/// The CPU backend dispatches one task per `(batch, seq_q)` pair via
+/// `parallel_for`, enabling SIMD dot products via `Float::dot_slice` on each
+/// query–key pair and coarse-grained parallelism over the batch × query matrix.
 pub fn scaled_dot_product_attention<T: Float, B: BackendOps<T> + Default>(
     query: &Tensor<T, B>,
     key: &Tensor<T, B>,
@@ -31,8 +44,9 @@ pub fn scaled_dot_product_attention<T: Float, B: BackendOps<T> + Default>(
     let v_shape = value.shape();
     let d_v = v_shape[2];
 
-    let mut output = Tensor::zeros_on([batch, seq_q, d_v], backend);
-    let mut attn_weights = Tensor::zeros_on([batch, seq_q, seq_k], backend);
+    // alloc_on: sdp_attention writes every output/attn_weights position — no zero-init needed.
+    let mut output = Tensor::alloc_on([batch, seq_q, d_v], backend);
+    let mut attn_weights = Tensor::alloc_on([batch, seq_q, seq_k], backend);
 
     let (out_storage, out_layout) = output.storage_mut_and_layout();
     let (aw_storage, aw_layout) = attn_weights.storage_mut_and_layout();

--- a/coeus-ops/src/backend_ops/cpu_impl/attention.rs
+++ b/coeus-ops/src/backend_ops/cpu_impl/attention.rs
@@ -17,8 +17,8 @@ fn row_max<T: Float>(row: &[T]) -> T {
 /// - `query`:  `[batch, seq_q, d_k]`
 /// - `key`:    `[batch, seq_k, d_k]`
 /// - `value`:  `[batch, seq_k, d_v]`
-/// - `output`: `[batch, seq_q, d_v]`  (pre-allocated, zeroed)
-/// - `attn_weights`: `[batch, seq_q, seq_k]` (pre-allocated, zeroed, returned for backward)
+/// - `output`: `[batch, seq_q, d_v]`  (pre-allocated; every position written by kernel)
+/// - `attn_weights`: `[batch, seq_q, seq_k]` (pre-allocated; every position written, returned for backward)
 ///
 /// All tensors must be contiguous with offset == 0.
 pub(crate) fn sdp_attention<T: Float, B: Backend>(

--- a/coeus-ops/src/sparse/conversions.rs
+++ b/coeus-ops/src/sparse/conversions.rs
@@ -42,8 +42,9 @@ where
     }
 
     let nnz = values_vec.len();
-    let mut indices = Tensor::<i64, B>::zeros_on([rank, nnz], backend);
-    let mut values = Tensor::<T, B>::zeros_on([nnz], backend);
+    // alloc_on: every element is written by the loops below — no zero-init needed.
+    let mut indices = Tensor::<i64, B>::alloc_on([rank, nnz], backend);
+    let mut values = Tensor::<T, B>::alloc_on([nnz], backend);
 
     let indices_slice = indices.as_mut_slice();
     for col in 0..nnz {
@@ -135,9 +136,10 @@ where
 
     triples.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 
-    let mut csr_values = Tensor::<T, B>::zeros_on([nnz], backend);
-    let mut csr_col_indices = Tensor::<i64, B>::zeros_on([nnz], backend);
-    let mut csr_row_offsets = Tensor::<i64, B>::zeros_on([rows + 1], backend);
+    // alloc_on: all nnz elements and all rows+1 offsets are written below — no zero-init needed.
+    let mut csr_values = Tensor::<T, B>::alloc_on([nnz], backend);
+    let mut csr_col_indices = Tensor::<i64, B>::alloc_on([nnz], backend);
+    let mut csr_row_offsets = Tensor::<i64, B>::alloc_on([rows + 1], backend);
 
     let val_mut = csr_values.as_mut_slice();
     let col_mut = csr_col_indices.as_mut_slice();

--- a/coeus-ops/src/sparse/mod.rs
+++ b/coeus-ops/src/sparse/mod.rs
@@ -1,3 +1,22 @@
+//! Sparse tensor operations: COO/CSR format conversions and sparse BLAS routines.
+//!
+//! # Zero-copy allocation policy
+//! Functions that write every output element use `alloc_on` (uninitialized
+//! allocation); functions that produce a dense output from a *sparse* source
+//! (e.g. `coo_to_dense`, `csr_to_dense`) use `zeros_on` because un-referenced
+//! positions must remain zero.
+//!
+//! | Function                  | Output alloc | Reason                               |
+//! |---------------------------|--------------|--------------------------------------|
+//! | `dense_to_coo`            | `alloc_on`   | writes every indices/values slot     |
+//! | `coo_to_dense`            | `zeros_on`   | sparse positions remain 0            |
+//! | `coo_to_csr`              | `alloc_on`   | writes all nnz + row offsets         |
+//! | `csr_to_dense`            | `zeros_on`   | sparse positions remain 0            |
+//! | `spmv`                    | `alloc_on`   | writes every output row              |
+//! | `spmm`                    | `alloc_on`   | writes every (row, col) pair         |
+//! | `spmm_backward_values`    | `alloc_on`   | writes every nnz gradient            |
+//! | `spmm_backward_dense`     | `alloc_on`   | writes every (k, n) pair             |
+
 // ── Sparse Tensor Operations Module ──
 
 /// Sparse format conversions (COO/CSR/dense interconversion).

--- a/coeus-ops/src/sparse/ops.rs
+++ b/coeus-ops/src/sparse/ops.rs
@@ -26,7 +26,8 @@ where
         "dimension mismatch: x shape must match CSR column count"
     );
 
-    let mut y = Tensor::<T, B>::zeros_on([rows], backend);
+    // alloc_on: every row r writes y[r] = sum via y_ptr.write — no zero-init needed.
+    let mut y = Tensor::<T, B>::alloc_on([rows], backend);
 
     let val_slice = a.values().as_slice();
     let col_slice = a.col_indices().as_slice();
@@ -82,7 +83,8 @@ where
         "dimension mismatch: CSR column count must match dense row count"
     );
 
-    let mut c = Tensor::<T, B>::zeros_on([m, n], backend);
+    // alloc_on: parallel_for over rows writes every c[r,j] for j in 0..n — no zero-init needed.
+    let mut c = Tensor::<T, B>::alloc_on([m, n], backend);
 
     let val_slice = a.values().as_slice();
     let col_slice = a.col_indices().as_slice();
@@ -143,7 +145,8 @@ where
     B::DeviceBuffer<i64>: CpuAddressableStorage<i64>,
 {
     let nnz = a_col_indices.numel();
-    let mut grad_values = Tensor::<T, B>::zeros_on([nnz], backend);
+    // alloc_on: every i in 0..nnz is written via grad_values_ptr.write(i, sum) — no zero-init needed.
+    let mut grad_values = Tensor::<T, B>::alloc_on([nnz], backend);
     let m = a_shape[0];
     let n = b.shape()[1];
 
@@ -210,7 +213,8 @@ where
     let m = a_shape[0];
     let k = a_shape[1];
     let n = grad_out.shape()[1];
-    let mut grad_b = Tensor::<T, B>::zeros_on([k, n], backend);
+    // alloc_on: parallel_for over j writes every grad_b[col,j] for col in 0..k — no zero-init needed.
+    let mut grad_b = Tensor::<T, B>::alloc_on([k, n], backend);
 
     let val_slice = a_values.as_slice();
     let col_slice = a_col_indices.as_slice();

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1718,3 +1718,29 @@ def test_log_sum_exp_matches_jax() -> None:
     t = jnp.array(data, dtype=jnp.float64).reshape(3, 3)
     exp = jsp.logsumexp(t, axis=1)
     _allclose("logsumexp", list(out_pyc.data), exp.tolist())
+
+# ---------------------------------------------------------------------------
+# tile / broadcast_to / index_select parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "tile"), reason="pycoeus.tile not available")
+def test_tile_matches_jax() -> None:
+    """jnp.tile(x, reps) vs pycoeus.tile(x, reps)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=False)
+    got = pycoeus.tile(x_pyc, [2, 3])
+    t = jnp.array(data, dtype=jnp.float64).reshape(2, 3)
+    exp = jnp.tile(t, (2, 3))
+    _allclose("tile", list(got.data), jnp.ravel(exp).tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "broadcast_to"), reason="pycoeus.broadcast_to not available")
+def test_broadcast_to_matches_jax() -> None:
+    """jnp.broadcast_to(x, shape) vs pycoeus.broadcast_to(x, shape)."""
+    data = [1.0, 2.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [1, 3], requires_grad=False)
+    got = pycoeus.broadcast_to(x_pyc, [4, 3])
+    t = jnp.array(data, dtype=jnp.float64).reshape(1, 3)
+    exp = jnp.broadcast_to(t, (4, 3))
+    _allclose("broadcast_to", list(got.data), jnp.ravel(exp).tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -4049,3 +4049,73 @@ def test_scatter_add_matches_pytorch() -> None:
     src_t = torch.tensor(src_data, dtype=torch.float64).reshape(2, 3)
     exp = base_t.scatter_add(0, idx_t, src_t)
     _allclose("scatter_add", list(got.data), exp.flatten().tolist())
+
+# ---------------------------------------------------------------------------
+# tile / broadcast_to / index_select / index_put parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "tile"), reason="pycoeus.tile not available")
+def test_tile_matches_pytorch() -> None:
+    """torch.tile(x, reps) vs pycoeus.tile(x, reps)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=False)
+    got = pycoeus.tile(x_pyc, [2, 3])
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3)
+    exp = torch.tile(t, (2, 3))
+    _allclose("tile", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "broadcast_to"), reason="pycoeus.broadcast_to not available")
+def test_broadcast_to_matches_pytorch() -> None:
+    """torch.broadcast_to(x, shape) vs pycoeus.broadcast_to(x, shape)."""
+    data = [1.0, 2.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [1, 3], requires_grad=False)
+    got = pycoeus.broadcast_to(x_pyc, [4, 3])
+    t = torch.tensor(data, dtype=torch.float64).reshape(1, 3)
+    exp = torch.broadcast_to(t, (4, 3))
+    _allclose("broadcast_to", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "index_select"), reason="pycoeus.index_select not available")
+def test_index_select_dim1_matches_pytorch() -> None:
+    """torch.index_select(x, 1, idx) vs pycoeus.index_select(x, 1, idx)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    idx_data = [2.0, 0.0]
+    x_pyc = pycoeus.Tensor(data, [3, 3], requires_grad=True)
+    idx_pyc = pycoeus.Tensor(idx_data, [2], requires_grad=False)
+    got = pycoeus.index_select(x_pyc, 1, idx_pyc)
+    got.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(3, 3).requires_grad_(True)
+    idx_t = torch.tensor([2, 0], dtype=torch.int64)
+    exp_t = torch.index_select(t, 1, idx_t)
+    exp_t.sum().backward()
+    _allclose("index_select_fwd", list(got.data), exp_t.detach().flatten().tolist())
+    _allclose("index_select_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "index_put"), reason="pycoeus.index_put not available")
+def test_index_put_matches_pytorch() -> None:
+    """x.index_put((indices,), values, accumulate=False)."""
+    data = [0.0] * 6
+    vals = [10.0, 20.0, 30.0]
+    idx = [0.0, 2.0, 4.0]
+    x_pyc = pycoeus.Tensor(data, [6], requires_grad=False)
+    idx_pyc = pycoeus.Tensor(idx, [3], requires_grad=False)
+    v_pyc = pycoeus.Tensor(vals, [3], requires_grad=False)
+    got = pycoeus.index_put(x_pyc, idx_pyc, v_pyc, accumulate=False)
+    t = torch.zeros(6, dtype=torch.float64)
+    exp = t.index_put((torch.tensor([0, 2, 4], dtype=torch.int64),),
+                      torch.tensor(vals, dtype=torch.float64), accumulate=False)
+    _allclose("index_put", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "nonzero"), reason="pycoeus.nonzero not available")
+def test_nonzero_matches_pytorch() -> None:
+    """torch.nonzero(x).T vs pycoeus.nonzero(x)."""
+    data = [0.0, 1.0, 0.0, 2.0, 0.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [6], requires_grad=False)
+    got = pycoeus.nonzero(x_pyc)
+    t = torch.tensor(data, dtype=torch.float64)
+    exp = torch.nonzero(t, as_tuple=False).t().squeeze(0)
+    _allclose("nonzero", list(got.data), exp.float().tolist())


### PR DESCRIPTION
Zero-copy: alloc_on for SDPA forward output+attn_weights; sparse spmv/spmm/backward/dense_to_coo/coo_to_csr. Sparse mod-level doc table. Moirai SeqCst audit (no changes — fences are necessary). Parity: PyTorch 130, JAX 64. G-043: 57 rows. All 661 tests pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces zero-copy optimizations by replacing `zeros_on` with `alloc_on` (uninitialized allocation) in attention and sparse operations where kernels write every output element, eliminating unnecessary zero-initialization overhead. The changes affect **scaled dot-product attention** forward pass output and attention weights, plus sparse operations (`spmv`, `spmm`, `dense_to_coo`, `coo_to_csr`, and backward passes). A comprehensive documentation table in `sparse/mod.rs` clarifies when each allocation strategy is appropriate. Additionally, the PR adds **two new benchmark functions** (SDP attention and nanmean) comprising 57 total benchmark rows, and extends **PyTorch and JAX parity test suites** with 130 and 64 tests respectively, covering operations like `tile`, `broadcast_to`, `index_select`, `index_put`, and `nonzero`.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-ops/src/sparse/mod.rs` |
| 2 | `coeus-ops/src/attention.rs` |
| 3 | `coeus-ops/src/backend_ops/cpu_impl/attention.rs` |
| 4 | `coeus-ops/src/sparse/conversions.rs` |
| 5 | `coeus-ops/src/sparse/ops.rs` |
| 6 | `coeus-nn/benches/nn_bench.rs` |
| 7 | `coeus-python/tests/test_pytorch_parity.py` |
| 8 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public sparse tensor API with conversion and matrix/vector operations available from one place.
  * Expanded tensor operation coverage for attention, sparse math, and shape/indexing behavior.

* **Tests**
  * Added parity tests to verify more tensor operations match expected behavior across backends.

* **Documentation**
  * Improved operation docs with clearer shape, masking, and allocation details.

* **Chores**
  * Added benchmark coverage for attention and NaN-aware reduction performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->