### PR TITLE
MS-260: hardshrink/softshrink/softsign/mish/celu parity (PyTorch 157, JAX 78)

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2627,10 +2627,13 @@ fn bench_vector_norm_forward(c: &mut Criterion) {
     group.finish();
 }
 
+// Reference is consumed by `criterion_group!` macro below; the macro
+// expansion does not propagate usage info, so suppress `dead_code` here.
+#[allow(dead_code, reason = "referenced by criterion_group! macro below")]
 fn bench_tan_forward(c: &mut Criterion) {
     // tan: [128, 256] — important for rotation/phase ops in signal processing.
     let input_data: Vec<f32> = (0..(BATCH * FEATURES))
-        .map(|i| (i as f32 * 0.0021).sin() * 1.5)  // stay in safe domain (|x| < π/2)
+        .map(|i| (i as f32 * 0.0021).sin() * 1.5) // stay in safe domain (|x| < π/2)
         .collect();
     let x_seq = Var::new(
         Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
@@ -2663,6 +2666,9 @@ fn bench_tan_forward(c: &mut Criterion) {
     group.finish();
 }
 
+// Reference is consumed by `criterion_group!` macro below; the macro
+// expansion does not propagate usage info, so suppress `dead_code` here.
+#[allow(dead_code, reason = "referenced by criterion_group! macro below")]
 fn bench_atan_forward(c: &mut Criterion) {
     // atan: [128, 256] — arctan is used in angle reconstruction and attention scores.
     let input_data: Vec<f32> = (0..(BATCH * FEATURES))

--- a/coeus-ops/src/adaptive_pool.rs
+++ b/coeus-ops/src/adaptive_pool.rs
@@ -38,6 +38,10 @@ fn region_end(i: usize, in_size: usize, out_size: usize) -> usize {
 /// Adaptive average pooling for `[N, C, L]` → `[N, C, output_size]`.
 ///
 /// Equivalent to PyTorch `nn.AdaptiveAvgPool1d(output_size)`.
+///
+/// # Memory
+/// Output is allocated uninitialized (`alloc_on`); every `[n, c, o]` position
+/// is written by the loop before the function returns.
 pub fn adaptive_avg_pool1d<T: Float, B: BackendOps<T> + Default>(
     input: &Tensor<T, B>,
     output_size: usize,

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1884,3 +1884,31 @@ def test_atan_matches_jax() -> None:
     exp = jnp.arctan(jnp.array(data, dtype=jnp.float64))
     _allclose("atan", list(got.data), exp.tolist(), atol=1e-12)
 
+# ---------------------------------------------------------------------------
+# hardshrink / mish / celu parity (JAX stax/nn equivalents)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mish"), reason="pycoeus.mish not available")
+def test_mish_matches_jax() -> None:
+    """x * tanh(softplus(x)) vs pycoeus.mish(x)."""
+    import jax.nn
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.mish(x_pyc)
+    t = jnp.array(data, dtype=jnp.float64)
+    # JAX mish: x * tanh(softplus(x))
+    exp = t * jnp.tanh(jnp.log1p(jnp.exp(t)))
+    _allclose("mish", list(got.data), exp.tolist(), atol=1e-8)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softsign"), reason="pycoeus.softsign not available")
+def test_softsign_matches_jax() -> None:
+    """jax.nn.soft_sign(x) vs pycoeus.softsign(x)."""
+    import jax.nn
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.softsign(x_pyc)
+    t = jnp.array(data, dtype=jnp.float64)
+    exp = jax.nn.soft_sign(t)
+    _allclose("softsign", list(got.data), exp.tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -4560,3 +4560,76 @@ def test_atan_matches_pytorch() -> None:
     _allclose("atan_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
     _allclose("atan_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
 
+# ---------------------------------------------------------------------------
+# erfinv / hardshrink / softshrink / softsign / mish / celu / elu parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "hardshrink"), reason="pycoeus.hardshrink not available")
+def test_hardshrink_matches_pytorch() -> None:
+    """torch.hardshrink(x, lambd=0.5) vs pycoeus.hardshrink(x, lambd=0.5)."""
+    data = [-1.0, -0.3, 0.0, 0.3, 1.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.hardshrink(x_pyc, 0.5)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.hardshrink(t, lambd=0.5)
+    out_t.sum().backward()
+    _allclose("hardshrink_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("hardshrink_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softshrink"), reason="pycoeus.softshrink not available")
+def test_softshrink_matches_pytorch() -> None:
+    """torch.softshrink(x, lambd=0.5) vs pycoeus.softshrink(x, lambd=0.5)."""
+    data = [-1.0, -0.3, 0.0, 0.3, 1.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.softshrink(x_pyc, 0.5)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.softshrink(t, lambd=0.5)
+    out_t.sum().backward()
+    _allclose("softshrink_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("softshrink_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softsign"), reason="pycoeus.softsign not available")
+def test_softsign_matches_pytorch() -> None:
+    """torch.nn.functional.softsign(x) vs pycoeus.softsign(x)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.softsign(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.softsign(t)
+    out_t.sum().backward()
+    _allclose("softsign_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("softsign_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mish"), reason="pycoeus.mish not available")
+def test_mish_matches_pytorch() -> None:
+    """torch.nn.functional.mish(x) vs pycoeus.mish(x), fwd+bwd."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.mish(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.mish(t)
+    out_t.sum().backward()
+    _allclose("mish_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-8)
+    _allclose("mish_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-8)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "celu"), reason="pycoeus.celu not available")
+def test_celu_matches_pytorch() -> None:
+    """torch.nn.functional.celu(x, alpha=1.0) vs pycoeus.celu(x, alpha=1.0)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.celu(x_pyc, 1.0)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.celu(t, alpha=1.0)
+    out_t.sum().backward()
+    _allclose("celu_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-10)
+    _allclose("celu_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-10)


### PR DESCRIPTION
Adds hardshrink, softshrink, softsign, mish, celu fwd+bwd PyTorch parity tests. JAX: mish, softsign. Adaptive_pool doc. PyTorch: 157, JAX: 78. All 474 Rust tests pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds forward and backward parity tests for five activation functions (`hardshrink`, `softshrink`, `softsign`, `mish`, and `celu`) against PyTorch, and two activation functions (`mish` and `softsign`) against JAX. Additionally, it includes minor code cleanup: documentation improvement for `adaptive_avg_pool1d` explaining memory allocation behavior, and suppression of spurious dead-code warnings in benchmark functions. The changes bring the test count to 157 PyTorch parity tests and 78 JAX parity tests, with all 474 Rust tests passing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-ops/src/adaptive_pool.rs` |
| 4 | `coeus-nn/benches/nn_bench.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-ops/src/adaptive_pool.rs` | Documentation addition for adaptive_avg_pool1d memory allocation behavior is unrelated to the activation function parity tests that are the focus of this PR |
| `coeus-nn/benches/nn_bench.rs` | Code cleanup (dead_code lint suppression and minor formatting) for tan/atan benchmarks is unrelated to the new activation function parity tests being added |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->