### PR TITLE
fix(python): replace undefined new_push! macro (build break)

### DIFF
--- a/coeus-python/src/tensor/pyimpl/mod.rs
+++ b/coeus-python/src/tensor/pyimpl/mod.rs
@@ -465,7 +465,7 @@ impl PyTensor {
         } as usize;
         let shape = self.inner.tensor.shape();
         let mut new_shape: Vec<usize> = shape[..start].to_vec();
-        new_push!(new_shape, shape[start..=end].iter().product());
+        new_shape.push(shape[start..=end].iter().product());
         new_shape.extend_from_slice(&shape[end + 1..]);
         let inner = py.allow_threads(|| coeus_autograd::reshape(&self.inner, new_shape));
         Ok(Self::from_var(inner))


### PR DESCRIPTION
`flatten`'s shape construction in `pyimpl/mod.rs` referenced a `new_push!` macro defined nowhere in the crate, breaking the entire `coeus-python` cdylib build on trunk — every `maturin develop` wheel build and pytest parity run fails with `cannot find macro new_push`. Replaced with `new_shape.push(...)`.

Verified: `cargo build -p coeus-python` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a build-breaking issue in the Python bindings where the `flatten` method referenced an undefined `new_push!` macro, causing all `coeus-python` builds to fail. The fix replaces the macro call with the standard `new_shape.push(...)` method.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/tensor/pyimpl/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the tensor flattening implementation with a cleaner way to build the resulting shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->