### PR TITLE
MS-321-323: mean/mul/sub/div/celu parity (PyTorch 253, JAX 123) + bench 112 + themis audit

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -4112,6 +4112,67 @@ fn bench_prod_forward(c: &mut Criterion) {
 }
 
 
+fn bench_var_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - var(unbiased) forward (128x256)");
+    group.bench_function("Burn NdArray (mean+sum proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).mean())) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::var(&x_seq, true))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::var(&x_moirai, true))) });
+    group.finish();
+}
+
+fn bench_hardshrink_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - hardshrink(0.5) forward (128x256)");
+    group.bench_function("Burn NdArray (relu proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::hardshrink(&x_seq, 0.5))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::hardshrink(&x_moirai, 0.5))) });
+    group.finish();
+}
+
+fn bench_mul_forward(c: &mut Criterion) {
+    let a_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin()).collect();
+    let b_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.005).cos()).collect();
+    let a_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &a_data), false);
+    let b_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &b_data), false);
+    let a_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &a_data), false);
+    let b_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &b_data), false);
+    let device = NdArrayDevice::default();
+    let a_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(a_data.clone(), [BATCH, FEATURES]), &device);
+    let b_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(b_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - mul forward (128x256)");
+    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(black_box(a_burn.clone()) * black_box(b_burn.clone()))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::mul(&a_seq, &b_seq))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::mul(&a_moirai, &b_moirai))) });
+    group.finish();
+}
+
+fn bench_div_forward(c: &mut Criterion) {
+    let a_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 4.0 + 0.1).collect();
+    let b_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.005).cos().abs() + 0.5).collect();
+    let a_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &a_data), false);
+    let b_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &b_data), false);
+    let a_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &a_data), false);
+    let b_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &b_data), false);
+    let device = NdArrayDevice::default();
+    let a_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(a_data.clone(), [BATCH, FEATURES]), &device);
+    let b_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(b_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - div forward (128x256)");
+    group.bench_function("Burn NdArray", |b| { b.iter(|| black_box(black_box(a_burn.clone()) / black_box(b_burn.clone()))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::div(&a_seq, &b_seq))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::div(&a_moirai, &b_moirai))) });
+    group.finish();
+}
+
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -4218,6 +4279,10 @@ criterion_group!(
     bench_acos_forward,
     bench_sum_forward,
     bench_linear_fwd_bwd,
-    bench_prod_forward
+    bench_prod_forward,
+    bench_var_forward,
+    bench_hardshrink_forward,
+    bench_mul_forward,
+    bench_div_forward
 );
 criterion_main!(benches);

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2453,13 +2453,12 @@ def test_mean_matches_jax() -> None:
     _allclose("mean", list(got.data), [exp])
 
 
-@pytest.mark.skipif(not hasattr(pycoeus, "mul"), reason="pycoeus.mul not available")
 def test_mul_matches_jax() -> None:
-    """jnp.multiply(a, b) vs pycoeus.mul(a, b)."""
+    """jnp.multiply(a, b) vs pycoeus a * b (tensor mul operator)."""
     a = [1.0, 2.0, 3.0, 4.0]
     b = [2.0, 0.5, -1.0, 3.0]
     a_pyc = pycoeus.Tensor(a, [4], requires_grad=False)
     b_pyc = pycoeus.Tensor(b, [4], requires_grad=False)
-    got = pycoeus.mul(a_pyc, b_pyc)
+    got = a_pyc * b_pyc
     exp = jnp.multiply(jnp.array(a, dtype=jnp.float64), jnp.array(b, dtype=jnp.float64))
     _allclose("mul", list(got.data), exp.tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -6030,3 +6030,85 @@ def test_asin_fwd_bwd_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("asin_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
     _allclose("asin_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# mean fwd+bwd / mul_fwd+bwd / sub_fwd+bwd / softsign_bwd / celu_bwd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mean"), reason="pycoeus.mean not available")
+def test_mean_fwd_bwd_matches_pytorch() -> None:
+    """torch.mean(x) global fwd+bwd vs pycoeus.mean(x)."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [6], requires_grad=True)
+    out_pyc = pycoeus.mean(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.mean(t)
+    out_t.backward()
+    _allclose("mean_fwd", list(out_pyc.data), [out_t.item()])
+    _allclose("mean_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+def test_mul_fwd_bwd_matches_pytorch() -> None:
+    """torch.mul(a, b) element-wise fwd+bwd via a * b tensor operator."""
+    a = [1.0, 2.0, 3.0, 4.0]
+    b = [2.0, 0.5, -1.0, 3.0]
+    a_pyc = pycoeus.Tensor(a, [4], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [4], requires_grad=True)
+    out_pyc = a_pyc * b_pyc
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64, requires_grad=True)
+    b_t = torch.tensor(b, dtype=torch.float64, requires_grad=True)
+    out_t = a_t * b_t
+    out_t.sum().backward()
+    _allclose("mul_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("mul_bwd_a", list(a_pyc.grad), a_t.grad.tolist())
+
+
+def test_sub_fwd_bwd_matches_pytorch() -> None:
+    """torch.sub(a, b) fwd+bwd via a - b tensor operator."""
+    a = [3.0, 1.0, 4.0, 1.0]
+    b = [1.0, 2.0, 1.0, 3.0]
+    a_pyc = pycoeus.Tensor(a, [4], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [4], requires_grad=True)
+    out_pyc = a_pyc - b_pyc
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64, requires_grad=True)
+    b_t = torch.tensor(b, dtype=torch.float64, requires_grad=True)
+    out_t = a_t - b_t
+    out_t.sum().backward()
+    _allclose("sub_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("sub_bwd_a", list(a_pyc.grad), a_t.grad.tolist())
+    _allclose("sub_bwd_b", list(b_pyc.grad), b_t.grad.tolist())
+
+
+def test_div_fwd_bwd_matches_pytorch() -> None:
+    """torch.div(a, b) fwd+bwd via a / b tensor operator."""
+    a = [6.0, 4.0, 9.0, 8.0]
+    b = [2.0, 2.0, 3.0, 4.0]
+    a_pyc = pycoeus.Tensor(a, [4], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [4], requires_grad=True)
+    out_pyc = a_pyc / b_pyc
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64, requires_grad=True)
+    b_t = torch.tensor(b, dtype=torch.float64, requires_grad=True)
+    out_t = a_t / b_t
+    out_t.sum().backward()
+    _allclose("div_fwd", list(out_pyc.data), out_t.detach().tolist())
+    _allclose("div_bwd_a", list(a_pyc.grad), a_t.grad.tolist(), atol=1e-10)
+    _allclose("div_bwd_b", list(b_pyc.grad), b_t.grad.tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "celu"), reason="pycoeus.celu not available")
+def test_celu_bwd_alpha05_matches_pytorch() -> None:
+    """F.celu(x, alpha=0.5) backward vs pycoeus.celu(x, 0.5)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.celu(x_pyc, 0.5)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.celu(t, alpha=0.5)
+    out_t.sum().backward()
+    _allclose("celu_05_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("celu_05_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)


### PR DESCRIPTION
mean/mul/sub/div/celu fwd+bwd via tensor operators. Themis: no locks, pure data structs. G-043: 112 rows. 486/486 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds forward and backward pass parity tests for several tensor operations (`mean`, `mul`, `sub`, `div`, `celu`) against PyTorch and JAX reference implementations, implemented via tensor operators. It also introduces performance benchmarks comparing these operations between Burn and Coeus backends (Sequential and Moirai). Additionally, benchmarks for `var` and `hardshrink` operations are included. All 486 tests pass successfully.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_jax_parity.py` |
| 2 | `coeus-python/tests/test_pytorch_parity.py` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-nn/benches/nn_bench.rs` | The PR title and body mention mean/mul/sub/div/celu operations, but the benchmarks file also adds `bench_var_forward` and `bench_hardshrink_forward` which are not mentioned in the PR title or body |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->