### PR TITLE
MS-278-279: sinh/cosh/log2/log10 parity (PyTorch 187, JAX 96) + bench 77 rows

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2878,6 +2878,67 @@ fn bench_std_forward(c: &mut Criterion) {
     group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::std_dev(&x_moirai, true))) });
     group.finish();
 }
+
+fn bench_sinh_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - sinh forward (128x256)");
+    group.bench_function("Burn NdArray (exp proxy)", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).exp()))
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::sinh(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::sinh(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_cosh_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - cosh forward (128x256)");
+    group.bench_function("Burn NdArray (exp+recip proxy)", |b| {
+        b.iter(|| { let e = black_box(x_burn.clone()).exp(); let ne = black_box(x_burn.clone()).neg().exp(); black_box((e + ne) / 2.0f32) })
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::cosh(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::cosh(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_log2_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs() + 0.01).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - log2 forward (128x256)");
+    group.bench_function("Burn NdArray (log/ln2 proxy)", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).log().div_scalar(2.0f32.ln())))
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log2(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log2(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_log10_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs() + 0.01).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - log10 forward (128x256)");
+    group.bench_function("Burn NdArray (log/ln10 proxy)", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).log().div_scalar(10.0f32.ln())))
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log10(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log10(black_box(&x_moirai)))) });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -2949,7 +3010,11 @@ criterion_group!(
     bench_std_forward,
     bench_exp_forward,
     bench_log_forward,
-    bench_neg_forward
+    bench_neg_forward,
+    bench_sinh_forward,
+    bench_cosh_forward,
+    bench_log2_forward,
+    bench_log10_forward
 );
 criterion_main!(benches);
 

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2074,3 +2074,47 @@ def test_log2_matches_jax() -> None:
     got = pycoeus.log2(x_pyc)
     exp = jnp.log2(jnp.array(data, dtype=jnp.float64))
     _allclose("log2", list(got.data), exp.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# sinh / cosh / log2 / log10 parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "sinh"), reason="pycoeus.sinh not available")
+def test_sinh_matches_jax() -> None:
+    """jnp.sinh(x) vs pycoeus.sinh(x)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.sinh(x_pyc)
+    exp = jnp.sinh(jnp.array(data, dtype=jnp.float64))
+    _allclose("sinh", list(got.data), exp.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "cosh"), reason="pycoeus.cosh not available")
+def test_cosh_matches_jax() -> None:
+    """jnp.cosh(x) vs pycoeus.cosh(x)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.cosh(x_pyc)
+    exp = jnp.cosh(jnp.array(data, dtype=jnp.float64))
+    _allclose("cosh", list(got.data), exp.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log2"), reason="pycoeus.log2 not available")
+def test_log2_matches_jax() -> None:
+    """jnp.log2(x) vs pycoeus.log2(x)."""
+    data = [0.5, 1.0, 2.0, 4.0, 8.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.log2(x_pyc)
+    exp = jnp.log2(jnp.array(data, dtype=jnp.float64))
+    _allclose("log2", list(got.data), exp.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log10"), reason="pycoeus.log10 not available")
+def test_log10_matches_jax() -> None:
+    """jnp.log10(x) vs pycoeus.log10(x)."""
+    data = [0.1, 1.0, 10.0, 100.0, 1000.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.log10(x_pyc)
+    exp = jnp.log10(jnp.array(data, dtype=jnp.float64))
+    _allclose("log10", list(got.data), exp.tolist(), atol=1e-12)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -4967,3 +4967,81 @@ def test_log10_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("log10_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
     _allclose("log10_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# sinh / cosh / log2 / log10 parity (new trig2 ops)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "sinh"), reason="pycoeus.sinh not available")
+def test_sinh_matches_pytorch() -> None:
+    """torch.sinh(x) vs pycoeus.sinh(x), fwd+bwd (d/dx sinh = cosh)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.sinh(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.sinh(t)
+    out_t.sum().backward()
+    _allclose("sinh_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("sinh_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "cosh"), reason="pycoeus.cosh not available")
+def test_cosh_matches_pytorch() -> None:
+    """torch.cosh(x) vs pycoeus.cosh(x), fwd+bwd (d/dx cosh = sinh)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.cosh(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.cosh(t)
+    out_t.sum().backward()
+    _allclose("cosh_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("cosh_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log2"), reason="pycoeus.log2 not available")
+def test_log2_matches_pytorch() -> None:
+    """torch.log2(x) vs pycoeus.log2(x), fwd+bwd (d/dx log2 = 1/(x*ln2))."""
+    data = [0.5, 1.0, 2.0, 4.0, 8.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.log2(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.log2(t)
+    out_t.sum().backward()
+    _allclose("log2_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("log2_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log10"), reason="pycoeus.log10 not available")
+def test_log10_matches_pytorch() -> None:
+    """torch.log10(x) vs pycoeus.log10(x), fwd+bwd (d/dx log10 = 1/(x*ln10))."""
+    data = [0.1, 1.0, 10.0, 100.0, 1000.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.log10(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.log10(t)
+    out_t.sum().backward()
+    _allclose("log10_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("log10_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "dot"), reason="pycoeus.dot not available")
+def test_dot_matches_pytorch() -> None:
+    """torch.dot(a, b) vs pycoeus.dot(a, b)."""
+    a = [1.0, 2.0, 3.0, 4.0, 5.0]
+    b = [5.0, 4.0, 3.0, 2.0, 1.0]
+    a_pyc = pycoeus.Tensor(a, [5], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [5], requires_grad=True)
+    out_pyc = pycoeus.dot(a_pyc, b_pyc)
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64, requires_grad=True)
+    b_t = torch.tensor(b, dtype=torch.float64, requires_grad=True)
+    out_t = torch.dot(a_t, b_t)
+    out_t.backward()
+    _allclose("dot_fwd", list(out_pyc.data), [out_t.item()])
+    _allclose("dot_bwd_a", list(a_pyc.grad), a_t.grad.tolist())
+    _allclose("dot_bwd_b", list(b_pyc.grad), b_t.grad.tolist())


### PR DESCRIPTION
sinh/cosh/log2/log10 fwd+bwd parity. JAX versions. dot fwd+bwd. G-043: 77 rows (sinh/cosh/log2/log10 benches). PyTorch: 187, JAX: 96. 457/457 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds parity tests and benchmarks for four mathematical operations (`sinh`, `cosh`, `log2`, and `log10`) ensuring they match both PyTorch and JAX implementations. The changes include forward and backward pass validation tests for PyTorch (with gradient checks), forward-only tests for JAX, and performance benchmarks comparing Coeus implementations against Burn's NdArray backend. Additionally, a `dot` product parity test for PyTorch is included. All 457 tests pass successfully.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_jax_parity.py` |
| 2 | `coeus-python/tests/test_pytorch_parity.py` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-python/tests/test_pytorch_parity.py` | The dot product test (test_dot_matches_pytorch) appears unrelated to the PR title which specifically mentions sinh/cosh/log2/log10 operations |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->