### PR TITLE
fix(autograd): use FRAC_2_SQRT_PI constant in erfc backward

### DIFF
--- a/coeus-autograd/src/ops/activation/trig.rs
+++ b/coeus-autograd/src/ops/activation/trig.rs
@@ -109,7 +109,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         let gauss = coeus_ops::exp(&neg_x_sq, backend);
         let neg_two_over_sqrt_pi = Tensor::full_on(
             gauss.shape(),
-            T::from_f64(-1.128_379_167_095_512_6),
+            T::from_f64(-core::f64::consts::FRAC_2_SQRT_PI),
             backend,
         );
         let scaled = coeus_ops::mul(&gauss, &neg_two_over_sqrt_pi, backend);


### PR DESCRIPTION
clippy `approx_constant` (deny-by-default) rejects the hand-written `-1.128_379_167_095_512_6` literal in the erfc backward; `-core::f64::consts::FRAC_2_SQRT_PI` is the exact same value and unblocks `clippy --all-targets -D warnings` for the whole crate.

Verified: clippy clean, fmt clean, nextest coeus-autograd 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR replaces a hard-coded mathematical constant `-1.128_379_167_095_512_6` with the standard library constant `-core::f64::consts::FRAC_2_SQRT_PI` in the erfc backward pass implementation. This change satisfies clippy's `approx_constant` lint while maintaining the exact same numerical value, enabling the crate to compile with `-D warnings`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/activation/trig.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->