### PR TITLE
MS-262: fix clamp backward at kink boundaries (inclusive [lo,hi] per PyTorch)

### DIFF
--- a/coeus-autograd/src/ops/activation/math.rs
+++ b/coeus-autograd/src/ops/activation/math.rs
@@ -286,18 +286,30 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let shape = self.input_tensor.shape();
-            // x - lo ≥ 0  ⟺  x ≥ lo
+            let one_scalar = Tensor::full_on(shape, T::one(), &backend);
+
+            // 1_{lo <= x} = 1 - 1_{x < lo} = 1 - ReluGrad(lo - x).
+            // At the kink x = lo: (lo - x) = 0, ReluGrad(0) = 0 (strict),
+            // so the indicator evaluates to 1 — matching PyTorch's
+            // `aten::clamp_backward_kernel` which is `[min, max]` inclusive.
             let lo_t = Tensor::full_on(shape, self.min_val, &backend);
-            let shifted_lo = coeus_ops::sub(&self.input_tensor, &lo_t, &backend);
-            let mask_lo =
-                coeus_ops::elementwise_unary(&shifted_lo, &backend, coeus_ops::UnaryOp::ReluGrad);
-            // hi - x ≥ 0  ⟺  x ≤ hi
+            let lo_minus_x = coeus_ops::sub(&lo_t, &self.input_tensor, &backend);
+            let mask_lt_lo =
+                coeus_ops::elementwise_unary(&lo_minus_x, &backend, coeus_ops::UnaryOp::ReluGrad);
+            let mask_lo_ge = coeus_ops::sub(&one_scalar, &mask_lt_lo, &backend);
+
+            // 1_{x <= hi} = 1 - 1_{x > hi} = 1 - ReluGrad(x - hi).
+            // At the kink x = hi: (x - hi) = 0, ReluGrad(0) = 0 (strict),
+            // so the upper indicator evaluates to 1 — same inclusive
+            // convention as the lower bound.
             let hi_t = Tensor::full_on(shape, self.max_val, &backend);
-            let shifted_hi = coeus_ops::sub(&hi_t, &self.input_tensor, &backend);
-            let mask_hi =
-                coeus_ops::elementwise_unary(&shifted_hi, &backend, coeus_ops::UnaryOp::ReluGrad);
-            // Inside mask = lo_mask AND hi_mask (product of indicators)
-            let inside = coeus_ops::mul(&mask_lo, &mask_hi, &backend);
+            let x_minus_hi = coeus_ops::sub(&self.input_tensor, &hi_t, &backend);
+            let mask_gt_hi =
+                coeus_ops::elementwise_unary(&x_minus_hi, &backend, coeus_ops::UnaryOp::ReluGrad);
+            let mask_hi_le = coeus_ops::sub(&one_scalar, &mask_gt_hi, &backend);
+
+            // Inside mask = mask_lo_ge AND mask_hi_le (product of indicators)
+            let inside = coeus_ops::mul(&mask_lo_ge, &mask_hi_le, &backend);
             let grad_in = coeus_ops::mul(grad_out, &inside, &backend);
             let lock = g.write();
             coeus_ops::add_assign(lock, &grad_in, &backend);

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2661,9 +2661,7 @@ fn bench_erf_forward(c: &mut Criterion) {
 
 fn bench_sin_cos_forward(c: &mut Criterion) {
     // sin+cos fused: [128, 256] — typical in RoPE / positional encoding.
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
-        .map(|i| i as f32 * 0.0031)
-        .collect();
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| i as f32 * 0.0031).collect();
     let x_seq = Var::new(
         Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
         false,

--- a/coeus-nn/tests/act_extended_tests.rs
+++ b/coeus-nn/tests/act_extended_tests.rs
@@ -455,6 +455,30 @@ fn leaky_relu_kink_at_zero_returns_slope() {
     assert_close_slice("leaky_relu_kink_dx", grad.as_slice(), &expected_grad, 1e-12);
 }
 
+// ── Clamp subgradient at x = min and x = max (documented contract parity vs PyTorch) ──
+
+/// PyTorch's `aten::clamp_backward_kernel` returns `1` at both boundaries
+/// `x == min` and `x == max` (the indicator `1_{lo <= x <= hi}` is inclusive
+/// on both ends). Coeus' `ClampNode::backward` must agree at the kink.
+#[test]
+fn clamp_kink_at_boundary_returns_one() {
+    let lo = -1.0_f64;
+    let hi = 2.0_f64;
+    let data = vec![-1.0_f64, 2.0_f64]; // exact min and exact max
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([data.len()], &data),
+        true,
+    );
+    let output = coeus_autograd::clamp(&input, lo, hi);
+    // Forward at the boundary is unchanged (clamp(x, x, x) = x).
+    assert_close_slice("clamp_kink_out", output.tensor.as_slice(), &data, 1e-12);
+    output.backward();
+    let grad = input.grad().expect("clamp requires grad");
+    // Backward at both kink positions must be 1 per PyTorch convention.
+    let expected_grad = vec![1.0_f64, 1.0_f64];
+    assert_close_slice("clamp_kink_dx", grad.as_slice(), &expected_grad, 1e-12);
+}
+
 // ── Module-level forward smoke tests (no parameters) ────────────────────
 
 #[test]


### PR DESCRIPTION
Fixes ClampNode::backward to return gradient 1 at x==lo and x==hi. Old: ReluGrad(x-lo)*ReluGrad(hi-x)=0 at kinks. New: complement pattern (1 - ReluGrad) gives inclusive boundary. New test: clamp_kink_at_boundary_returns_one. 400/400 tests pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the gradient computation for the `clamp` operation at boundary values (`x == lo` and `x == hi`) to match PyTorch's behavior. Previously, the backward pass incorrectly returned zero at these kink points; now it correctly returns one by using a complementary indicator pattern (`1 - ReluGrad`) that makes the boundary conditions inclusive. A new test (`clamp_kink_at_boundary_returns_one`) verifies the fix, ensuring the gradient is `1.0` at both boundaries as per PyTorch's `aten::clamp_backward_kernel` convention.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/act_extended_tests.rs` |
| 2 | `coeus-autograd/src/ops/activation/math.rs` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-nn/benches/nn_bench.rs` | This appears to be a formatting-only change (collapsing a multi-line map expression) in a benchmark file for sin/cos operations, which is unrelated to the clamp gradient fix that is the main purpose of this PR. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gradient behavior for clamped values at the exact lower and upper bounds, so boundary points now receive a gradient of `1` instead of being treated as outside the range.

* **Tests**
  * Added coverage to verify clamp outputs and gradients at both boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->