### PR TITLE
MS-266-272: abs/sqrt/floor/ceil/round/trunc/clamp-boundary parity (PyTorch 171, JAX 86) + bench 69

### DIFF
--- a/coeus-autograd/tests/autograd/reductions.rs
+++ b/coeus-autograd/tests/autograd/reductions.rs
@@ -1,5 +1,6 @@
 use coeus_autograd::{
-    cumsum, log_sum_exp, max_axis, mean_axis, min_axis, norm_p, norm_p_axis, sum_axis, Var,
+    cumsum, log_sum_exp, max_axis, mean_axis, min_axis, norm_p, norm_p_axis, std_dev, sum_axis,
+    var, var_mean, var_mean_axis, Var,
 };
 use coeus_core::MoiraiBackend;
 use coeus_tensor::Tensor;
@@ -249,4 +250,96 @@ fn test_cumsum_autograd() {
     assert!((gx_s[1] - 9.0).abs() < 1e-10, "cumsum grad[1]: {}", gx_s[1]);
     assert!((gx_s[2] - 7.0).abs() < 1e-10, "cumsum grad[2]: {}", gx_s[2]);
     assert!((gx_s[3] - 4.0).abs() < 1e-10, "cumsum grad[3]: {}", gx_s[3]);
+}
+
+#[test]
+fn test_var_autograd_matches_analytic() {
+    let backend = MoiraiBackend::new();
+    // x = [1,2,3,4]: mean = 2.5; unbiased var = ((1.5)^2+(0.5)^2+(0.5)^2+(1.5)^2)/3
+    // = 5/3; biased divides by 4 -> 5/4.
+    let data = [1.0f64, 2.0, 3.0, 4.0];
+    let x = Var::new(Tensor::from_slice_on(vec![4], &data, &backend), true);
+
+    let (v, mu) = var_mean(&x, true);
+    assert!((mu.tensor.as_slice()[0] - 2.5).abs() < 1e-14, "mean");
+    assert!(
+        (v.tensor.as_slice()[0] - 5.0 / 3.0).abs() < 1e-14,
+        "unbiased var: {}",
+        v.tensor.as_slice()[0]
+    );
+    let vb = var(&x, false);
+    assert!((vb.tensor.as_slice()[0] - 1.25).abs() < 1e-14, "biased var");
+    let s = std_dev(&x, true);
+    assert!(
+        (s.tensor.as_slice()[0] - (5.0f64 / 3.0).sqrt()).abs() < 1e-14,
+        "std"
+    );
+
+    // Analytic gradient of the unbiased variance: dv/dx_i = 2(x_i - mean)/(n-1)
+    // (the mean-path terms cancel because sum(x_j - mean) = 0).
+    v.backward();
+    let gx = x.grad().unwrap();
+    let gx = gx.as_slice();
+    for (i, &xi) in data.iter().enumerate() {
+        let expected = 2.0 * (xi - 2.5) / 3.0;
+        assert!(
+            (gx[i] - expected).abs() < 1e-14,
+            "d var/dx[{i}]: {} vs {expected}",
+            gx[i]
+        );
+    }
+
+    // Numerical-gradient cross-check (central differences, h = 1e-6): an
+    // implementation-independent oracle for the composed backward.
+    let h = 1e-6f64;
+    for i in 0..data.len() {
+        let mut dp = data;
+        dp[i] += h;
+        let mut dm = data;
+        dm[i] -= h;
+        let vp = var(
+            &Var::new(Tensor::from_slice_on(vec![4], &dp, &backend), false),
+            true,
+        );
+        let vm = var(
+            &Var::new(Tensor::from_slice_on(vec![4], &dm, &backend), false),
+            true,
+        );
+        let numeric = (vp.tensor.as_slice()[0] - vm.tensor.as_slice()[0]) / (2.0 * h);
+        assert!(
+            (numeric - gx[i]).abs() < 1e-8,
+            "numeric {numeric} vs autograd {} at {i}",
+            gx[i]
+        );
+    }
+}
+
+#[test]
+fn test_var_axis_autograd_matches_analytic() {
+    let backend = MoiraiBackend::new();
+    // [[1,2,3],[4,6,8]] axis=1: means [2,6]; unbiased vars [1, 4].
+    let data = [1.0f64, 2.0, 3.0, 4.0, 6.0, 8.0];
+    let x = Var::new(Tensor::from_slice_on(vec![2, 3], &data, &backend), true);
+
+    let (v, mu) = var_mean_axis(&x, 1, true);
+    assert_eq!(v.tensor.shape(), &[2, 1], "keepdim shape");
+    let vs = v.tensor.as_slice().to_vec();
+    let ms = mu.tensor.as_slice().to_vec();
+    assert!((ms[0] - 2.0).abs() < 1e-14 && (ms[1] - 6.0).abs() < 1e-14, "means");
+    assert!((vs[0] - 1.0).abs() < 1e-14, "row0 var: {}", vs[0]);
+    assert!((vs[1] - 4.0).abs() < 1e-14, "row1 var: {}", vs[1]);
+
+    // Row-local gradient: dv_r/dx_ri = 2(x_ri - mean_r)/(extent-1), extent-1 = 2.
+    v.backward();
+    let gx = x.grad().unwrap();
+    let gx = gx.as_slice();
+    let means = [2.0, 2.0, 2.0, 6.0, 6.0, 6.0];
+    for i in 0..6 {
+        let expected = 2.0 * (data[i] - means[i]) / 2.0;
+        assert!(
+            (gx[i] - expected).abs() < 1e-14,
+            "d var/dx[{i}]: {} vs {expected}",
+            gx[i]
+        );
+    }
 }

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2807,6 +2807,21 @@ fn bench_asin_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_erfc_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - erfc forward (128x256)");
+    group.bench_function("Burn NdArray (1-tanh proxy)", |b| {
+        b.iter(|| { let t = black_box(x_burn.clone()).tanh(); black_box(t.mul_scalar(-1.0f32).add_scalar(1.0f32)) })
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::erfc(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::erfc(black_box(&x_moirai)))) });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -2873,6 +2888,8 @@ criterion_group!(
     bench_tan_forward,
     bench_atan_forward,
     bench_clamp_forward,
-    bench_asin_forward
+    bench_asin_forward,
+    bench_erfc_forward
 );
 criterion_main!(benches);
+

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -1964,3 +1964,47 @@ def test_sign_matches_jax() -> None:
     t = jnp.array(data, dtype=jnp.float64)
     exp = jnp.sign(t)
     _allclose("sign", list(got.data), exp.tolist())
+
+# ---------------------------------------------------------------------------
+# abs / sqrt / floor / ceil parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "abs"), reason="pycoeus.abs not available")
+def test_abs_matches_jax() -> None:
+    """jnp.abs(x) vs pycoeus.abs(x)."""
+    data = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.abs(x_pyc)
+    exp = jnp.abs(jnp.array(data, dtype=jnp.float64))
+    _allclose("abs", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "sqrt"), reason="pycoeus.sqrt not available")
+def test_sqrt_matches_jax() -> None:
+    """jnp.sqrt(x) vs pycoeus.sqrt(x)."""
+    data = [0.25, 1.0, 4.0, 9.0, 16.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.sqrt(x_pyc)
+    exp = jnp.sqrt(jnp.array(data, dtype=jnp.float64))
+    _allclose("sqrt", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "floor"), reason="pycoeus.floor not available")
+def test_floor_matches_jax() -> None:
+    """jnp.floor(x) vs pycoeus.floor(x)."""
+    data = [-1.9, -1.0, 0.5, 1.0, 1.9]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.floor(x_pyc)
+    exp = jnp.floor(jnp.array(data, dtype=jnp.float64))
+    _allclose("floor", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "ceil"), reason="pycoeus.ceil not available")
+def test_ceil_matches_jax() -> None:
+    """jnp.ceil(x) vs pycoeus.ceil(x)."""
+    data = [-1.9, -1.0, 0.5, 1.0, 1.9]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.ceil(x_pyc)
+    exp = jnp.ceil(jnp.array(data, dtype=jnp.float64))
+    _allclose("ceil", list(got.data), exp.tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -4732,3 +4732,88 @@ def test_recip_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("recip_fwd", list(out_pyc.data), out_t.detach().tolist())
     _allclose("recip_bwd", list(x_pyc.grad), t.grad.tolist())
+
+# ---------------------------------------------------------------------------
+# abs / sqrt / floor / ceil / round / trunc / clamp boundary parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "abs"), reason="pycoeus.abs not available")
+def test_abs_matches_pytorch() -> None:
+    """torch.abs(x) vs pycoeus.abs(x), fwd+bwd."""
+    data = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.abs(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.abs(t)
+    out_t.sum().backward()
+    _allclose("abs_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("abs_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "sqrt"), reason="pycoeus.sqrt not available")
+def test_sqrt_matches_pytorch() -> None:
+    """torch.sqrt(x) vs pycoeus.sqrt(x), fwd+bwd."""
+    data = [0.25, 1.0, 4.0, 9.0, 16.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.sqrt(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.sqrt(t)
+    out_t.sum().backward()
+    _allclose("sqrt_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("sqrt_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "floor"), reason="pycoeus.floor not available")
+def test_floor_matches_pytorch() -> None:
+    """torch.floor(x) vs pycoeus.floor(x)."""
+    data = [-1.9, -1.0, 0.5, 1.0, 1.9]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.floor(x_pyc)
+    exp = torch.floor(torch.tensor(data, dtype=torch.float64))
+    _allclose("floor", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "ceil"), reason="pycoeus.ceil not available")
+def test_ceil_matches_pytorch() -> None:
+    """torch.ceil(x) vs pycoeus.ceil(x)."""
+    data = [-1.9, -1.0, 0.5, 1.0, 1.9]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.ceil(x_pyc)
+    exp = torch.ceil(torch.tensor(data, dtype=torch.float64))
+    _allclose("ceil", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "round"), reason="pycoeus.round not available")
+def test_round_matches_pytorch() -> None:
+    """torch.round(x) vs pycoeus.round(x)."""
+    data = [-1.5, -0.5, 0.4, 0.5, 1.5]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.round(x_pyc)
+    exp = torch.round(torch.tensor(data, dtype=torch.float64))
+    _allclose("round", list(got.data), exp.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "trunc"), reason="pycoeus.trunc not available")
+def test_trunc_matches_pytorch() -> None:
+    """torch.trunc(x) vs pycoeus.trunc(x)."""
+    data = [-1.9, -1.0, 0.0, 1.4, 1.9]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.trunc(x_pyc)
+    exp = torch.trunc(torch.tensor(data, dtype=torch.float64))
+    _allclose("trunc", list(got.data), exp.tolist())
+
+
+def test_clamp_boundary_matches_pytorch() -> None:
+    """Gradient is 1 at x==min and x==max (inclusive boundary per PyTorch convention)."""
+    data = [-1.0, 0.5, 2.0]  # x[0]=min, x[2]=max
+    x_pyc = pycoeus.Tensor(data, [3], requires_grad=True)
+    out_pyc = pycoeus.clamp(x_pyc, -1.0, 2.0)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.clamp(t, min=-1.0, max=2.0)
+    out_t.sum().backward()
+    _allclose("clamp_boundary_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("clamp_boundary_bwd", list(x_pyc.grad), t.grad.tolist())


### PR DESCRIPTION
abs/sqrt fwd+bwd, floor/ceil/round/trunc fwd-only, clamp boundary kink test. JAX: abs/sqrt/floor/ceil. G-043 erfc bench. PyTorch: 171, JAX: 86, bench: 69. 453/453 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive test coverage for mathematical operations including `abs`, `sqrt`, `floor`, `ceil`, `round`, `trunc`, and `clamp` against PyTorch and JAX to ensure numerical parity. It includes forward and backward pass validation for differentiable operations (`abs`, `sqrt`), forward-only tests for non-differentiable rounding operations, a boundary condition test for `clamp` gradients, and adds variance/standard deviation autograd tests with both analytic and numerical gradient verification. Additionally, an `erfc` (complementary error function) benchmark is added to compare performance across backends.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-autograd/tests/autograd/reductions.rs` |
| 4 | `coeus-nn/benches/nn_bench.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-autograd/tests/autograd/reductions.rs` | This file adds variance and standard deviation autograd tests, which are statistical reduction operations unrelated to the mathematical element-wise operations (abs/sqrt/floor/ceil/round/trunc/clamp) mentioned in the PR title and body. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->