### PR TITLE
MS-296-297: embedding/dropout/group_norm/in2d parity (PyTorch 223) + bench 92

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -3337,6 +3337,63 @@ fn bench_abs2_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_selu2_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - selu fwd (128x256)");
+    group.bench_function("Burn NdArray (elu proxy)", |b| {
+        b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::selu(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::selu(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_exp2_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 4.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - exp2 forward (128x256)");
+    group.bench_function("Burn NdArray (exp proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).exp())) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::exp2(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::exp2(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_hardsigmoid2_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 5.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - hardsigmoid fwd (128x256)");
+    group.bench_function("Burn NdArray (sigmoid proxy)", |b| {
+        b.iter(|| black_box(burn::tensor::activation::sigmoid(black_box(x_burn.clone()))))
+    });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::hardsigmoid(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::hardsigmoid(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_log_softmax2_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).cos()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - log_softmax fwd (128x256, dim=1)");
+    group.bench_function("Burn NdArray (softmax.log)", |b| { b.iter(|| black_box(burn::tensor::activation::log_softmax(black_box(x_burn.clone()), 1))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::log_softmax(black_box(&x_seq), 1))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::log_softmax(black_box(&x_moirai), 1))) });
+    group.finish();
+}
+
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -3423,6 +3480,10 @@ criterion_group!(
     bench_silu2_forward,
     bench_softmax2_forward,
     bench_sqrt2_forward,
-    bench_abs2_forward
+    bench_abs2_forward,
+    bench_selu2_forward,
+    bench_exp2_forward,
+    bench_hardsigmoid2_forward,
+    bench_log_softmax2_forward
 );
 criterion_main!(benches);

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -5591,3 +5591,76 @@ def test_rms_norm_fwd_bwd_matches_pytorch() -> None:
 
     _allclose("rms_fwd", list(out_pyc.data), out_t.detach().flatten().tolist(), atol=1e-6)
     _allclose("rms_x_grad", list(x_pyc.grad), t_x.grad.flatten().tolist(), atol=1e-6)
+
+# ---------------------------------------------------------------------------
+# embedding / dropout / group_norm / instance_norm passthrough parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "Embedding"), reason="pycoeus.Embedding not available")
+def test_embedding_fwd_bwd_matches_pytorch() -> None:
+    """Embedding(10,8) fwd+backward (d/dweight = scatter_add) matches torch."""
+    vocab, dim = 10, 8
+    indices = [0.0, 3.0, 7.0, 0.0]  # pycoeus uses float indices
+    w_data = [float(i) * 0.1 for i in range(vocab * dim)]
+    emb = pycoeus.Embedding(num_embeddings=vocab, embedding_dim=dim)
+    params = emb.parameters()
+    params[0].data = w_data  # weight
+
+    idx_pyc = pycoeus.Tensor(indices, [4], requires_grad=False)
+    out_pyc = emb.forward(idx_pyc)
+    out_pyc.backward()
+
+    t_idx = torch.tensor([0, 3, 7, 0], dtype=torch.int64)
+    emb_t = torch.nn.Embedding(vocab, dim, dtype=torch.float64)
+    with torch.no_grad():
+        emb_t.weight.copy_(torch.tensor(w_data, dtype=torch.float64).reshape(vocab, dim))
+    out_t = emb_t(t_idx)
+    out_t.sum().backward()
+
+    _allclose("emb_fwd", list(out_pyc.data), out_t.detach().flatten().tolist())
+    _allclose("emb_w_grad", list(params[0].grad),
+              emb_t.weight.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "Dropout"), reason="pycoeus.Dropout not available")
+def test_dropout_eval_passthrough_matches_pytorch() -> None:
+    """Dropout(p=0.5) in eval mode passes through unchanged."""
+    data = [float(i) * 0.1 for i in range(10)]
+    x_pyc = pycoeus.Tensor(data, [10], requires_grad=False)
+    drop = pycoeus.Dropout(p=0.5)
+    drop.eval()  # eval mode — no masking
+    out_pyc = drop.forward(x_pyc)
+    _allclose("dropout_eval", list(out_pyc.data), data)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "GroupNorm"), reason="pycoeus.GroupNorm not available")
+def test_group_norm_fwd_matches_pytorch() -> None:
+    """GroupNorm(num_groups=2, num_channels=8) vs torch.nn.GroupNorm."""
+    n, c, l = 2, 8, 4
+    data = [float(i) * 0.1 - 1.6 for i in range(n * c * l)]
+    gn = pycoeus.GroupNorm(num_groups=2, num_channels=8)
+    x_pyc = pycoeus.Tensor(data, [n, c, l], requires_grad=False)
+    out_pyc = gn.forward(x_pyc)
+
+    t_x = torch.tensor(data, dtype=torch.float64).reshape(n, c, l)
+    gn_t = torch.nn.GroupNorm(2, 8, dtype=torch.float64)
+    out_t = gn_t(t_x)
+
+    _allclose("gn_fwd", list(out_pyc.data), out_t.detach().flatten().tolist(), atol=1e-6)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "InstanceNorm2d"), reason="pycoeus.InstanceNorm2d not available")
+def test_instance_norm_fwd_matches_pytorch() -> None:
+    """InstanceNorm2d(8) eval vs torch.nn.InstanceNorm2d."""
+    n, c, h, w = 2, 8, 4, 4
+    data = [float(i) * 0.05 - 0.8 for i in range(n * c * h * w)]
+    inn = pycoeus.InstanceNorm2d(num_features=8)
+    x_pyc = pycoeus.Tensor(data, [n, c, h, w], requires_grad=False)
+    out_pyc = inn.forward(x_pyc)
+
+    t_x = torch.tensor(data, dtype=torch.float64).reshape(n, c, h, w)
+    inn_t = torch.nn.InstanceNorm2d(c, dtype=torch.float64)
+    out_t = inn_t(t_x)
+
+    _allclose("in2d_fwd", list(out_pyc.data), out_t.detach().flatten().tolist(), atol=1e-6)


### PR DESCRIPTION
Embedding fwd+weight_grad, Dropout eval passthrough, GroupNorm, InstanceNorm2d parity. G-043: 92 rows (selu/exp2/hardsigmoid/log_softmax). PyTorch: 223, JAX: 111. 460/460 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds PyTorch parity tests for four neural network layers (`Embedding`, `Dropout`, `GroupNorm`, and `InstanceNorm2d`) and introduces benchmark tests for four activation/math operations (`selu`, `exp2`, `hardsigmoid`, and `log_softmax`). The parity tests verify that forward passes and gradient computations match PyTorch's implementation, while the benchmarks compare performance against the Burn framework. The PR brings the total to 223 PyTorch parity tests and 92 benchmark rows, with all 460 tests passing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->