### PR TITLE
test(autograd): Close ConvTranspose3d parity

### DIFF
--- a/coeus-autograd/src/ops/activation/relu.rs
+++ b/coeus-autograd/src/ops/activation/relu.rs
@@ -215,7 +215,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Pre
 /// Tracked PReLU with a single scalar α slope.
 ///
 /// `y = max(0, x) + α · min(0, x)`. Gradient is `1` if `x ≥ 0`, else `α`.
-/// For per-channel α (PyTorch's [`nn.PReLU(num_parameters=N)`]), compose the
+/// For per-channel α (PyTorch's `nn.PReLU(num_parameters=N)`), compose the
 /// tracked scalar-α helper with `coeus_ops::broadcast_to` so α matches the
 /// input's channel axis.
 #[must_use]

--- a/coeus-autograd/tests/autograd/nn_conv.rs
+++ b/coeus-autograd/tests/autograd/nn_conv.rs
@@ -1,4 +1,4 @@
-use coeus_autograd::{conv_transpose1d, conv_transpose2d, Var};
+use coeus_autograd::{conv_transpose1d, conv_transpose2d, conv_transpose3d, Var};
 use coeus_core::MoiraiBackend;
 use coeus_tensor::Tensor;
 
@@ -135,4 +135,71 @@ fn conv_transpose2d_no_bias_backward() {
     // elements should equal sum-over-input times output_area/input_numel.
     let gw_sum: f64 = gw.to_contiguous().as_slice().iter().copied().sum();
     assert!(gw_sum > 0.0, "grad_weight must be nonzero");
+}
+
+#[test]
+fn conv_transpose3d_backward_accumulates_exact_gradients() {
+    // Input  [N=1, C_in=1, D=2, H=2, W=2] = [1,2,3,4,5,6,7,8].
+    // Weight [C_in=1, C_out=1, KD=1, KH=1, KW=1] = [1].
+    // Bias   [C_out=1] = [0.5].
+    // stride=1, padding=0, dilation=1: forward is input + bias.
+    //
+    // Backward with seed [1,2,3,4,5,6,7,8]:
+    //   grad_input  = seed
+    //   grad_weight = sum(input * seed) = 1^2 + ... + 8^2 = 204
+    //   grad_bias   = sum(seed) = 36
+    let backend = MoiraiBackend::new();
+    let input = Var::new(
+        Tensor::from_slice_on(
+            vec![1, 1, 2, 2, 2],
+            &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            &backend,
+        ),
+        true,
+    );
+    let weight = Var::new(
+        Tensor::from_slice_on(vec![1, 1, 1, 1, 1], &[1.0_f64], &backend),
+        true,
+    );
+    let bias = Var::new(Tensor::from_slice_on(vec![1], &[0.5_f64], &backend), true);
+
+    let out_tensor = coeus_ops::conv_transpose3d(
+        &input.tensor,
+        &weight.tensor,
+        Some(&bias.tensor),
+        1,
+        0,
+        0,
+        1,
+        &backend,
+    );
+    let out = conv_transpose3d(&input, &weight, &Some(bias.clone()), out_tensor, 1, 0, 0, 1);
+    assert_eq!(
+        out.tensor.to_contiguous().as_slice(),
+        &[1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5],
+        "conv_transpose3d forward"
+    );
+
+    let seed = Tensor::from_slice_on(
+        vec![1, 1, 2, 2, 2],
+        &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        &backend,
+    );
+    out.backward_with_seed(seed);
+
+    assert_eq!(
+        input.grad().unwrap().to_contiguous().as_slice(),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        "conv_transpose3d grad_input"
+    );
+    assert_eq!(
+        weight.grad().unwrap().to_contiguous().as_slice(),
+        &[204.0],
+        "conv_transpose3d grad_weight"
+    );
+    assert_eq!(
+        bias.grad().unwrap().to_contiguous().as_slice(),
+        &[36.0],
+        "conv_transpose3d grad_bias"
+    );
 }


### PR DESCRIPTION
Recovers the sole unmerged content from stray branches `feat/g038-l1-loss`/`feat/g038-poisson-nll` (both names pointed at one June-28 commit; their namesake losses landed long ago):

- **test**: add `conv_transpose3d_backward_accumulates_exact_gradients` to the Rust-side autograd suite (the Python-side pytorch parity test landed separately; this pins the exact-gradient contract in coeus-autograd's own tests).
- **docs**: fix a broken rustdoc intra-doc link in the PReLU docs (`[`nn.PReLU(...)`]` is not a resolvable item path).

Cherry-picked with the commit's stale June-28 PM-doc hunks dropped (main's docs advanced through MS-250 since).

## Verification
- `cargo nextest run -p coeus-autograd -E 'test(conv_transpose)'`: **4/4** (incl. the new 3d test)
- `cargo test --doc -p coeus-autograd`: 15/15; `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes the test coverage for `ConvTranspose3d` backward pass by adding a comprehensive gradient accumulation test, and fixes a broken rustdoc link in the PReLU documentation. The test verifies that gradients for input, weight, and bias are correctly computed for a 3D transposed convolution operation with known expected values.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/activation/relu.rs` |
| 2 | `coeus-autograd/tests/autograd/nn_conv.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the wording and formatting of a PReLU note for per-channel usage.

* **Tests**
  * Added coverage for 3D transposed convolution backward behavior.
  * Verified exact gradient accumulation for input, weight, and bias values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->