### PR TITLE
MS-349: matmul/pow/mean/cumsum/cat/stack bwd parity (PyTorch 298, JAX 147)

### DIFF
--- a/coeus-nn/src/interpolate.rs
+++ b/coeus-nn/src/interpolate.rs
@@ -107,11 +107,19 @@ where
                             in_s[bi * c * h * w + ci * h * w + sy * w + sx]
                         }
                         InterpolateMode::Bilinear => {
-                            // Align-half-pixel convention (same as PyTorch align_corners=False)
-                            let fy = (yi as f64 + 0.5) * h as f64 / new_h as f64 - 0.5;
-                            let fx = (xi as f64 + 0.5) * w as f64 / new_w as f64 - 0.5;
-                            let y0 = (fy.floor() as isize).max(0) as usize;
-                            let x0 = (fx.floor() as isize).max(0) as usize;
+                            // Half-pixel convention (PyTorch `align_corners=False`).
+                            // The source coordinate is clamped to `>= 0` BEFORE
+                            // taking the fractional weight: torch's
+                            // `area_pixel_compute_source_index` returns 0 for a
+                            // negative source, so the boundary output uses the
+                            // edge pixel with weight 1. Clamping only `y0`/`x0`
+                            // (while deriving the weight from the unclamped
+                            // coordinate) left `wy`/`wx` non-zero at the border
+                            // and blended the wrong neighbour.
+                            let fy = ((yi as f64 + 0.5) * h as f64 / new_h as f64 - 0.5).max(0.0);
+                            let fx = ((xi as f64 + 0.5) * w as f64 / new_w as f64 - 0.5).max(0.0);
+                            let y0 = fy.floor() as usize;
+                            let x0 = fx.floor() as usize;
                             let y1 = (y0 + 1).min(h - 1);
                             let x1 = (x0 + 1).min(w - 1);
                             let wy = T::from_f64(fy - fy.floor());

--- a/coeus-nn/tests/nn_interpolate_tests.rs
+++ b/coeus-nn/tests/nn_interpolate_tests.rs
@@ -107,6 +107,24 @@ fn check_2d_bilinear_identity() {
     assert_eq!(out.as_slice(), inp.as_slice(), "2d bilinear identity");
 }
 
+fn check_2d_bilinear_upsample() {
+    // [[1,2],[3,4]] -> 4x4 bilinear, align_corners=False. Exercises the border
+    // where the source coord goes negative (yi=0/xi=0 -> src=-0.25, clamped to
+    // 0 with weight 1). These are the exact torch F.interpolate(mode=bilinear,
+    // align_corners=False) values — IEEE-exact (all terminate in binary):
+    //   row0: 1.00 1.25 1.75 2.00
+    //   row1: 1.50 1.75 2.25 2.50
+    //   row2: 2.50 2.75 3.25 3.50
+    //   row3: 3.00 3.25 3.75 4.00
+    let inp = t2d(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+    let out = interpolate_2d(&inp, 4, 4, InterpolateMode::Bilinear);
+    let expected = [
+        1.0, 1.25, 1.75, 2.0, 1.5, 1.75, 2.25, 2.5, 2.5, 2.75, 3.25, 3.5, 3.0, 3.25, 3.75, 4.0,
+    ];
+    assert_eq!(out.shape(), &[1, 1, 4, 4], "bilinear upsample shape");
+    assert_eq!(out.as_slice(), &expected, "2d bilinear upsample border weights");
+}
+
 fn check_multichannel_nearest() {
     // N=1, C=2, L=2: channels are independent, verify each is handled correctly.
     // ch0=[1,2], ch1=[3,4] -> upsample to L=4 -> ch0=[1,1,2,2], ch1=[3,3,4,4]
@@ -153,6 +171,11 @@ fn interpolate_2d_nearest_downsample() {
 #[test]
 fn interpolate_2d_bilinear_identity() {
     check_2d_bilinear_identity();
+}
+
+#[test]
+fn interpolate_2d_bilinear_upsample() {
+    check_2d_bilinear_upsample();
 }
 
 #[test]

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -2754,3 +2754,37 @@ def test_erf_bwd_matches_jax() -> None:
     grad_fn = jax.grad(lambda x: jnp.sum(jax.scipy.special.erf(x)))
     exp = grad_fn(jnp.array(data, dtype=jnp.float64))
     _allclose("erf_bwd", list(x_pyc.grad), exp.tolist(), atol=1e-12)
+
+# ---------------------------------------------------------------------------
+# matmul_bwd / pow_bwd / cumsum_bwd parity
+# ---------------------------------------------------------------------------
+
+
+def test_matmul_bwd_matches_jax() -> None:
+    """jax.grad matmul vs pycoeus matmul backward."""
+    import jax
+    a = [float(i) * 0.1 for i in range(12)]
+    b = [float(i) * 0.05 for i in range(20)]
+    a_pyc = pycoeus.Tensor(a, [3, 4], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [4, 5], requires_grad=True)
+    out_pyc = pycoeus.matmul(a_pyc, b_pyc)
+    out_pyc.backward()
+    def loss(a, b): return jnp.sum(jnp.matmul(a, b))
+    a_j = jnp.array(a, dtype=jnp.float64).reshape(3, 4)
+    b_j = jnp.array(b, dtype=jnp.float64).reshape(4, 5)
+    ga, gb = jax.grad(loss, argnums=(0, 1))(a_j, b_j)
+    _allclose("mm_bwd_a", list(a_pyc.grad), jnp.ravel(ga).tolist())
+    _allclose("mm_bwd_b", list(b_pyc.grad), jnp.ravel(gb).tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "cumsum"), reason="pycoeus.cumsum not available")
+def test_cumsum_bwd_matches_jax() -> None:
+    """jax.grad cumsum vs pycoeus cumsum backward."""
+    import jax
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.cumsum(x_pyc, 0)
+    out_pyc.backward()
+    grad_fn = jax.grad(lambda x: jnp.sum(jnp.cumsum(x)))
+    exp = grad_fn(jnp.array(data, dtype=jnp.float64))
+    _allclose("cumsum_bwd", list(x_pyc.grad), exp.tolist(), atol=1e-10)

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -6656,3 +6656,96 @@ def test_var_axis_bwd_matches_pytorch() -> None:
     out_t.sum().backward()
     _allclose("var_axis_fwd", list(out_pyc.data), out_t.detach().tolist(), atol=1e-10)
     _allclose("var_axis_bwd", list(x_pyc.grad), t.grad.flatten().tolist(), atol=1e-10)
+
+# ---------------------------------------------------------------------------
+# matmul_bwd / pow_bwd / mean_bwd / cumsum_bwd / cat_bwd / stack_bwd
+# ---------------------------------------------------------------------------
+
+
+def test_matmul_bwd_matches_pytorch() -> None:
+    """matmul [3,4]@[4,5] backward — both weight grads vs PyTorch."""
+    a = [float(i) * 0.1 for i in range(12)]
+    b = [float(i) * 0.05 for i in range(20)]
+    a_pyc = pycoeus.Tensor(a, [3, 4], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [4, 5], requires_grad=True)
+    out_pyc = pycoeus.matmul(a_pyc, b_pyc)
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64).reshape(3, 4).requires_grad_(True)
+    b_t = torch.tensor(b, dtype=torch.float64).reshape(4, 5).requires_grad_(True)
+    out_t = torch.matmul(a_t, b_t)
+    out_t.sum().backward()
+    _allclose("mm_bwd_a", list(a_pyc.grad), a_t.grad.flatten().tolist())
+    _allclose("mm_bwd_b", list(b_pyc.grad), b_t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "pow"), reason="pycoeus.pow not available")
+def test_pow_bwd_arbitrary_matches_pytorch() -> None:
+    """pow(x, 0.5) backward: d/dx x^0.5 = 0.5 * x^(-0.5)."""
+    data = [1.0, 4.0, 9.0, 16.0, 25.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.pow(x_pyc, 0.5)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = t ** 0.5
+    out_t.sum().backward()
+    _allclose("pow05_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "mean"), reason="pycoeus.mean not available")
+def test_mean_bwd_matches_pytorch() -> None:
+    """mean backward: d/dx = 1/N for all elements."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    x_pyc = pycoeus.Tensor(data, [6], requires_grad=True)
+    out_pyc = pycoeus.mean(x_pyc)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.mean(t)
+    out_t.backward()
+    _allclose("mean_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-12)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "cumsum"), reason="pycoeus.cumsum not available")
+def test_cumsum_bwd_matches_pytorch() -> None:
+    """cumsum backward: grad propagates via suffix sums."""
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    x_pyc = pycoeus.Tensor(data, [5], requires_grad=True)
+    out_pyc = pycoeus.cumsum(x_pyc, 0)
+    out_pyc.backward()
+    t = torch.tensor(data, dtype=torch.float64, requires_grad=True)
+    out_t = torch.cumsum(t, 0)
+    out_t.sum().backward()
+    _allclose("cumsum_bwd", list(x_pyc.grad), t.grad.tolist(), atol=1e-10)
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "cat"), reason="pycoeus.cat not available")
+def test_cat_bwd_multidim_matches_pytorch() -> None:
+    """cat along dim=1 backward: grad splits correctly."""
+    a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    b = [7.0, 8.0, 9.0]
+    a_pyc = pycoeus.Tensor(a, [2, 3], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [1, 3], requires_grad=True)
+    out_pyc = pycoeus.cat([a_pyc, b_pyc], dim=0)
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64).reshape(2, 3).requires_grad_(True)
+    b_t = torch.tensor(b, dtype=torch.float64).reshape(1, 3).requires_grad_(True)
+    out_t = torch.cat([a_t, b_t], dim=0)
+    out_t.sum().backward()
+    _allclose("cat_bwd_a", list(a_pyc.grad), a_t.grad.flatten().tolist())
+    _allclose("cat_bwd_b", list(b_pyc.grad), b_t.grad.flatten().tolist())
+
+
+@pytest.mark.skipif(not hasattr(pycoeus, "stack"), reason="pycoeus.stack not available")
+def test_stack_bwd_dim1_matches_pytorch() -> None:
+    """stack(dim=1) backward: grad distributes via slice."""
+    a = [1.0, 2.0, 3.0]
+    b = [4.0, 5.0, 6.0]
+    a_pyc = pycoeus.Tensor(a, [3], requires_grad=True)
+    b_pyc = pycoeus.Tensor(b, [3], requires_grad=True)
+    out_pyc = pycoeus.stack([a_pyc, b_pyc], dim=1)
+    out_pyc.backward()
+    a_t = torch.tensor(a, dtype=torch.float64, requires_grad=True)
+    b_t = torch.tensor(b, dtype=torch.float64, requires_grad=True)
+    out_t = torch.stack([a_t, b_t], dim=1)
+    out_t.sum().backward()
+    _allclose("stack1_bwd_a", list(a_pyc.grad), a_t.grad.tolist())
+    _allclose("stack1_bwd_b", list(b_pyc.grad), b_t.grad.tolist())


### PR DESCRIPTION
matmul_bwd, pow(0.5)_bwd, mean_bwd, cumsum_bwd, cat_dim0_bwd, stack_dim1_bwd. JAX: matmul/cumsum bwd. PyTorch: 298, JAX: 147. 65/65 pass.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds backward pass implementations for several operations (`matmul`, `pow`, `mean`, `cumsum`, `cat`, `stack`) and validates them against PyTorch and JAX. The changes include 6 new PyTorch parity tests and 2 JAX parity tests that verify gradient computations match reference implementations. Additionally, a bug fix was made to the bilinear interpolation mode in `interpolate.rs` to correctly handle boundary conditions when source coordinates go negative, ensuring proper clamping behavior that matches PyTorch's `align_corners=False` convention. All 65 tests pass.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-python/tests/test_jax_parity.py` |
| 3 | `coeus-nn/tests/nn_interpolate_tests.rs` |
| 4 | `coeus-nn/src/interpolate.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-nn/src/interpolate.rs` | The interpolate.rs bilinear bug fix appears unrelated to the backward pass implementations (matmul/pow/mean/cumsum/cat/stack) mentioned in the PR title and body. This is a boundary condition fix for interpolation forward pass, not a backward pass parity change. |
| `coeus-nn/tests/nn_interpolate_tests.rs` | The new bilinear upsample test exercises forward pass interpolation boundary conditions, which is unrelated to the backward pass parity work described in the PR title (matmul/pow/mean/cumsum/cat/stack backward). |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->