### PR TITLE
[codex] Close MS-236 gate tracking drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,11 @@
 
 ### Fixed
 
+- **MS-236 gate-tracking drift** — updated the sprint checklist to reflect the
+  reverified `coeus-python` package gate (72/72 nextest) and warning-clean
+  `coeus-autograd` / `coeus-python` rustdoc gate after the shared Atlas path
+  crates compiled successfully. ([patch])
+
 - **`unused_mut` clippy regression in BN1d training** — dropped unneeded `mut`
   on `BatchNorm1d::from_parts(...)` in `coeus-nn/tests/norm_parity.rs` so the
   workspace passes `cargo clippy --workspace --all-targets -- -D warnings`

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -42,12 +42,11 @@
   coeus-autograd -p coeus-python --all-targets -- -D warnings`;
   `rustup run nightly cargo test --doc -p coeus-autograd -p coeus-python`
   (15/15 autograd doctests, 0 pycoeus doctests); `git diff --check`.
-- [ ] Residual non-MS-236 gate blockers: `rustup run nightly cargo nextest run
-  -p coeus-python --no-fail-fast` is 70/72 with `test_dot_cross_vector_ops`
-  and `test_statistical_ops` failing on `Tensor - float` Python assertions;
-  `rustup run nightly cargo doc -p coeus-autograd -p coeus-python --no-deps`
-  is blocked before Coeus docs by local `leto-ops` method-ambiguity compile
-  errors in the shared Atlas checkout.
+- [x] Residual non-MS-236 gate blockers rechecked and closed: `rustup run
+  nightly cargo nextest run -p coeus-python --no-fail-fast` now passes 72/72
+  after scalar-tensor assertion cleanup, and `rustup run nightly cargo doc -p
+  coeus-autograd -p coeus-python --no-deps` is warning-clean after the shared
+  Atlas `leto-ops` / `melinoe` path crates compile.
 
 ### Previous Sprint: MS-218 - Apollo FFT autograd + Python parity [COMPLETE]
 - [x] [minor] Added Apollo-backed `coeus_autograd::{fft_1d, ifft_1d,


### PR DESCRIPTION
## Summary
- update docs/checklist.md to mark the stale MS-236 package/doc blockers closed
- record the docs-sync in CHANGELOG.md

## Validation
- git diff --check
- previous same-checkout evidence: rustup run nightly cargo nextest run -p coeus-python --no-fail-fast (72/72)
- previous same-checkout evidence: rustup run nightly cargo doc -p coeus-autograd -p coeus-python --no-deps

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates documentation to reflect that previously failing gate checks for MS-236 are now passing. Specifically, it marks the `coeus-python` nextest suite (now 72/72 passing) and `coeus-autograd`/`coeus-python` rustdoc generation (now warning-clean) as resolved in the sprint checklist, and records this documentation sync in the changelog.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/checklist.md` |
| 2 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->