### PR TITLE
MS-335-340: topk dim0 fix + parity (PyTorch 280, JAX 139) + bench 144

### DIFF
--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -4668,6 +4668,111 @@ fn bench_celu_backward(c: &mut Criterion) {
 }
 
 
+fn bench_selu_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.002).sin() * 3.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - selu fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (selu fwd)", |b| { b.iter(|| black_box(burn::tensor::activation::selu(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::selu(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::selu(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_exp2_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 4.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - exp2 fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (exp proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).exp())) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::exp2(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::exp2(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_log2_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos().abs() + 0.1).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - log2 fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (log proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).log())) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::log2(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::log2(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_atan_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).cos() * 5.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - atan fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (tan proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::tanh(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::atan(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::atan(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_sinh_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - sinh fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (exp proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).exp())) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::sinh(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::sinh(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_cosh_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.001).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - cosh fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (exp proxy)", |b| { b.iter(|| black_box(black_box(x_burn.clone()).exp())) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::cosh(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::cosh(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_erf_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - erf fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (tanh proxy)", |b| { b.iter(|| black_box(burn::tensor::activation::tanh(black_box(x_burn.clone())))) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::erf(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::erf(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+fn bench_erfc_backward(c: &mut Criterion) {
+    let input_data: Vec<f32> = (0..(BATCH * FEATURES)).map(|i| (i as f32 * 0.003).sin() * 2.0).collect();
+    let x_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let x_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data), true);
+    let device = NdArrayDevice::default();
+    let x_burn: BurnTensor<BurnB, 2> = BurnTensor::from_data(TensorData::new(input_data.clone(), [BATCH, FEATURES]), &device);
+    let mut group = c.benchmark_group("Burn vs Coeus - erfc fwd+bwd (128x256)");
+    group.bench_function("Burn NdArray (1-tanh proxy)", |b| { b.iter(|| { let t = black_box(x_burn.clone()).tanh(); black_box(t.mul_scalar(-1.0f32).add_scalar(1.0f32)) }) });
+    group.bench_function("Coeus Sequential", |b| { b.iter(|| { let o = coeus_autograd::erfc(black_box(&x_seq)); black_box(o).backward() }) });
+    group.bench_function("Coeus Moirai", |b| { b.iter(|| { let o = coeus_autograd::erfc(black_box(&x_moirai)); black_box(o).backward() }) });
+    group.finish();
+}
+
+
 criterion_group!(
     benches,
     bench_linear_forward,
@@ -4802,6 +4907,14 @@ criterion_group!(
     bench_mish_backward,
     bench_softsign_backward,
     bench_elu_backward,
-    bench_celu_backward
+    bench_celu_backward,
+    bench_selu_backward,
+    bench_exp2_backward,
+    bench_log2_backward,
+    bench_atan_backward,
+    bench_sinh_backward,
+    bench_cosh_backward,
+    bench_erf_backward,
+    bench_erfc_backward
 );
 criterion_main!(benches);

--- a/coeus-ops/src/reduction/topk.rs
+++ b/coeus-ops/src/reduction/topk.rs
@@ -29,6 +29,15 @@ pub fn topk_impl<T: Scalar>(
     let out_numel: usize = out_shape.iter().product();
     let outer = out_numel / k;
 
+    // Row-major strides of the output: results write back through `dim`'s
+    // output stride, so non-terminal dims (e.g. dim = 0) interleave into the
+    // output correctly instead of being laid out line-contiguously (which is
+    // only equivalent when `dim` is the last axis).
+    let mut out_strides = vec![1usize; ndim];
+    for d in (0..ndim.saturating_sub(1)).rev() {
+        out_strides[d] = out_strides[d + 1] * out_shape[d + 1];
+    }
+
     for outer_idx in 0..outer {
         // Map outer_idx to coordinates excluding dim.
         let mut coords = vec![0usize; ndim];
@@ -72,8 +81,13 @@ pub fn topk_impl<T: Scalar>(
             });
         }
 
+        let out_base: usize = coords
+            .iter()
+            .enumerate()
+            .map(|(d, &c)| if d != dim { c * out_strides[d] } else { 0 })
+            .sum();
         for (rank, (v, orig_idx)) in pairs.iter().enumerate() {
-            let flat_out = outer_idx * k + rank;
+            let flat_out = out_base + rank * out_strides[dim];
             val_slice[flat_out] = *v;
             idx_slice[flat_out] = *orig_idx as i64;
         }

--- a/coeus-ops/tests/arg_reduction_leto_diff.rs
+++ b/coeus-ops/tests/arg_reduction_leto_diff.rs
@@ -82,3 +82,34 @@ fn moirai_arg_reductions_match_reference() {
     check_backend::<f32, _>(&backend);
     check_backend::<f64, _>(&backend);
 }
+
+/// topk along a non-terminal dim writes back through the output strides —
+/// regression for the line-contiguous layout bug (values were transposed for
+/// dim = 0). Reference: torch.topk(x, 2, dim=0, largest=False, sorted=True).
+#[test]
+fn topk_dim0_matches_torch_reference() {
+    use coeus_core::MoiraiBackend;
+    let backend = MoiraiBackend::new();
+    let x = coeus_tensor::Tensor::<f64, MoiraiBackend>::from_slice_on(
+        vec![3, 4],
+        &[3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0, 5.0, 3.0, 5.0, 8.0],
+        &backend,
+    );
+    let (vals, idxs) = coeus_ops::topk(&x, 2, 0, false);
+    assert_eq!(vals.shape(), &[2, 4]);
+    // Per-column two smallest, sorted ascending, laid out along dim 0:
+    // row0 = [3, 1, 2, 1], row1 = [5, 3, 4, 6].
+    let expected = [3.0, 1.0, 2.0, 1.0, 5.0, 3.0, 4.0, 6.0];
+    let got = vals.to_contiguous_on(&backend);
+    for (i, (g, w)) in got.as_slice().iter().zip(expected.iter()).enumerate() {
+        assert_eq!(g, w, "vals[{i}]");
+    }
+    // Indices are positions along dim 0 (per column, ascending-value order):
+    // col0 -> [0, 1] (3 then the row-1 five), col1 -> [0, 2] (1 then 3),
+    // col2 -> [1, 0] (2 then 4), col3 -> [0, 1] (1 then 6).
+    let expected_idx: [i64; 8] = [0, 0, 1, 0, 1, 2, 0, 1];
+    let gi = idxs.to_contiguous_on(&backend);
+    for (i, (g, w)) in gi.as_slice().iter().zip(expected_idx.iter()).enumerate() {
+        assert_eq!(g, w, "idxs[{i}]");
+    }
+}

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2623,3 +2623,47 @@ def test_square_matches_jax() -> None:
     got = pycoeus.pow(x_pyc, 2.0)
     exp = jnp.square(jnp.array(data, dtype=jnp.float64))
     _allclose("square", list(got.data), exp.tolist())
+
+# ---------------------------------------------------------------------------
+# selu_bwd / elu_bwd / log_sigmoid / cumprod_bwd parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "selu"), reason="pycoeus.selu not available")
+def test_selu_bwd_matches_jax() -> None:
+    """jax.grad selu vs pycoeus selu backward."""
+    import jax, jax.nn
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.selu(x_pyc)
+    out_pyc.backward()
+    grad_fn = jax.grad(lambda x: jnp.sum(jax.nn.selu(x)))
+    exp = grad_fn(jnp.array(data, dtype=jnp.float64))
+    _allclose("selu_bwd", list(x_pyc.grad), exp.tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mish"), reason="pycoeus.mish not available")
+def test_mish_bwd_matches_jax() -> None:
+    """jax.grad mish vs pycoeus mish backward."""
+    import jax
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.mish(x_pyc)
+    out_pyc.backward()
+    def jax_mish(x): return x * jnp.tanh(jnp.log1p(jnp.exp(x)))
+    grad_fn = jax.grad(lambda x: jnp.sum(jax_mish(x)))
+    exp = grad_fn(jnp.array(data, dtype=jnp.float64))
+    _allclose("mish_bwd", list(x_pyc.grad), exp.tolist(), atol=1e-8)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "cumprod"), reason="pycoeus.cumprod not available")
+def test_cumprod_bwd_matches_jax() -> None:
+    """jax.grad cumprod sum vs pycoeus cumprod backward."""
+    import jax
+    data = [2.0, 3.0, 4.0]
+    x_pyc = pycoeus.Tensor(data, [3], requires_grad=True)
+    out_pyc = pycoeus.cumprod(x_pyc, 0)
+    out_pyc.backward()
+    grad_fn = jax.grad(lambda x: jnp.sum(jnp.cumprod(x)))
+    exp = grad_fn(jnp.array(data, dtype=jnp.float64))
+    _allclose("cumprod_bwd", list(x_pyc.grad), exp.tolist(), atol=1e-10)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -6410,3 +6410,84 @@ def test_prelu_vector_alpha_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("prelu_v_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-12)
     _allclose("prelu_v_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# topk_dim0 / celu_bwd / log_sigmoid_bwd / hardshrink_bwd / elu_bwd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "topk"), reason="pycoeus.topk not available")
+def test_topk_dim0_matches_pytorch() -> None:
+    """torch.topk(x, 2, dim=0) vs pycoeus.topk(x, 2, dim=0) — non-terminal axis."""
+    data = [3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0, 5.0, 3.0, 5.0, 8.0]
+    x_pyc = pycoeus.Tensor(data, [3, 4], requires_grad=False)
+    vals_pyc, _ = pycoeus.topk(x_pyc, 2, dim=0, largest=True)
+    t = torch.tensor(data, dtype=torch.float64).reshape(3, 4)
+    vals_t, _ = torch.topk(t, 2, dim=0, largest=True, sorted=True)
+    _allclose("topk_dim0", list(vals_pyc.data), vals_t.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "celu"), reason="pycoeus.celu not available")
+def test_celu_bwd_matches_pytorch() -> None:
+    """celu(alpha=1.0) backward matches PyTorch."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.celu(x_pyc, 1.0)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.celu(t, alpha=1.0)
+    out_t.sum().backward()
+    _allclose("celu_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "log_sigmoid"), reason="pycoeus.log_sigmoid not available")
+def test_log_sigmoid_bwd_matches_pytorch() -> None:
+    """log_sigmoid backward: d/dx = -sigmoid(-x) = -(1 - sigmoid(x))."""
+    data = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.log_sigmoid(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.logsigmoid(t)
+    out_t.sum().backward()
+    _allclose("logsig_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "hardshrink"), reason="pycoeus.hardshrink not available")
+def test_hardshrink_bwd_matches_pytorch() -> None:
+    """hardshrink backward: 1 if |x|>lambd, else 0."""
+    data = [-2.0, -0.3, 0.0, 0.3, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.hardshrink(x_pyc, 0.5)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.hardshrink(t, lambd=0.5)
+    out_t.sum().backward()
+    _allclose("hshrink_bwd", list(x_pyc.grad), t.grad.tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "elu"), reason="pycoeus.elu not available")
+def test_elu_bwd_alpha1_matches_pytorch() -> None:
+    """elu backward (alpha=1): 1 if x>=0, else exp(x)."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.elu(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.elu(t, alpha=1.0)
+    out_t.sum().backward()
+    _allclose("elu_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "selu"), reason="pycoeus.selu not available")
+def test_selu_bwd_matches_pytorch() -> None:
+    """selu backward matches PyTorch."""
+    data = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.selu(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.nn.functional.selu(t)
+    out_t.sum().backward()
+    _allclose("selu_bwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-10)
+    _allclose("selu_bwd_grad", list(x_pyc.grad), t.grad.tolist(), atol=1e-10)


### PR DESCRIPTION
Fix topk non-terminal axis (output stride bug). Parity: celu/log_sigmoid/hardshrink/elu/selu backward. JAX: selu_bwd/mish_bwd/cumprod_bwd. G-043: 144 rows. 255/255 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a stride calculation bug in the `topk` operation for non-terminal dimensions (like `dim=0`) that was causing incorrectly transposed outputs. It also adds backward pass implementations for several activation functions (`celu`, `log_sigmoid`, `hardshrink`, `elu`, `selu` in PyTorch parity, and `selu_bwd`, `mish_bwd`, `cumprod_bwd` in JAX parity). The changes include comprehensive test coverage with 255/255 tests passing and adds 144 new benchmark rows for the newly implemented operations.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-ops/src/reduction/topk.rs` |
| 2 | `coeus-ops/tests/arg_reduction_leto_diff.rs` |
| 3 | `coeus-python/tests/test_pytorch_parity.py` |
| 4 | `coeus-python/tests/test_jax_parity.py` |
| 5 | `coeus-nn/benches/nn_bench.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected top-k results when selecting along a non-last dimension, improving output ordering and index placement.

* **Tests**
  * Added regression coverage for top-k with `dim=0`.
  * Expanded benchmark coverage for several additional backward passes.
  * Added new parity tests for backward gradients across multiple operations in both JAX and PyTorch comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->