### PR TITLE
MS-286-290: mean/max/min_axis + reshape/permute parity (PyTorch 212, JAX 109) + bench 84

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -3244,6 +3244,46 @@ fn bench_gelu2_forward(c: &mut Criterion) {
     group.finish();
 }
 
+
+fn bench_atanh_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 0.9).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - atanh forward (128x256)");
+    group.bench_function("Burn NdArray (log proxy)", |b| { b.iter(|| { let one = BurnTensor::<BurnB, 2>::ones_like(black_box(&x_burn)); black_box(((one.clone() + black_box(x_burn.clone())) / (one - black_box(x_burn.clone()))).log() * 0.5f32) }) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::atanh(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::atanh(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_expm1_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - expm1 forward (128x256)");
+    group.bench_function("Burn NdArray (exp-1 proxy)", |b| { b.iter(|| { let one = BurnTensor::<BurnB, 2>::ones_like(black_box(&x_burn)); black_box(black_box(x_burn.clone()).exp() - one) }) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::expm1(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::expm1(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_log1p_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - log1p forward (128x256)");
+    group.bench_function("Burn NdArray (log(1+x) proxy)", |b| { b.iter(|| { let one = BurnTensor::<BurnB, 2>::ones_like(black_box(&x_burn)); black_box((one + black_box(x_burn.clone())).log()) }) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log1p(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log1p(black_box(&x_moirai)))) });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -3323,6 +3363,9 @@ criterion_group!(
     bench_relu2_forward,
     bench_tanh2_forward,
     bench_sigmoid2_forward,
-    bench_gelu2_forward
+    bench_gelu2_forward,
+    bench_atanh_forward,
+    bench_expm1_forward,
+    bench_log1p_forward
 );
 criterion_main!(benches);

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2251,3 +2251,29 @@ def test_sum_axis_matches_jax() -> None:
     t = jnp.array(data, dtype=jnp.float64).reshape(2, 3)
     exp = jnp.sum(t, axis=1)
     _allclose("sum_axis", list(got.data), exp.tolist())
+
+# ---------------------------------------------------------------------------
+# mean_axis / reshape / permute parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mean_axis"), reason="pycoeus.mean_axis not available")
+def test_mean_axis_matches_jax() -> None:
+    """jnp.mean(x, axis=1) vs pycoeus.mean_axis(x, 1)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=False)
+    got = pycoeus.mean_axis(x_pyc, 1)
+    t = jnp.array(data, dtype=jnp.float64).reshape(2, 3)
+    exp = jnp.mean(t, axis=1)
+    _allclose("mean_axis", list(got.data), exp.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "reshape"), reason="pycoeus.reshape not available")
+def test_reshape_matches_jax() -> None:
+    """jnp.reshape(x, shape) vs pycoeus.reshape(x, shape)."""
+    data = [float(i) for i in range(12)]
+    x_pyc = pycoeus.Tensor(data, [2, 6], requires_grad=False)
+    got = pycoeus.reshape(x_pyc, [3, 4])
+    t = jnp.array(data, dtype=jnp.float64).reshape(2, 6)
+    exp = jnp.reshape(t, (3, 4))
+    _allclose("reshape", list(got.data), jnp.ravel(exp).tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -5339,3 +5339,82 @@ def test_sum_axis_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("sum_axis_fwd", list(out_pyc.data), out_t.detach().tolist())
     _allclose("sum_axis_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+# ---------------------------------------------------------------------------
+# mean_axis / max_axis / min_axis / reshape / permute parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mean_axis"), reason="pycoeus.mean_axis not available")
+def test_mean_axis_matches_pytorch() -> None:
+    """torch.mean(x, dim=1) vs pycoeus.mean_axis(x, 1), fwd+bwd."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=True)
+    out_pyc = pycoeus.mean_axis(x_pyc, 1)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3).requires_grad_(True)
+    out_t = torch.mean(t, dim=1)
+    out_t.sum().backward()
+    _allclose("mean_axis_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("mean_axis_bwd", list(x_pyc.grad), t.grad.flatten().tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "max_axis"), reason="pycoeus.max_axis not available")
+def test_max_axis_matches_pytorch() -> None:
+    """torch.max(x, dim=1).values vs pycoeus.max_axis(x, 1) — forward only (non-differentiable)."""
+    data = [3.0, 1.0, 4.0, 1.0, 5.0, 9.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=False)
+    got = pycoeus.max_axis(x_pyc, 1)
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3)
+    exp = torch.max(t, dim=1, keepdim=True).values
+    _allclose("max_axis", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "min_axis"), reason="pycoeus.min_axis not available")
+def test_min_axis_matches_pytorch() -> None:
+    """torch.min(x, dim=1).values vs pycoeus.min_axis(x, 1) — forward only."""
+    data = [3.0, 1.0, 4.0, 1.0, 5.0, 9.0]
+    x_pyc = pycoeus.Tensor(data, [2, 3], requires_grad=False)
+    got = pycoeus.min_axis(x_pyc, 1)
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3)
+    exp = torch.min(t, dim=1, keepdim=True).values
+    _allclose("min_axis", list(got.data), exp.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "reshape"), reason="pycoeus.reshape not available")
+def test_reshape_matches_pytorch() -> None:
+    """torch.reshape(x, shape) vs pycoeus.reshape(x, shape), fwd+bwd."""
+    data = [float(i) for i in range(12)]
+    x_pyc = pycoeus.Tensor(data, [2, 6], requires_grad=True)
+    out_pyc = pycoeus.reshape(x_pyc, [3, 4])
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 6).requires_grad_(True)
+    out_t = t.reshape(3, 4)
+    out_t.sum().backward()
+    _allclose("reshape_fwd", list(out_pyc.data), out_t.detach().flatten().tolist())
+    _allclose("reshape_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "permute"), reason="pycoeus.permute not available")
+def test_permute_matches_pytorch() -> None:
+    """torch.permute(x, (1,0,2)) vs pycoeus.permute(x, [1,0,2]), fwd+bwd."""
+    data = [float(i) for i in range(24)]
+    x_pyc = pycoeus.Tensor(data, [2, 3, 4], requires_grad=True)
+    out_pyc = pycoeus.permute(x_pyc, [1, 0, 2])
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(2, 3, 4).requires_grad_(True)
+    out_t = t.permute(1, 0, 2)
+    out_t.sum().backward()
+    _allclose("permute_fwd", list(out_pyc.data), out_t.detach().flatten().tolist())
+    _allclose("permute_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "zeros"), reason="pycoeus.zeros not available")
+def test_zeros_ones_full_parity() -> None:
+    """Creation ops match torch."""
+    z = pycoeus.zeros([3, 4])
+    _allclose("zeros", list(z.data), torch.zeros(3, 4, dtype=torch.float64).flatten().tolist())
+    o = pycoeus.ones([3, 4])
+    _allclose("ones", list(o.data), torch.ones(3, 4, dtype=torch.float64).flatten().tolist())
+    f = pycoeus.full([2, 3], 5.0, False)
+    _allclose("full", list(f.data), torch.full((2, 3), 5.0, dtype=torch.float64).flatten().tolist())


### PR DESCRIPTION
mean_axis/max_axis/min_axis fwd, reshape/permute fwd+bwd, creation ops. JAX mean_axis/reshape. G-043: 84 rows (atanh/expm1/log1p). PyTorch: 212, JAX: 109. 458/458 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds parity tests for tensor operations (`mean_axis`, `max_axis`, `min_axis`, `reshape`, `permute`) against PyTorch and JAX, and introduces benchmarks for three mathematical functions (`atanh`, `expm1`, `log1p`). The changes expand test coverage to validate that the custom tensor implementation matches the behavior of established frameworks, adding 212 PyTorch tests and 109 JAX tests. Additionally, 84 benchmark rows (referenced as G-043) are added comparing Coeus Sequential and Moirai backends against Burn NdArray for the new math operations. All 458 tests pass.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->