### PR TITLE
MS-309-311: elu/selu/log_sigmoid/adap_pool/conv_transp parity (PyTorch 239, JAX 118) + bench 104

### DIFF
--- a/coeus-autograd/src/ops/activation/math.rs
+++ b/coeus-autograd/src/ops/activation/math.rs
@@ -362,9 +362,7 @@ where
         let one = T::one();
         let mut out_host = vec![T::zero(); n];
         if exp_i == 0 {
-            for v in &mut out_host {
-                *v = one;
-            }
+            out_host.fill(one);
         } else if exp_i > 0 {
             let k = exp_i as u32;
             for i in 0..n {

--- a/coeus-autograd/src/ops/reduction/mod.rs
+++ b/coeus-autograd/src/ops/reduction/mod.rs
@@ -3,8 +3,8 @@
 // Organized into sub-modules: max_axis/min_axis in `max_min`, norm variants in `norm`.
 
 mod max_min;
-mod prod;
 mod norm;
+mod prod;
 mod variance;
 
 pub use max_min::{max_axis, min_axis};

--- a/coeus-autograd/src/ops/reduction/prod.rs
+++ b/coeus-autograd/src/ops/reduction/prod.rs
@@ -68,8 +68,7 @@ where
                 acc = acc * xs[i];
             }
 
-            let gi_increment =
-                Tensor::from_slice(self.input_saved.shape_cloned(), &gi);
+            let gi_increment = Tensor::from_slice(self.input_saved.shape_cloned(), &gi);
             let gl = g.write();
             coeus_ops::add_assign(gl, &gi_increment, &backend);
         }
@@ -91,7 +90,10 @@ where
     B::DeviceBuffer<T>:
         coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
 {
-    assert!(input.tensor.numel() > 0, "prod: empty tensors have no product");
+    assert!(
+        input.tensor.numel() > 0,
+        "prod: empty tensors have no product"
+    );
     let backend = B::default();
     let value = coeus_ops::prod(&input.tensor, &backend);
     let out_tensor = Tensor::from_slice_on(vec![1], &[value], &backend);

--- a/coeus-autograd/tests/autograd/reductions.rs
+++ b/coeus-autograd/tests/autograd/reductions.rs
@@ -376,6 +376,10 @@ fn test_prod_autograd_matches_analytic() {
     let gz = z.grad().unwrap();
     let gz = gz.as_slice();
     for (i, want) in [0.0, 6.0, 0.0].iter().enumerate() {
-        assert!((gz[i] - want).abs() < 1e-14, "zero dx[{i}]: {} vs {want}", gz[i]);
+        assert!(
+            (gz[i] - want).abs() < 1e-14,
+            "zero dx[{i}]: {} vs {want}",
+            gz[i]
+        );
     }
 }

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -3880,6 +3880,77 @@ fn bench_mean_axis_forward(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_elu2_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - elu fwd (128x256)");
+    group.bench_function("Burn NdArray (relu proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::elu(black_box(&x_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::elu(black_box(&x_moirai)))) });
+    group.finish();
+}
+
+fn bench_cumsum_dim0_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - cumsum(dim=0) forward (128x256)");
+    group.bench_function("Burn NdArray (cumsum dim=0 n/a, sum proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).sum_dim(0))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::cumsum(black_box(&x_seq), 0))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::cumsum(black_box(&x_moirai), 0))) });
+    group.finish();
+}
+
+fn bench_where_cond_forward(c: &mut Criterion) {
+    let cond_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| if i % 2 == 0 { 1.0 } else { 0.0 }).collect();
+    let a_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin()).collect();
+    let b_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.005).cos()).collect();
+    let cond_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &cond_data), false);
+    let a_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &a_data), false);
+    let b_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &b_data), false);
+    let cond_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &cond_data), false);
+    let a_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &a_data), false);
+    let b_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &b_data), false);
+    let device = NdArrayDevice::default();
+    let a_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(a_data.clone(), [BATCH, FEATURES]), &device);
+    let b_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(b_data.clone(), [BATCH, FEATURES]), &device);
+    let c_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(cond_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - where_cond forward (128x256)");
+    group.bench_function("Burn NdArray (mask_where proxy)", |b| { b.iter(|| { let mask = black_box(c_burn.clone()).equal_elem(1.0f32); black_box(black_box(a_burn.clone()).mask_where(mask, black_box(b_burn.clone()))) }) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::where_cond(black_box(&cond_seq), black_box(&a_seq), black_box(&b_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::where_cond(black_box(&cond_moirai), black_box(&a_moirai), black_box(&b_moirai)))) });
+    group.finish();
+}
+
+fn bench_conv1d2_forward(c: &mut Criterion) {
+    // Conv1d(16,32,k=3): [8,16,64] — second conv1d row with different shape
+    const N1: usize = 8;
+    const C_IN1: usize = 16;
+    const C_OUT1: usize = 32;
+    const K1: usize = 3;
+    const L1: usize = 64;
+    let inp_data: Vec<f32> = (0..(N1 * C_IN1 * L1)).map(|i| (i as f32 * 0.002).cos()).collect();
+    let device = NdArrayDevice::default();
+    let inp_burn: BurnTensor<BurnB, 3> = BurnTensor::from_data(TensorData::new(inp_data.clone(), [N1, C_IN1, L1]), &device);
+    let burn_conv = burn::nn::conv::Conv1dConfig::new(C_IN1, C_OUT1, K1).with_bias(false).with_padding(PaddingConfig1d::Valid).init::<BurnB>(&device);
+    let inp_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![N1, C_IN1, L1], &inp_data), false);
+    let inp_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![N1, C_IN1, L1], &inp_data), false);
+    let conv_seq = coeus_nn::Conv1d::<f32, SequentialBackend>::new(C_IN1, C_OUT1, K1, false);
+    let conv_moirai = coeus_nn::Conv1d::<f32, MoiraiBackend>::new(C_IN1, C_OUT1, K1, false);
+    use coeus_nn::Module;
+    let mut group = c.benchmark_group("Burn vs Coeus - Conv1d(16,32,k=3) fwd (8x16x64)");
+    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(burn_conv.forward(black_box(inp_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(conv_seq.forward(black_box(&inp_seq)))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(conv_moirai.forward(black_box(&inp_moirai)))) });
+    group.finish();
+}
+
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -3978,6 +4049,10 @@ criterion_group!(
     bench_scatter_add_forward,
     bench_argmax2_forward,
     bench_topk2_forward,
-    bench_mean_axis_forward
+    bench_mean_axis_forward,
+    bench_elu2_forward,
+    bench_cumsum_dim0_forward,
+    bench_where_cond_forward,
+    bench_conv1d2_forward
 );
 criterion_main!(benches);

--- a/coeus-ops/src/adaptive_pool.rs
+++ b/coeus-ops/src/adaptive_pool.rs
@@ -81,6 +81,10 @@ where
 /// Adaptive max pooling for `[N, C, L]` → `[N, C, output_size]`.
 ///
 /// Equivalent to PyTorch `nn.AdaptiveMaxPool1d(output_size)`.
+///
+/// # Memory
+/// Output is `alloc_on` (uninitialized); every `[n, c, oi]` position is written
+/// exactly once by the loop — no zero-initialization overhead.
 pub fn adaptive_max_pool1d<T: Float, B: BackendOps<T> + Default>(
     input: &Tensor<T, B>,
     output_size: usize,
@@ -121,6 +125,10 @@ where
 ///
 /// Equivalent to PyTorch `nn.AdaptiveAvgPool2d((out_h, out_w))`.
 /// Uses `parallel_for` over (N×C) pairs on contiguous inputs.
+///
+/// # Memory
+/// Output is `alloc_on` (uninitialized); parallel_for writes every `(oh, ow)`
+/// position — no zero-initialization overhead.
 pub fn adaptive_avg_pool2d<T: Float, B: BackendOps<T> + Default + Backend>(
     input: &Tensor<T, B>,
     out_h: usize,
@@ -183,6 +191,10 @@ where
 ///
 /// Equivalent to PyTorch `nn.AdaptiveMaxPool2d((out_h, out_w))`.
 /// Uses `parallel_for` over (N×C) pairs on contiguous inputs.
+///
+/// # Memory
+/// Output is `alloc_on` (uninitialized); parallel_for writes every position
+/// exactly once — no zero-initialization overhead.
 pub fn adaptive_max_pool2d<T: Float, B: BackendOps<T> + Default + Backend>(
     input: &Tensor<T, B>,
     out_h: usize,

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2373,3 +2373,29 @@ def test_log_softmax_dim0_matches_jax() -> None:
     t = jnp.array(data, dtype=jnp.float64).reshape(2, 3)
     exp = jax.nn.log_softmax(t, axis=0)
     _allclose("lsm_dim0", list(got.data), jnp.ravel(exp).tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# elu / selu / log_sigmoid parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "elu"), reason="pycoeus.elu not available")
+def test_elu_matches_jax() -> None:
+    """jax.nn.elu(x) vs pycoeus.elu(x) (alpha fixed at 1.0)."""
+    import jax.nn
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.elu(x_pyc)
+    exp = jax.nn.elu(jnp.array(data, dtype=jnp.float64))
+    _allclose("elu", list(got.data), exp.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "selu"), reason="pycoeus.selu not available")
+def test_selu_matches_jax() -> None:
+    """jax.nn.selu(x) vs pycoeus.selu(x)."""
+    import jax.nn
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.selu(x_pyc)
+    exp = jax.nn.selu(jnp.array(data, dtype=jnp.float64))
+    _allclose("selu", list(got.data), exp.tolist(), atol=1e-10)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -5807,3 +5807,75 @@ def test_scatter_add_accumulate_matches_pytorch() -> None:
     src_t = torch.tensor(src, dtype=torch.float64).reshape(2, 3)
     exp = base_t.scatter_add(0, idx_t, src_t)
     _allclose("scatter_add_accum", list(out_pyc.data), exp.flatten().tolist())
+
+# ---------------------------------------------------------------------------
+# elu / log_sigmoid / adaptive_avg_pool1d / conv_transpose2d_shape parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "elu"), reason="pycoeus.elu not available")
+def test_elu_fwd_bwd_matches_pytorch() -> None:
+    """F.elu(x, alpha=1.0) fwd+bwd vs pycoeus.elu(x) (alpha fixed at 1.0)."""
+    data = [-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [7], requires_grad=True)
+    out_pyc = pycoeus.elu(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.elu(t, alpha=1.0)
+    out_t.sum().backward()
+    _allclose("elu_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("elu_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log_sigmoid"), reason="pycoeus.log_sigmoid not available")
+def test_log_sigmoid_fwd_bwd_matches_pytorch() -> None:
+    """F.logsigmoid(x) fwd+bwd vs pycoeus.log_sigmoid(x)."""
+    data = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.log_sigmoid(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.logsigmoid(t)
+    out_t.sum().backward()
+    _allclose("logsigmoid_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("logsigmoid_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "AdaptiveAvgPool1d"), reason="pycoeus.AdaptiveAvgPool1d not available")
+def test_adaptive_avg_pool1d_fwd_matches_pytorch() -> None:
+    """nn.AdaptiveAvgPool1d(4) on [2,8,16] vs torch."""
+    n, c, l, out_s = 2, 8, 16, 4
+    data = [float(i) * 0.05 for i in range(n * c * l)]
+    pool = pycoeus.AdaptiveAvgPool1d(output_size=out_s)
+    x_pyc = pycoeus.Tensor(data, [n, c, l], requires_grad=False)
+    out_pyc = pool.forward(x_pyc)
+    t = torch.tensor(data, dtype=torch.float64).reshape(n, c, l)
+    exp = torch.nn.AdaptiveAvgPool1d(out_s)(t)
+    _allclose("adapavgpool1d", list(out_pyc.data), exp.detach().flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "selu"), reason="pycoeus.selu not available")
+def test_selu_fwd_bwd_matches_pytorch() -> None:
+    """F.selu(x) fwd+bwd vs pycoeus.selu(x) — scale=1.0507, alpha=1.6733."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.selu(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.selu(t)
+    out_t.sum().backward()
+    _allclose("selu_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-10)
+    _allclose("selu_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "ConvTranspose2d"), reason="pycoeus.ConvTranspose2d not available")
+def test_conv_transpose2d_shape_matches_pytorch() -> None:
+    """ConvTranspose2d(4,8,k=3) output shape [2,4,6,6] -> [2,8,8,8]."""
+    n, c_in, h, w = 2, 4, 6, 6
+    c_out, k = 8, 3
+    data = [float(i) * 0.01 for i in range(n * c_in * h * w)]
+    ct = pycoeus.ConvTranspose2d(in_channels=c_in, out_channels=c_out, kernel_size=k)
+    x_pyc = pycoeus.Tensor(data, [n, c_in, h, w], requires_grad=False)
+    out = ct.forward(x_pyc)
+    assert list(out.shape) == [n, c_out, h + k - 1, w + k - 1], \
+        f"Expected {[n, c_out, 8, 8]}, got {list(out.shape)}"


### PR DESCRIPTION
elu/selu fwd+bwd (alpha=1 hardcoded), log_sigmoid, AdaptiveAvgPool1d, ConvTranspose2d shape. G-043: 104 rows. adaptive_pool doc improvements. 464/464 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds forward and backward implementations for `elu`, `selu`, and `log_sigmoid` activation functions, along with `AdaptiveAvgPool1d` and `ConvTranspose2d` shape verification. The changes establish parity with PyTorch and JAX frameworks through 75 new test cases (PyTorch: 5 tests, JAX: 2 tests) and adds 4 new benchmark functions (elu, cumsum, where_cond, conv1d). Documentation improvements for adaptive pooling functions clarify memory allocation patterns. Minor code quality improvements include replacing loop-based initialization with `fill()` and fixing formatting/import ordering.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-ops/src/adaptive_pool.rs` |
| 4 | `coeus-nn/benches/nn_bench.rs` |
| 5 | `coeus-autograd/src/ops/activation/math.rs` |
| 6 | `coeus-autograd/src/ops/reduction/prod.rs` |
| 7 | `coeus-autograd/tests/autograd/reductions.rs` |
| 8 | `coeus-autograd/src/ops/reduction/mod.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-autograd/src/ops/reduction/mod.rs` | Import reordering (norm/prod swap) appears to be unrelated formatting change in a reduction module, not related to the activation/pooling/conv features described in PR title |
| `coeus-autograd/src/ops/reduction/prod.rs` | Formatting changes (whitespace adjustments, assert reformatting) in product reduction operation are unrelated to the elu/selu/log_sigmoid/adaptive_pool/conv_transpose features |
| `coeus-autograd/tests/autograd/reductions.rs` | Formatting change to assert statement in prod test is unrelated to the activation/pooling/conv features being added |
| `coeus-autograd/src/ops/activation/math.rs` | Refactoring loop to use fill() method is a minor code quality improvement unrelated to the new activation functions (elu/selu/log_sigmoid) mentioned in PR title |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->