### PR TITLE
MS-270: var/std parity tests + G-043 to 70 rows (std bench)

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2822,6 +2822,22 @@ fn bench_erfc_forward(c: &mut Criterion) {
     group.finish();
 }
 
+
+fn bench_std_forward(c: &mut Criterion) {
+    // std (unbiased): [128, 256] — variance reduction used in normalization.
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.0017).sin()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - std forward (128x256)");
+    group.bench_function("Burn NdArray (mean proxy)", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).mean()))
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::std_dev(&x_seq, true))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::std_dev(&x_moirai, true))) });
+    group.finish();
+}
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -2889,7 +2905,8 @@ criterion_group!(
     bench_atan_forward,
     bench_clamp_forward,
     bench_asin_forward,
-    bench_erfc_forward
+    bench_erfc_forward,
+    bench_std_forward
 );
 criterion_main!(benches);
 

--- a/coeus-python/src/ops/statistics.rs
+++ b/coeus-python/src/ops/statistics.rs
@@ -4,6 +4,38 @@ use coeus_tensor::Tensor;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+/// Drop the reduced axis unless `keepdim`, collapsing a fully-reduced result to `[1]`.
+fn drop_axis_dim(
+    inner: coeus_autograd::Var<f64, MoiraiBackend>,
+    axis: usize,
+    keepdim: bool,
+) -> coeus_autograd::Var<f64, MoiraiBackend> {
+    if keepdim {
+        return inner;
+    }
+    let mut shape = inner.tensor.shape().to_vec();
+    shape.remove(axis);
+    if shape.is_empty() {
+        shape = vec![1];
+    }
+    coeus_autograd::reshape(&inner, shape)
+}
+
+/// Reject reductions whose Bessel-corrected denominator would be zero.
+fn validate_stat_denominator(op: &str, count: usize, unbiased: bool) -> PyResult<()> {
+    if count == 0 {
+        return Err(PyValueError::new_err(format!(
+            "{op}: empty tensors have no variance"
+        )));
+    }
+    if unbiased && count == 1 {
+        return Err(PyValueError::new_err(format!(
+            "{op}: unbiased variance of a single element divides by zero"
+        )));
+    }
+    Ok(())
+}
+
 #[pyfunction]
 #[pyo3(name = "std", signature = (input, unbiased = true, axis = None, keepdim = false))]
 pub fn std_dev(
@@ -12,23 +44,18 @@ pub fn std_dev(
     axis: Option<usize>,
     keepdim: bool,
     py: Python<'_>,
-) -> PyResult<Py<PyAny>> {
-    let backend = MoiraiBackend::new();
-    if input.inner.tensor.numel() == 0 {
-        return Err(PyValueError::new_err(
-            "std: empty tensors have no standard deviation",
-        ));
-    }
+) -> PyResult<PyTensor> {
     if let Some(ax) = axis {
         validate_stat_axis("std", input, ax)?;
-        let reduced = py
-            .allow_threads(|| coeus_ops::std_dev_axis(&input.inner.tensor, ax, unbiased, &backend));
-        return tensor_or_scalar_reduction(py, reduced, ax, keepdim);
+        validate_stat_denominator("std", input.inner.tensor.shape()[ax], unbiased)?;
+        let inner = py.allow_threads(|| coeus_autograd::std_dev_axis(&input.inner, ax, unbiased));
+        return Ok(PyTensor {
+            inner: drop_axis_dim(inner, ax, keepdim),
+        });
     }
-    let v = py.allow_threads(|| {
-        coeus_ops::std_dev::<f64, MoiraiBackend>(&input.inner.tensor, unbiased, &backend)
-    });
-    scalar_object(py, v)
+    validate_stat_denominator("std", input.inner.tensor.numel(), unbiased)?;
+    let inner = py.allow_threads(|| coeus_autograd::std_dev(&input.inner, unbiased));
+    Ok(PyTensor::from_var(inner))
 }
 
 #[pyfunction]
@@ -39,21 +66,18 @@ pub fn tensor_var(
     axis: Option<usize>,
     keepdim: bool,
     py: Python<'_>,
-) -> PyResult<Py<PyAny>> {
-    let backend = MoiraiBackend::new();
-    if input.inner.tensor.numel() == 0 {
-        return Err(PyValueError::new_err("var: empty tensors have no variance"));
-    }
+) -> PyResult<PyTensor> {
     if let Some(ax) = axis {
         validate_stat_axis("var", input, ax)?;
-        let reduced =
-            py.allow_threads(|| coeus_ops::var_axis(&input.inner.tensor, ax, unbiased, &backend));
-        return tensor_or_scalar_reduction(py, reduced, ax, keepdim);
+        validate_stat_denominator("var", input.inner.tensor.shape()[ax], unbiased)?;
+        let inner = py.allow_threads(|| coeus_autograd::var_axis(&input.inner, ax, unbiased));
+        return Ok(PyTensor {
+            inner: drop_axis_dim(inner, ax, keepdim),
+        });
     }
-    let v = py.allow_threads(|| {
-        coeus_ops::var::<f64, MoiraiBackend>(&input.inner.tensor, unbiased, &backend)
-    });
-    scalar_object(py, v)
+    validate_stat_denominator("var", input.inner.tensor.numel(), unbiased)?;
+    let inner = py.allow_threads(|| coeus_autograd::var(&input.inner, unbiased));
+    Ok(PyTensor::from_var(inner))
 }
 
 #[pyfunction]
@@ -64,24 +88,23 @@ pub fn var_mean(
     axis: Option<usize>,
     keepdim: bool,
     py: Python<'_>,
-) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-    let backend = MoiraiBackend::new();
-    if input.inner.tensor.numel() == 0 {
-        return Err(PyValueError::new_err(
-            "var_mean: empty tensors have no variance",
-        ));
-    }
+) -> PyResult<(PyTensor, PyTensor)> {
     if let Some(ax) = axis {
         validate_stat_axis("var_mean", input, ax)?;
-        let (variance, mean) = py.allow_threads(|| {
-            coeus_ops::var_mean_axis(&input.inner.tensor, ax, unbiased, &backend)
-        });
-        return stat_pair_reduction(py, variance, mean, ax, keepdim);
+        validate_stat_denominator("var_mean", input.inner.tensor.shape()[ax], unbiased)?;
+        let (v, mu) = py.allow_threads(|| coeus_autograd::var_mean_axis(&input.inner, ax, unbiased));
+        return Ok((
+            PyTensor {
+                inner: drop_axis_dim(v, ax, keepdim),
+            },
+            PyTensor {
+                inner: drop_axis_dim(mu, ax, keepdim),
+            },
+        ));
     }
-    let (variance, mean) = py.allow_threads(|| {
-        coeus_ops::var_mean::<f64, MoiraiBackend>(&input.inner.tensor, unbiased, &backend)
-    });
-    Ok((scalar_object(py, variance)?, scalar_object(py, mean)?))
+    validate_stat_denominator("var_mean", input.inner.tensor.numel(), unbiased)?;
+    let (v, mu) = py.allow_threads(|| coeus_autograd::var_mean(&input.inner, unbiased));
+    Ok((PyTensor::from_var(v), PyTensor::from_var(mu)))
 }
 
 #[pyfunction]
@@ -92,24 +115,23 @@ pub fn std_mean(
     axis: Option<usize>,
     keepdim: bool,
     py: Python<'_>,
-) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-    let backend = MoiraiBackend::new();
-    if input.inner.tensor.numel() == 0 {
-        return Err(PyValueError::new_err(
-            "std_mean: empty tensors have no standard deviation",
-        ));
-    }
+) -> PyResult<(PyTensor, PyTensor)> {
     if let Some(ax) = axis {
         validate_stat_axis("std_mean", input, ax)?;
-        let (std, mean) = py.allow_threads(|| {
-            coeus_ops::std_mean_axis(&input.inner.tensor, ax, unbiased, &backend)
-        });
-        return stat_pair_reduction(py, std, mean, ax, keepdim);
+        validate_stat_denominator("std_mean", input.inner.tensor.shape()[ax], unbiased)?;
+        let (sd, mu) = py.allow_threads(|| coeus_autograd::std_mean_axis(&input.inner, ax, unbiased));
+        return Ok((
+            PyTensor {
+                inner: drop_axis_dim(sd, ax, keepdim),
+            },
+            PyTensor {
+                inner: drop_axis_dim(mu, ax, keepdim),
+            },
+        ));
     }
-    let (std, mean) = py.allow_threads(|| {
-        coeus_ops::std_mean::<f64, MoiraiBackend>(&input.inner.tensor, unbiased, &backend)
-    });
-    Ok((scalar_object(py, std)?, scalar_object(py, mean)?))
+    validate_stat_denominator("std_mean", input.inner.tensor.numel(), unbiased)?;
+    let (sd, mu) = py.allow_threads(|| coeus_autograd::std_mean(&input.inner, unbiased));
+    Ok((PyTensor::from_var(sd), PyTensor::from_var(mu)))
 }
 
 #[pyfunction]
@@ -223,56 +245,6 @@ fn validate_stat_axis(op: &str, input: &PyTensor, axis: usize) -> PyResult<()> {
     Ok(())
 }
 
-fn tensor_or_scalar_reduction(
-    py: Python<'_>,
-    reduced: Tensor<f64, MoiraiBackend>,
-    axis: usize,
-    keepdim: bool,
-) -> PyResult<Py<PyAny>> {
-    if keepdim {
-        return Ok(Py::new(
-            py,
-            PyTensor {
-                inner: coeus_autograd::Var::new(reduced, false),
-            },
-        )?
-        .into_any());
-    }
-
-    let mut shape = reduced.shape().to_vec();
-    shape.remove(axis);
-    if shape.is_empty() {
-        let backend = MoiraiBackend::new();
-        let value = reduced.to_contiguous_on(&backend).as_slice()[0];
-        scalar_object(py, value)
-    } else {
-        let squeezed = reduced.reshape(shape);
-        Ok(Py::new(
-            py,
-            PyTensor {
-                inner: coeus_autograd::Var::new(squeezed, false),
-            },
-        )?
-        .into_any())
-    }
-}
-
-fn stat_pair_reduction(
-    py: Python<'_>,
-    stat: Tensor<f64, MoiraiBackend>,
-    mean: Tensor<f64, MoiraiBackend>,
-    axis: usize,
-    keepdim: bool,
-) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-    Ok((
-        tensor_or_scalar_reduction(py, stat, axis, keepdim)?,
-        tensor_or_scalar_reduction(py, mean, axis, keepdim)?,
-    ))
-}
-
-fn scalar_object(py: Python<'_>, value: f64) -> PyResult<Py<PyAny>> {
-    Ok(value.into_pyobject(py)?.unbind().into_any())
-}
 
 /// Clip the global gradient norm of a list of parameters.
 ///

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2008,3 +2008,18 @@ def test_ceil_matches_jax() -> None:
     got = pycoeus.ceil(x_pyc)
     exp = jnp.ceil(jnp.array(data, dtype=jnp.float64))
     _allclose("ceil", list(got.data), exp.tolist())
+
+# ---------------------------------------------------------------------------
+# var / std parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "var"), reason="pycoeus.var not available")
+def test_var_matches_jax() -> None:
+    """jnp.var(x) (population) vs pycoeus.var(x, unbiased=False)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.var(x_pyc, unbiased=False)
+    t = jnp.array(data, dtype=jnp.float64)
+    exp = jnp.var(t)
+    _allclose("var", list(got.data), [float(exp)])

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -4817,3 +4817,46 @@ def test_clamp_boundary_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("clamp_boundary_fwd", list(out_pyc.data), out_t.detach().tolist())
     _allclose("clamp_boundary_bwd", list(x_pyc.grad), t.grad.tolist())
+
+# ---------------------------------------------------------------------------
+# var / std parity (tracked autograd via composition)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "var"), reason="pycoeus.var not available")
+def test_var_unbiased_matches_pytorch() -> None:
+    """torch.var(x, unbiased=True) vs pycoeus.var(x, unbiased=True), fwd+bwd."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.var(x_pyc, unbiased=True)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.var(t, unbiased=True)
+    out_t.backward()
+    _allclose("var_fwd", list(out_pyc.data), [out_t.item()])
+    _allclose("var_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "std"), reason="pycoeus.std not available")
+def test_std_unbiased_matches_pytorch() -> None:
+    """torch.std(x, unbiased=True) vs pycoeus.std(x, unbiased=True), fwd+bwd."""
+    data = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+    x_pyc = pycoeus.Tensor(data, [8], requires_grad=True)
+    out_pyc = pycoeus.std(x_pyc, unbiased=True)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.std(t, unbiased=True)
+    out_t.backward()
+    _allclose("std_fwd", list(out_pyc.data), [out_t.item()], atol=1e-10)
+    _allclose("std_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "var"), reason="pycoeus.var not available")
+def test_var_population_matches_pytorch() -> None:
+    """torch.var(x, unbiased=False) (population variance) vs pycoeus.var(x, unbiased=False)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.var(x_pyc, unbiased=False)
+    t = torch.tensor(data, dtype=torch.float64)
+    exp = torch.var(t, unbiased=False)
+    _allclose("var_pop", list(got.data), [exp.item()])


### PR DESCRIPTION
var/std fwd+bwd parity (pycoeus.var, pycoeus.std via pyo3 name aliases). JAX var population parity. G-043: 70 rows (std_dev bench). PyTorch: 174, JAX: 87. 453/453 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds forward and backward parity tests for variance and standard deviation operations (`pycoeus.var`, `pycoeus.std`) against PyTorch and JAX, refactors the Python statistics operations to use autograd-tracked variables instead of raw tensors (enabling gradient computation), adds validation for edge cases where denominators would be zero, and extends the benchmark suite with a new `std_dev` benchmark (G-043) running at 70 rows. All 453 tests pass with PyTorch showing 174 tests and JAX showing 87 tests.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-python/src/ops/statistics.rs` |
| 4 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->