### PR TITLE
fix(nn): correct hinge_embedding_loss to torch formula

### DIFF
--- a/coeus-nn/src/loss.rs
+++ b/coeus-nn/src/loss.rs
@@ -314,10 +314,12 @@ where
     let mask_tensor = Tensor::from_slice_on(x.tensor.shape(), &mask_data, &backend);
     let mask_var = Var::new(mask_tensor, false);
 
-    let candidate1 =
-        coeus_autograd::relu(&coeus_autograd::neg(&coeus_autograd::scalar_sub(x, margin)));
-    let candidate2 = coeus_autograd::relu(&coeus_autograd::neg(x));
-    let selected = coeus_autograd::where_cond(&mask_var, &candidate1, &candidate2);
+    // PyTorch HingeEmbeddingLoss: target = +1 → loss = x (identity, no clamp);
+    // target = -1 → loss = max(0, margin - x). `mask` is 1 where target > 0, so
+    // `where_cond` selects the identity branch there and the hinge branch (the
+    // `-1` case) otherwise.
+    let hinge = coeus_autograd::relu(&coeus_autograd::neg(&coeus_autograd::scalar_sub(x, margin)));
+    let selected = coeus_autograd::where_cond(&mask_var, x, &hinge);
     coeus_autograd::mean(&selected)
 }
 

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -765,8 +765,10 @@ fn test_cosine_similarity_forward_and_backward() {
 #[test]
 fn test_hinge_embedding_loss() {
     // x = [0.5, 2, -1, 0.3], target = [+1, -1, +1, -1], margin = 1.
-    // Per element: y=+1 -> max(0, margin - x); y=-1 -> max(0, -x).
-    //   0.5, 0.0, 2.0, 0.0  =>  mean = 2.5 / 4 = 0.625.
+    // PyTorch HingeEmbeddingLoss: y=+1 -> loss = x (identity, no clamp);
+    // y=-1 -> loss = max(0, margin - x). (The prior assertions encoded a wrong
+    // formula and are corrected here to torch's documented contract.)
+    //   0.5, max(0,1-2)=0, -1.0, max(0,1-0.3)=0.7  =>  mean = 0.2 / 4 = 0.05.
     let x = Var::new(
         Tensor::<f64, MoiraiBackend>::from_slice([4], &[0.5, 2.0, -1.0, 0.3]),
         true,
@@ -775,16 +777,20 @@ fn test_hinge_embedding_loss() {
 
     let loss = hinge_embedding_loss(&x, &target, 1.0);
     assert_eq!(loss.tensor.shape(), &[1]);
-    assert!((loss.tensor.as_slice()[0] - 0.625).abs() < 1e-12);
+    assert!(
+        (loss.tensor.as_slice()[0] - 0.05).abs() < 1e-12,
+        "fwd: {} vs 0.05",
+        loss.tensor.as_slice()[0]
+    );
 
     loss.backward();
-    // Subgradient d/dx: active positive hinge (margin-x>0, y=+1) -> -1/N;
-    // active negative hinge (-x>0, y=-1) -> -1/N; inactive -> 0. N = 4.
-    //   i0: y=+1, margin-x=0.5>0 -> -0.25   i1: y=-1, -x=-2<0 -> 0
-    //   i2: y=+1, margin-x=2>0   -> -0.25   i3: y=-1, -x=-0.3<0 -> 0
+    // d/dx (seed 1/N from mean, N=4): identity branch (y=+1) -> 1/N; hinge
+    // branch (y=-1) -> -1/N when margin > x else 0.
+    //   i0: y=+1 -> 0.25            i1: y=-1, 1-2<0 -> 0
+    //   i2: y=+1 -> 0.25            i3: y=-1, 1-0.3>0 -> -0.25
     let grad = x.grad().expect("hinge x grad");
     let g = grad.as_slice();
-    let expected = [-0.25, 0.0, -0.25, 0.0];
+    let expected = [0.25, 0.0, 0.25, -0.25];
     for (i, (&got, &want)) in g.iter().zip(expected.iter()).enumerate() {
         assert!(
             (got - want).abs() < 1e-12,


### PR DESCRIPTION
`hinge_embedding_loss` used the wrong per-element formula — `max(0, margin - x)` for target=+1 and `max(0, -x)` for target=-1. PyTorch `HingeEmbeddingLoss` is **y=+1 → x** (identity, no clamp); **y=-1 → max(0, margin - x)**. Fixed the `where_cond` branches (identity on the positive mask, hinge on the negative).

The pre-existing unit test had encoded the wrong formula in its reference values (e.g. asserted mean 0.625 where torch gives 0.05) — corrected to torch's contract with the derivation documented in-comment (analytically-incorrect-test escape hatch).

Closes `test_hinge_embedding_loss_matches_pytorch` (fwd + bwd, verified at 1e-10). fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the `hinge_embedding_loss` implementation where the formula did not match PyTorch's `HingeEmbeddingLoss` behavior. The corrected formula now properly applies the identity function (no clamping) when target is +1, and applies `max(0, margin - x)` when target is -1. The existing unit test was also updated because it had encoded the incorrect formula in its expected values, changing the expected mean from 0.625 to 0.05 to match PyTorch's actual output.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/nn_loss_tests.rs` |
| 2 | `coeus-nn/src/loss.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->