### PR TITLE
MS-285: prelu/squeeze/prod/sum_axis parity (PyTorch 206, JAX 107)

### DIFF
--- a/coeus-autograd/src/ops/activation/mod.rs
+++ b/coeus-autograd/src/ops/activation/mod.rs
@@ -145,8 +145,8 @@ pub use silu::{mish, silu, softplus, MishOp, SiluOp, SoftplusOp};
 pub use tanh_act::{tanh, TanhOp};
 pub use trig::{
     acos, acosh, asin, asinh, atan, atanh, cos, cosh, erf, erfc, exp, expm1, log, log10, log1p,
-    log2, sin, sinh, tan, AcosOp, AcoshOp, AsinOp, AsinhOp, AtanOp, AtanhOp, CoshOp, CosOp,
-    ErfOp, ErfcOp, ExpOp, Expm1Op, Log10Op, Log1pOp, Log2Op, LogOp, SinOp, SinhOp, TanOp,
+    log2, sin, sinh, tan, AcosOp, AcoshOp, AsinOp, AsinhOp, AtanOp, AtanhOp, CosOp, CoshOp, ErfOp,
+    ErfcOp, ExpOp, Expm1Op, Log10Op, Log1pOp, Log2Op, LogOp, SinOp, SinhOp, TanOp,
 };
 // Extended-family re-exports (G-037).
 pub use ext::{

--- a/coeus-autograd/src/ops/activation/trig.rs
+++ b/coeus-autograd/src/ops/activation/trig.rs
@@ -107,8 +107,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         let x_sq = coeus_ops::mul(x, x, backend);
         let neg_x_sq = coeus_ops::neg(&x_sq, backend);
         let gauss = coeus_ops::exp(&neg_x_sq, backend);
-        let neg_two_over_sqrt_pi =
-            Tensor::full_on(gauss.shape(), T::from_f64(-1.128_379_167_095_512_6), backend);
+        let neg_two_over_sqrt_pi = Tensor::full_on(
+            gauss.shape(),
+            T::from_f64(-1.128_379_167_095_512_6),
+            backend,
+        );
         let scaled = coeus_ops::mul(&gauss, &neg_two_over_sqrt_pi, backend);
         coeus_ops::mul(grad_out, &scaled, backend)
     }

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -18,11 +18,10 @@ pub mod shape;
 pub mod var_ops;
 
 pub use activation::{
-    abs, acos, acosh, asin, asinh, atan, atanh, ceil, celu, clamp, cos, cosh, elu, erf, erfc,
-    exp, expm1, floor, gelu, gelu_tanh, hardshrink, hardsigmoid, hardswish, hardtanh,
-    leaky_relu, log, log10, log1p, log2, mish, neg, pack_pairs, pow, prelu, recip, relu, round,
-    sigmoid, sign, silu, sin, sinh, softplus, softshrink, softsign, sqrt, tan, tanh, threshold,
-    trunc,
+    abs, acos, acosh, asin, asinh, atan, atanh, ceil, celu, clamp, cos, cosh, elu, erf, erfc, exp,
+    expm1, floor, gelu, gelu_tanh, hardshrink, hardsigmoid, hardswish, hardtanh, leaky_relu, log,
+    log10, log1p, log2, mish, neg, pack_pairs, pow, prelu, recip, relu, round, sigmoid, sign, silu,
+    sin, sinh, softplus, softshrink, softsign, sqrt, tan, tanh, threshold, trunc,
 };
 pub use arithmetic::{
     add, div, mean, mean_axis, mul, nanmean, nansum, scalar_add, scalar_div, scalar_mul,

--- a/coeus-autograd/tests/autograd/linalg.rs
+++ b/coeus-autograd/tests/autograd/linalg.rs
@@ -1,0 +1,62 @@
+use coeus_autograd::{matmul, Var};
+use coeus_core::MoiraiBackend;
+use coeus_tensor::Tensor;
+
+/// Batched matmul (bmm) backward: with an all-ones seed, the analytic
+/// gradients are `grad_A = 1 @ Bᵀ` (every row of `grad_A[b]` equals the
+/// per-row sums of `B[b]`) and `grad_B = Aᵀ @ 1` (every column of
+/// `grad_B[b]` equals the per-column sums of `A[b]`). Regression test for
+/// the backward panicking on batched B ("transpose requires 2D tensor").
+#[test]
+fn test_bmm_backward_accumulates_exact_gradients() {
+    let backend = MoiraiBackend::new();
+    // Batch 0: A0 = [[1,2,3],[4,5,6]], B0 = [[1,0],[0,1],[1,1]]
+    // Batch 1: A1 = [[0,1,0],[2,0,2]], B1 = [[2,1],[1,2],[0,3]]
+    let a = Var::new(
+        Tensor::from_slice_on(
+            vec![2, 2, 3],
+            &[
+                1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 1.0, 0.0, 2.0, 0.0, 2.0,
+            ],
+            &backend,
+        ),
+        true,
+    );
+    let b = Var::new(
+        Tensor::from_slice_on(
+            vec![2, 3, 2],
+            &[
+                1.0f64, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 2.0, 0.0, 3.0,
+            ],
+            &backend,
+        ),
+        true,
+    );
+
+    let c = matmul(&a, &b);
+    assert_eq!(c.tensor.shape(), &[2, 2, 2]);
+    // C0 = [[4,5],[10,11]]; C1 = [[1,2],[4,8]].
+    let cs = c.tensor.as_slice();
+    let expected_fwd = [4.0, 5.0, 10.0, 11.0, 1.0, 2.0, 4.0, 8.0];
+    for (got, want) in cs.iter().zip(expected_fwd.iter()) {
+        assert!((got - want).abs() < 1e-14, "fwd {got} vs {want}");
+    }
+
+    c.backward();
+
+    // grad_A[b] rows = row sums of B[b]: B0 rows sum to [1,1,2]; B1 to [3,3,3].
+    let ga = a.grad().unwrap();
+    let ga = ga.as_slice();
+    let expected_ga = [1.0, 1.0, 2.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0];
+    for (i, (got, want)) in ga.iter().zip(expected_ga.iter()).enumerate() {
+        assert!((got - want).abs() < 1e-14, "grad_a[{i}] {got} vs {want}");
+    }
+
+    // grad_B[b] columns = column sums of A[b]: A0 cols [5,7,9]; A1 cols [2,1,2].
+    let gb = b.grad().unwrap();
+    let gb = gb.as_slice();
+    let expected_gb = [5.0, 5.0, 7.0, 7.0, 9.0, 9.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0];
+    for (i, (got, want)) in gb.iter().zip(expected_gb.iter()).enumerate() {
+        assert!((got - want).abs() < 1e-14, "grad_b[{i}] {got} vs {want}");
+    }
+}

--- a/coeus-autograd/tests/autograd/mod.rs
+++ b/coeus-autograd/tests/autograd/mod.rs
@@ -2,6 +2,7 @@ mod embedding;
 mod exp_log;
 mod float16;
 mod grad_mode;
+mod linalg;
 mod nn_conv;
 mod ops_overloads;
 mod reductions;

--- a/coeus-autograd/tests/autograd/reductions.rs
+++ b/coeus-autograd/tests/autograd/reductions.rs
@@ -325,7 +325,10 @@ fn test_var_axis_autograd_matches_analytic() {
     assert_eq!(v.tensor.shape(), &[2, 1], "keepdim shape");
     let vs = v.tensor.as_slice().to_vec();
     let ms = mu.tensor.as_slice().to_vec();
-    assert!((ms[0] - 2.0).abs() < 1e-14 && (ms[1] - 6.0).abs() < 1e-14, "means");
+    assert!(
+        (ms[0] - 2.0).abs() < 1e-14 && (ms[1] - 6.0).abs() < 1e-14,
+        "means"
+    );
     assert!((vs[0] - 1.0).abs() < 1e-14, "row0 var: {}", vs[0]);
     assert!((vs[1] - 4.0).abs() < 1e-14, "row1 var: {}", vs[1]);
 

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -2780,216 +2780,467 @@ fn bench_atan_forward(c: &mut Criterion) {
 }
 
 fn bench_clamp_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 3.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).sin() * 3.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - clamp(-1,1) forward (128x256)");
     group.bench_function("Burn NdArray (clamp_min+clamp_max)", |b| {
-        b.iter(|| black_box(black_box(x_burn.clone()).clamp_min(-1.0f32).clamp_max(1.0f32)))
+        b.iter(|| {
+            black_box(
+                black_box(x_burn.clone())
+                    .clamp_min(-1.0f32)
+                    .clamp_max(1.0f32),
+            )
+        })
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::clamp(black_box(&x_seq), -1.0, 1.0))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::clamp(black_box(&x_moirai), -1.0, 1.0))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::clamp(black_box(&x_seq), -1.0, 1.0)))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::clamp(black_box(&x_moirai), -1.0, 1.0)))
+    });
     group.finish();
 }
 
 fn bench_asin_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.0019).sin() * 0.9).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0019).sin() * 0.9)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - asin forward (128x256)");
-    group.bench_function("Burn NdArray (sin proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).sin())) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::asin(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::asin(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray (sin proxy)", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).sin()))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::asin(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::asin(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_erfc_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 2.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).sin() * 2.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - erfc forward (128x256)");
     group.bench_function("Burn NdArray (1-tanh proxy)", |b| {
-        b.iter(|| { let t = black_box(x_burn.clone()).tanh(); black_box(t.mul_scalar(-1.0f32).add_scalar(1.0f32)) })
+        b.iter(|| {
+            let t = black_box(x_burn.clone()).tanh();
+            black_box(t.mul_scalar(-1.0f32).add_scalar(1.0f32))
+        })
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::erfc(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::erfc(black_box(&x_moirai)))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::erfc(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::erfc(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
-
-
 fn bench_exp_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin()).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.001).sin())
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - exp forward (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(black_box(x_burn.clone()).exp())) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::exp(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::exp(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).exp()))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::exp(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::exp(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_log_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs() + 0.01).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).cos().abs() + 0.01)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - log forward (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(black_box(x_burn.clone()).log())) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).log()))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::log(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::log(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_neg_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin()).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).sin())
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - neg forward (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(black_box(x_burn.clone()).neg())) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::neg(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::neg(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(black_box(x_burn.clone()).neg()))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::neg(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::neg(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_std_forward(c: &mut Criterion) {
     // std (unbiased): [128, 256] — variance reduction used in normalization.
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.0017).sin()).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.0017).sin())
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - std forward (128x256)");
     group.bench_function("Burn NdArray (mean proxy)", |b| {
         b.iter(|| black_box(black_box(x_burn.clone()).mean()))
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::std_dev(&x_seq, true))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::std_dev(&x_moirai, true))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::std_dev(&x_seq, true)))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::std_dev(&x_moirai, true)))
+    });
     group.finish();
 }
 
 fn bench_sinh_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 2.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.001).sin() * 2.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - sinh forward (128x256)");
     group.bench_function("Burn NdArray (exp proxy)", |b| {
         b.iter(|| black_box(black_box(x_burn.clone()).exp()))
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::sinh(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::sinh(black_box(&x_moirai)))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::sinh(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::sinh(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_cosh_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 2.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.001).sin() * 2.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - cosh forward (128x256)");
     group.bench_function("Burn NdArray (exp+recip proxy)", |b| {
-        b.iter(|| { let e = black_box(x_burn.clone()).exp(); let ne = black_box(x_burn.clone()).neg().exp(); black_box((e + ne) / 2.0f32) })
+        b.iter(|| {
+            let e = black_box(x_burn.clone()).exp();
+            let ne = black_box(x_burn.clone()).neg().exp();
+            black_box((e + ne) / 2.0f32)
+        })
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::cosh(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::cosh(black_box(&x_moirai)))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::cosh(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::cosh(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_log2_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs() + 0.01).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).cos().abs() + 0.01)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - log2 forward (128x256)");
     group.bench_function("Burn NdArray (log/ln2 proxy)", |b| {
         b.iter(|| black_box(black_box(x_burn.clone()).log().div_scalar(2.0f32.ln())))
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log2(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log2(black_box(&x_moirai)))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::log2(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::log2(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_log10_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs() + 0.01).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).cos().abs() + 0.01)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - log10 forward (128x256)");
     group.bench_function("Burn NdArray (log/ln10 proxy)", |b| {
         b.iter(|| black_box(black_box(x_burn.clone()).log().div_scalar(10.0f32.ln())))
     });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log10(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log10(black_box(&x_moirai)))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::log10(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::log10(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
-
 fn bench_relu2_forward(c: &mut Criterion) {
     // relu [128,256] — explicit Burn vs Coeus parity row (Burn has relu_forward already)
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 2.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.003).sin() * 2.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - relu2 fwd (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone())))) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::relu(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::relu(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::relu(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::relu(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_tanh2_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin()).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.002).sin())
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - tanh fwd (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::tanh(black_box(x_burn.clone())))) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::tanh(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::tanh(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn::tensor::activation::tanh(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::tanh(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::tanh(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_sigmoid2_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.002).sin() * 3.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - sigmoid fwd (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::sigmoid(black_box(x_burn.clone())))) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::sigmoid(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::sigmoid(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn::tensor::activation::sigmoid(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::sigmoid(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::sigmoid(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
 fn bench_gelu2_forward(c: &mut Criterion) {
-    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
-    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
-    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES))
+        .map(|i| (i as f32 * 0.002).sin() * 3.0)
+        .collect();
+    let x_seq = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
+    let x_moirai = Var::new(
+        Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
+        false,
+    );
     let device = NdArrayDevice::default();
-    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(
+        TensorData::new(input_data.clone(), [BATCH, FEATURES]),
+        &device,
+    );
     let mut group = c.benchmark_group("Burn vs Coeus - gelu fwd (128x256)");
-    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn::tensor::activation::gelu(black_box(x_burn.clone())))) });
-    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::gelu(black_box(&x_seq)))) });
-    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::gelu(black_box(&x_moirai)))) });
+    group.bench_function("Burn NdArray", |b| {
+        b.iter(|| black_box(burn::tensor::activation::gelu(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| black_box(coeus_autograd::gelu(black_box(&x_seq))))
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| black_box(coeus_autograd::gelu(black_box(&x_moirai))))
+    });
     group.finish();
 }
 
@@ -3075,4 +3326,3 @@ criterion_group!(
     bench_gelu2_forward
 );
 criterion_main!(benches);
-

--- a/coeus-ops/src/fuse/mod.rs
+++ b/coeus-ops/src/fuse/mod.rs
@@ -9,9 +9,9 @@ pub use expr_node::{
     CPU_EVAL_CACHE,
 };
 pub use op_tags::{
-    wgsl_erf_approx_expr, wgsl_gelu_expr, wgsl_gelu_grad_expr, Abs, Acos, Acosh, Add, Asin,
-    Asinh, Atan, Atanh, BinaryOpTag, Ceil, Cos, Cosh, Div, Elu, EluGrad, Erf, Erfc, Exp, Expm1,
-    Floor, Gelu, GeluGrad, GeluTanh, GeluTanhGrad, LeakyReluGradTag, LeakyReluTag, Log, Log10,
-    Log1p, Log2, Mish, MishGrad, Mul, Neg, Recip, Relu, Round, Sigmoid, Sign, Silu, SiluGrad,
-    Sin, Sinh, Softplus, SoftplusGrad, Sqrt, Sub, Tan, Tanh, Trunc, UnaryOpTag,
+    wgsl_erf_approx_expr, wgsl_gelu_expr, wgsl_gelu_grad_expr, Abs, Acos, Acosh, Add, Asin, Asinh,
+    Atan, Atanh, BinaryOpTag, Ceil, Cos, Cosh, Div, Elu, EluGrad, Erf, Erfc, Exp, Expm1, Floor,
+    Gelu, GeluGrad, GeluTanh, GeluTanhGrad, LeakyReluGradTag, LeakyReluTag, Log, Log10, Log1p,
+    Log2, Mish, MishGrad, Mul, Neg, Recip, Relu, Round, Sigmoid, Sign, Silu, SiluGrad, Sin, Sinh,
+    Softplus, SoftplusGrad, Sqrt, Sub, Tan, Tanh, Trunc, UnaryOpTag,
 };

--- a/coeus-ops/src/lib.rs
+++ b/coeus-ops/src/lib.rs
@@ -37,11 +37,11 @@ pub mod sparse;
 pub mod unary;
 
 pub use unary::{
-    abs, abs_assign, acos, acosh, asin, asinh, atan, atanh, causal_softmax, ceil, ceil_assign,
-    cos, cos_assign, cosh, elementwise_unary, elementwise_unary_assign, elementwise_unary_to, elu,
+    abs, abs_assign, acos, acosh, asin, asinh, atan, atanh, causal_softmax, ceil, ceil_assign, cos,
+    cos_assign, cosh, elementwise_unary, elementwise_unary_assign, elementwise_unary_to, elu,
     elu_assign, erf, erfc, exp, exp_assign, expm1, floor, floor_assign, gelu, gelu_assign,
-    gelu_tanh, gelu_tanh_assign, glu, leaky_relu, leaky_relu_assign, log, log_assign, log10,
-    log1p, log2, log_softmax_axis, masked_softmax, mish, mish_assign, neg, neg_assign, recip,
+    gelu_tanh, gelu_tanh_assign, glu, leaky_relu, leaky_relu_assign, log, log10, log1p, log2,
+    log_assign, log_softmax_axis, masked_softmax, mish, mish_assign, neg, neg_assign, recip,
     recip_assign, relu, relu_assign, round, round_assign, sigmoid, sigmoid_assign, sign,
     sign_assign, silu, silu_assign, sin, sin_assign, sinh, softplus, softplus_assign, sqrt,
     sqrt_assign, tan, tanh, tanh_assign, trunc, trunc_assign,

--- a/coeus-ops/src/unary/mod.rs
+++ b/coeus-ops/src/unary/mod.rs
@@ -14,7 +14,7 @@ pub use activation::{
 pub use kernel::{elementwise_unary, elementwise_unary_assign, elementwise_unary_to};
 pub use math::{
     abs, abs_assign, acos, acosh, asin, asinh, atan, atanh, ceil, ceil_assign, cos, cos_assign,
-    cosh, erf, erfc, exp, exp_assign, expm1, floor, floor_assign, log, log_assign, log10, log1p,
-    log2, neg, neg_assign, recip, recip_assign, round, round_assign, sign, sign_assign, sin,
+    cosh, erf, erfc, exp, exp_assign, expm1, floor, floor_assign, log, log10, log1p, log2,
+    log_assign, neg, neg_assign, recip, recip_assign, round, round_assign, sign, sign_assign, sin,
     sin_assign, sinh, sqrt, sqrt_assign, tan, trunc, trunc_assign,
 };

--- a/coeus-python/src/ops/statistics.rs
+++ b/coeus-python/src/ops/statistics.rs
@@ -92,7 +92,8 @@ pub fn var_mean(
     if let Some(ax) = axis {
         validate_stat_axis("var_mean", input, ax)?;
         validate_stat_denominator("var_mean", input.inner.tensor.shape()[ax], unbiased)?;
-        let (v, mu) = py.allow_threads(|| coeus_autograd::var_mean_axis(&input.inner, ax, unbiased));
+        let (v, mu) =
+            py.allow_threads(|| coeus_autograd::var_mean_axis(&input.inner, ax, unbiased));
         return Ok((
             PyTensor {
                 inner: drop_axis_dim(v, ax, keepdim),
@@ -119,7 +120,8 @@ pub fn std_mean(
     if let Some(ax) = axis {
         validate_stat_axis("std_mean", input, ax)?;
         validate_stat_denominator("std_mean", input.inner.tensor.shape()[ax], unbiased)?;
-        let (sd, mu) = py.allow_threads(|| coeus_autograd::std_mean_axis(&input.inner, ax, unbiased));
+        let (sd, mu) =
+            py.allow_threads(|| coeus_autograd::std_mean_axis(&input.inner, ax, unbiased));
         return Ok((
             PyTensor {
                 inner: drop_axis_dim(sd, ax, keepdim),
@@ -244,7 +246,6 @@ fn validate_stat_axis(op: &str, input: &PyTensor, axis: usize) -> PyResult<()> {
     }
     Ok(())
 }
-
 
 /// Clip the global gradient norm of a list of parameters.
 ///

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2226,3 +2226,28 @@ def test_log1p_matches_jax() -> None:
     got = pycoeus.log1p(x_pyc)
     exp = jnp.log1p(jnp.array(data, dtype=jnp.float64))
     _allclose("log1p", list(got.data), exp.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# prelu / prod / sum_axis parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "prod"), reason="pycoeus.prod not available")
+def test_prod_matches_jax() -> None:
+    """jnp.prod(x) vs pycoeus.prod(x)."""
+    data = [1.0, 2.0, 3.0, 4.0]
+    x_pyc = pycoeus.Tensor(data, [4], requires_grad=False)
+    got = pycoeus.prod(x_pyc)
+    exp = float(jnp.prod(jnp.array(data, dtype=jnp.float64)))
+    _allclose("prod", list(got.data), [exp])
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "sum_axis"), reason="pycoeus.sum_axis not available")
+def test_sum_axis_matches_jax() -> None:
+    """jnp.sum(x, axis=1) vs pycoeus.sum_axis(x, 1)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=False)
+    got = pycoeus.sum_axis(x_pyc, 1)
+    t = jnp.array(data, dtype=jnp.float64).reshape(2, 3)
+    exp = jnp.sum(t, axis=1)
+    _allclose("sum_axis", list(got.data), exp.tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -5276,3 +5276,66 @@ def test_log1p_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("log1p_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
     _allclose("log1p_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# prelu / squeeze / unsqueeze / prod / sum_axis parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "prelu"), reason="pycoeus.prelu not available")
+def test_prelu_fwd_bwd_matches_pytorch() -> None:
+    """PReLU fwd+bwd: d/dx prelu = 1 if x>0, else alpha."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    alpha = 0.25
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.prelu(x_pyc, alpha)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.prelu(t, torch.tensor([alpha], dtype=torch.float64))
+    out_t.sum().backward()
+    _allclose("prelu_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("prelu_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "squeeze"), reason="pycoeus.squeeze not available")
+def test_squeeze_unsqueeze_matches_pytorch() -> None:
+    """torch.squeeze/unsqueeze roundtrip vs pycoeus."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [1, 2, 3], requires_grad=False)
+    sq = pycoeus.squeeze(x_pyc, 0)
+    t = torch.tensor(data, dtype=torch.float64).reshape(1, 2, 3)
+    sq_t = torch.squeeze(t, 0)
+    _allclose("squeeze", list(sq.data), sq_t.flatten().tolist())
+    assert list(sq.shape) == [2, 3], f"Expected [2,3] got {list(sq.shape)}"
+
+    us = pycoeus.unsqueeze(x_pyc, 0)
+    us_t = torch.unsqueeze(t, 0)
+    assert list(us.shape) == list(us_t.shape), f"unsqueeze shape mismatch"
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "prod"), reason="pycoeus.prod not available")
+def test_prod_matches_pytorch() -> None:
+    """torch.prod(x) vs pycoeus.prod(x), fwd+bwd."""
+    data = [1.0, 2.0, 3.0, 4.0]
+    x_pyc = pycoeus.Tensor(data, [4], requires_grad=True)
+    out_pyc = pycoeus.prod(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.prod(t)
+    out_t.backward()
+    _allclose("prod_fwd", list(out_pyc.data), [out_t.item()])
+    _allclose("prod_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "sum_axis"), reason="pycoeus.sum_axis not available")
+def test_sum_axis_matches_pytorch() -> None:
+    """torch.sum(x, dim=1) vs pycoeus.sum_axis(x, axis=1), fwd+bwd."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=True)
+    out_pyc = pycoeus.sum_axis(x_pyc, 1)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3).requires_grad_(True)
+    out_t = torch.sum(t, dim=1, keepdim=False)
+    out_t.sum().backward()
+    _allclose("sum_axis_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("sum_axis_bwd", list(x_pyc.grad), t.grad.flatten().tolist())


### PR DESCRIPTION
prelu fwd+bwd, squeeze/unsqueeze shape, prod fwd+bwd, sum_axis fwd+bwd. JAX prod and sum_axis. PyTorch: 206, JAX: 107. 458/458 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds PyTorch and JAX parity for several operations including `prelu` (forward and backward), `squeeze`/`unsqueeze` shape operations, `prod` (forward and backward), and `sum_axis` (forward and backward). The changes bring PyTorch compatibility to 206 operations and JAX to 107 operations, with all 458 tests passing. The implementation includes comprehensive test coverage demonstrating exact numerical parity with both frameworks, along with a new batched matrix multiplication (`bmm`) regression test and minor code formatting improvements across module exports.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-autograd/tests/autograd/linalg.rs` |
| 4 | `coeus-autograd/tests/autograd/reductions.rs` |
| 5 | `coeus-autograd/tests/autograd/mod.rs` |
| 6 | `coeus-autograd/src/ops/activation/trig.rs` |
| 7 | `coeus-autograd/src/ops/activation/mod.rs` |
| 8 | `coeus-autograd/src/ops/mod.rs` |
| 9 | `coeus-ops/src/fuse/mod.rs` |
| 10 | `coeus-ops/src/lib.rs` |
| 11 | `coeus-ops/src/unary/mod.rs` |
| 12 | `coeus-python/src/ops/statistics.rs` |
| 13 | `coeus-nn/benches/nn_bench.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-nn/benches/nn_bench.rs` | Large-scale formatting/refactoring of benchmark code that appears unrelated to the PR's stated goal of adding prelu/squeeze/prod/sum_axis parity |
| `coeus-autograd/tests/autograd/linalg.rs` | New batched matrix multiplication (bmm) test appears unrelated to the PR's focus on prelu/squeeze/prod/sum_axis operations |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->