### PR TITLE
MS-330-332: softplus/tanh/softsign/tril/batchnorm_eval parity (PyTorch 267, JAX 133) + bench 128

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -4442,6 +4442,127 @@ fn bench_sign_forward(c: &mut Criterion) {
 }
 
 
+fn bench_hardsigmoid_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 5.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - hardsigmoid forward (128x256)");
+    group.bench_function("Burn NdArray (sigmoid proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::sigmoid(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::hardsigmoid(&x_seq))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::hardsigmoid(&x_moirai))) });
+    group.finish();
+}
+
+fn bench_celu_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - celu(alpha=1) forward (128x256)");
+    group.bench_function("Burn NdArray (relu proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::celu(&x_seq, 1.0))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::celu(&x_moirai, 1.0))) });
+    group.finish();
+}
+
+fn bench_tanh_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin()).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - tanh fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (tanh fwd proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::tanh(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| { let o = coeus_autograd::tanh(black_box(&x_seq)); black_box(o).backward() })
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| { let o = coeus_autograd::tanh(black_box(&x_moirai)); black_box(o).backward() })
+    });
+    group.finish();
+}
+
+fn bench_sigmoid_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 3.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - sigmoid fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (sigmoid fwd proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::sigmoid(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| { let o = coeus_autograd::sigmoid(black_box(&x_seq)); black_box(o).backward() })
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| { let o = coeus_autograd::sigmoid(black_box(&x_moirai)); black_box(o).backward() })
+    });
+    group.finish();
+}
+
+fn bench_softplus_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - softplus forward (128x256)");
+    group.bench_function("Burn NdArray (log1p_exp proxy)", |b| { b.iter(|| { let e = black_box(x_burn.clone()).exp(); let one = BurnTensor::<BurnB, 2>::ones_like(&e); black_box((one + e).log()) }) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::softplus(&x_seq))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::softplus(&x_moirai))) });
+    group.finish();
+}
+
+fn bench_hardswish_forward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 4.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), false);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - hardswish forward (128x256)");
+    group.bench_function("Burn NdArray (relu proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| black_box(coeus_autograd::hardswish(&x_seq))) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| black_box(coeus_autograd::hardswish(&x_moirai))) });
+    group.finish();
+}
+
+fn bench_gelu_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - gelu fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (gelu fwd proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::gelu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| { let o = coeus_autograd::gelu(black_box(&x_seq)); black_box(o).backward() })
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| { let o = coeus_autograd::gelu(black_box(&x_moirai)); black_box(o).backward() })
+    });
+    group.finish();
+}
+
+fn bench_silu_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).cos() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - silu fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (silu fwd proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::silu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| {
+        b.iter(|| { let o = coeus_autograd::silu(black_box(&x_seq)); black_box(o).backward() })
+    });
+    group.bench_function("Coeus Moirai", |b| {
+        b.iter(|| { let o = coeus_autograd::silu(black_box(&x_moirai)); black_box(o).backward() })
+    });
+    group.finish();
+}
+
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -4560,6 +4681,14 @@ criterion_group!(
     bench_softshrink_forward,
     bench_pow_forward,
     bench_softsign_forward,
-    bench_sign_forward
+    bench_sign_forward,
+    bench_hardsigmoid_forward,
+    bench_celu_forward,
+    bench_tanh_backward,
+    bench_sigmoid_backward,
+    bench_softplus_forward,
+    bench_hardswish_forward,
+    bench_gelu_backward,
+    bench_silu_backward
 );
 criterion_main!(benches);

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2532,3 +2532,54 @@ def test_sigmoid_bwd_matches_jax() -> None:
     grad_fn = jax.grad(jax_sig_sum)
     exp_grad = grad_fn(jnp.array(data, dtype=jnp.float64))
     _allclose("sigmoid_bwd", list(x_pyc.grad), exp_grad.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# tanh_bwd / softplus / softsign / sub / div parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "tanh"), reason="pycoeus.tanh not available")
+def test_tanh_bwd_matches_jax() -> None:
+    """jax grad of tanh sum vs pycoeus tanh backward."""
+    import jax
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.tanh(x_pyc)
+    out_pyc.backward()
+    def tanh_sum(x): return jnp.sum(jnp.tanh(x))
+    grad_fn = jax.grad(tanh_sum)
+    exp_grad = grad_fn(jnp.array(data, dtype=jnp.float64))
+    _allclose("tanh_bwd", list(x_pyc.grad), exp_grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softplus"), reason="pycoeus.softplus not available")
+def test_softplus_matches_jax() -> None:
+    """jax.nn.softplus(x) vs pycoeus.softplus(x)."""
+    import jax.nn
+    data = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=False)
+    got = pycoeus.softplus(x_pyc)
+    exp = jax.nn.softplus(jnp.array(data, dtype=jnp.float64))
+    _allclose("softplus", list(got.data), exp.tolist(), atol=1e-12)
+
+
+def test_sub_matches_jax() -> None:
+    """jnp.subtract(a, b) vs a - b tensor operator."""
+    a = [3.0, 1.0, 4.0, 1.0]
+    b = [1.0, 2.0, 1.0, 3.0]
+    a_pyc = pycoeus.Tensor(a, [4], requires_grad=False)
+    b_pyc = pycoeus.Tensor(b, [4], requires_grad=False)
+    got = a_pyc - b_pyc
+    exp = jnp.subtract(jnp.array(a, dtype=jnp.float64), jnp.array(b, dtype=jnp.float64))
+    _allclose("sub", list(got.data), exp.tolist())
+
+
+def test_div_matches_jax() -> None:
+    """jnp.divide(a, b) vs a / b tensor operator."""
+    a = [6.0, 4.0, 9.0, 8.0]
+    b = [2.0, 2.0, 3.0, 4.0]
+    a_pyc = pycoeus.Tensor(a, [4], requires_grad=False)
+    b_pyc = pycoeus.Tensor(b, [4], requires_grad=False)
+    got = a_pyc / b_pyc
+    exp = jnp.divide(jnp.array(a, dtype=jnp.float64), jnp.array(b, dtype=jnp.float64))
+    _allclose("div", list(got.data), exp.tolist())

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -6212,3 +6212,104 @@ def test_conv_transpose1d_shape_matches_pytorch() -> None:
     out = ct.forward(x_pyc)
     assert list(out.shape) == [n, c_out, l + k - 1], \
         f"Expected {[n, c_out, 12]}, got {list(out.shape)}"
+
+# ---------------------------------------------------------------------------
+# softplus_bwd / tanh_bwd / softsign_bwd / prelu_bwd / softshrink_bwd / tril_bwd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softplus"), reason="pycoeus.softplus not available")
+def test_softplus_fwd_bwd_matches_pytorch() -> None:
+    """F.softplus(x) fwd+bwd vs pycoeus.softplus(x)."""
+    data = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.softplus(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.softplus(t)
+    out_t.sum().backward()
+    _allclose("softplus_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("softplus_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "tanh"), reason="pycoeus.tanh not available")
+def test_tanh_bwd_matches_pytorch() -> None:
+    """tanh backward specifically: d/dx tanh(x) = 1 - tanh^2(x)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.tanh(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.tanh(t)
+    out_t.sum().backward()
+    _allclose("tanh_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softsign"), reason="pycoeus.softsign not available")
+def test_softsign_fwd_bwd_matches_pytorch() -> None:
+    """F.softsign(x) fwd+bwd vs pycoeus.softsign(x)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.softsign(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.softsign(t)
+    out_t.sum().backward()
+    _allclose("softsign_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
+    _allclose("softsign_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "softshrink"), reason="pycoeus.softshrink not available")
+def test_softshrink_bwd_matches_pytorch() -> None:
+    """F.softshrink(x, lambd=0.5) fwd+bwd - gradient is 1 where |x|>lambd, else 0."""
+    data = [-2.0, -0.3, 0.0, 0.3, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.softshrink(x_pyc, 0.5)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.softshrink(t, lambd=0.5)
+    out_t.sum().backward()
+    _allclose("softshrink_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "tril"), reason="pycoeus.tril not available")
+def test_tril_bwd_matches_pytorch() -> None:
+    """tril fwd+bwd: gradient only flows through lower-triangular positions."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=True)
+    out_pyc = pycoeus.tril(x_pyc, 0)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(4, 4).requires_grad_(True)
+    out_t = torch.tril(t, diagonal=0)
+    out_t.sum().backward()
+    _allclose("tril_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "triu"), reason="pycoeus.triu not available")
+def test_triu_bwd_matches_pytorch() -> None:
+    """triu fwd+bwd: gradient only flows through upper-triangular positions."""
+    data = [float(i) for i in range(16)]
+    x_pyc = pycoeus.Tensor(data, [4, 4], requires_grad=True)
+    out_pyc = pycoeus.triu(x_pyc, 0)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64).reshape(4, 4).requires_grad_(True)
+    out_t = torch.triu(t, diagonal=0)
+    out_t.sum().backward()
+    _allclose("triu_bwd", list(x_pyc.grad), t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "BatchNorm1d"), reason="pycoeus.BatchNorm1d not available")
+def test_batchnorm1d_eval_matches_pytorch() -> None:
+    """BatchNorm1d eval mode fwd matches torch (uses running stats)."""
+    feat, batch = 8, 4
+    data = [float(i) * 0.1 - 1.6 for i in range(batch * feat)]
+    bn = pycoeus.BatchNorm1d(num_features=feat)
+    bn.eval()
+    x_pyc = pycoeus.Tensor(data, [batch, feat], requires_grad=False)
+    out_pyc = bn.forward(x_pyc)
+    # In eval mode output is (x - 0) / sqrt(1 + eps) * 1 + 0 ≈ x (identity with fresh BN)
+    t_x = torch.tensor(data, dtype=torch.float64).reshape(batch, feat)
+    bn_t = torch.nn.BatchNorm1d(feat, dtype=torch.float64)
+    bn_t.eval()
+    out_t = bn_t(t_x)
+    _allclose("bn1d_eval_fwd", list(out_pyc.data), out_t.detach().flatten().tolist(), atol=1e-6)


### PR DESCRIPTION
softplus/tanh/softsign/softshrink/tril/triu fwd+bwd, batchnorm eval. JAX: tanh_bwd/softplus/sub/div. G-043: 128 rows (backward benches). 486/486 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive test coverage and performance benchmarks for neural network activation functions and operations. It introduces PyTorch parity tests for forward and backward passes of `softplus`, `tanh`, `softsign`, `softshrink`, `tril`, `triu`, and `batchnorm` in eval mode (267 total PyTorch tests). It also adds JAX parity tests for `tanh_bwd`, `softplus`, `sub`, and `div` operations (133 total JAX tests). Finally, it includes 128 benchmark rows for activation functions comparing Burn NdArray, Coeus Sequential, and Coeus Moirai backends, with a focus on backward pass performance for operations like `tanh`, `sigmoid`, `gelu`, and `silu`.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->