### PR TITLE
fix(autograd): pairwise_distance adds eps to the difference (torch-exact)

### DIFF
--- a/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs
+++ b/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs
@@ -80,11 +80,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
 
 /// Tracked row-wise p-norm pairwise distance (PyTorch `PairwiseDistance`):
 /// for inputs `x1, x2` of shape `[N, D]`, returns a `[N]` vector with
-/// `out_i = max(sum_k |x1_ik - x2_ik|^p, eps)^(1/p)`. Matches PyTorch's
-/// `torch.nn.functional.pairwise_distance` exactly: the `eps` only enters
-/// as a `clamp_min` floor before the `(1/p)` root, so for the common case
-/// `sum > eps` the result is the pure `||diff||_p` norm (no perturbation)
-/// and the gradient factors carry no `eps`-dependent term.
+/// `out_i = (sum_k |x1_ik - x2_ik + eps|^p)^(1/p)`. Matches PyTorch's
+/// `torch.nn.functional.pairwise_distance` (`at::norm(x1 - x2 + eps, p)`)
+/// exactly: `eps` is added to the difference, keeping the summed norm
+/// strictly positive so the `s^(1/p - 1)` gradient factor stays finite.
 pub fn pairwise_distance<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     x1: &Var<T, B>,
     x2: &Var<T, B>,
@@ -145,21 +144,22 @@ pub fn pairwise_distance<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     let mut grad_unit = vec![T::zero(); n];
     for i in 0..rows {
         let base = i * feat;
+        // PyTorch computes `at::norm(x1 - x2 + eps, p)`: `eps` is added to the
+        // difference itself, not clamped onto the summed norm. Because every
+        // shifted term contributes `eps^p > 0`, the norm is strictly positive,
+        // which is exactly what keeps the `s^(1/p - 1)` gradient factor finite
+        // (the reason torch adds `eps` here). It also resolves boundary cases —
+        // e.g. an exactly-at-margin triplet — the same way torch does.
         let mut s = T::zero();
         for k in 0..feat {
-            let diff = x1_host[base + k] - x2_host[base + k];
+            let diff = x1_host[base + k] - x2_host[base + k] + eps;
             s = s + diff.abs().powf(p);
         }
-        // PyTorch's PairwiseDistance dereferences eps as a `clamp_min` on the
-        // inner sum, not a direct additive term. Using `max(s, eps)` means
-        // the gradient carries no `eps`-dependent bias on the common
-        // `s > eps` branch, bitwise-matching torch's reduction order.
-        let s_floor = if s > eps { s } else { eps };
-        let s_scaled = s_floor.powf(inv_p);
+        let s_scaled = s.powf(inv_p);
         out[i] = s_scaled;
-        let scale = s_floor.powf(inv_p - one);
+        let scale = s.powf(inv_p - one);
         for k in 0..feat {
-            let diff = x1_host[base + k] - x2_host[base + k];
+            let diff = x1_host[base + k] - x2_host[base + k] + eps;
             let mag = diff.abs().powf(p_minus_one);
             let sign = if diff > T::zero() {
                 one

--- a/coeus-nn/tests/nn_loss_tests.rs
+++ b/coeus-nn/tests/nn_loss_tests.rs
@@ -395,21 +395,17 @@ fn test_pairwise_distance() {
     );
     let dist = pairwise_distance(&x1, &x2, p, eps);
     assert_eq!(dist.tensor.shape(), &[2]);
-    let diffs = [[1.0_f64, 2.0], [2.0, 3.0]];
+    // Torch `pairwise_distance` = `at::norm(x1 - x2 + eps, p)`: eps is added to
+    // the difference itself (not clamped onto the summed norm), which keeps the
+    // norm strictly positive so the `s^(1/p - 1)` gradient factor stays finite.
+    let diffs = [[1.0_f64 + eps, 2.0 + eps], [2.0 + eps, 3.0 + eps]];
     let s: Vec<f64> = diffs
         .iter()
         .map(|r| r.iter().map(|d| d.abs().powf(p)).sum::<f64>())
         .collect();
     let out = dist.tensor.as_slice();
-    let eps = 1e-6_f64;
-    // Torch `pairwise_distance` semantics: clamp_min the inner sum to `eps`
-    // before the `(1/p)` root, so for `s >> eps` the forward is the pure
-    // `||diff||_p` and the gradient is `max(s, eps)^(1/p - 1) * |d|^(p-1) * sign(d)`.
-    // (The previous `s + eps` form added an O(eps/denom) perturbation that
-    // differed from torch's reduction order at the `eps^(1/p)` ULP.)
-    let s_floor: Vec<f64> = s.iter().map(|&v| if v > eps { v } else { eps }).collect();
     for i in 0..2 {
-        let exp = s_floor[i].powf(1.0 / p);
+        let exp = s[i].powf(1.0 / p);
         assert!((out[i] - exp).abs() <= 1e-12, "pd fwd {}", i);
     }
     let total = coeus_autograd::sum(&dist);
@@ -417,7 +413,7 @@ fn test_pairwise_distance() {
     let g1 = x1.grad().expect("x1 grad");
     let g2 = x2.grad().expect("x2 grad");
     for i in 0..2 {
-        let scale = s_floor[i].powf(1.0 / p - 1.0);
+        let scale = s[i].powf(1.0 / p - 1.0);
         for (k, &d) in diffs[i].iter().enumerate() {
             let eg = scale * d.abs().powf(p - 1.0) * d.signum();
             assert!(

--- a/coeus-python/tests/test_jax_parity.py
+++ b/coeus-python/tests/test_jax_parity.py
@@ -945,15 +945,14 @@ def test_triplet_margin_matches_jax() -> None:
     n_j = jnp.asarray(n, dtype=jnp.float64).reshape(2, 2)
 
     def f(av):
-        # PyTorch `triplet_margin_loss` ultimately inherits the
-        # `clamp_min(eps)` per-row reduction from `pairwise_distance` —
-        # i.e., no `+eps` perturbation on common-magnitude rows. Mirror
-        # the corrected PyTorch/Burn contract here so JAX-PyTorch agreement
-        # holds. (The previous `(... + 1e-6)` form pushed boundary rows
-        # slightly above 0 and disagreed with torch's reduction order at
-        # the O(eps/denom) term.)
-        d_ap = jnp.sqrt(jnp.maximum(jnp.sum((av - p_j) ** 2, axis=1), 1e-6))
-        d_an = jnp.sqrt(jnp.maximum(jnp.sum((av - n_j) ** 2, axis=1), 1e-6))
+        # PyTorch `pairwise_distance` is `at::norm(x1 - x2 + eps, p)`: eps is
+        # added to the difference, not clamped onto the summed norm. This
+        # keeps the norm strictly positive (finite gradient) and nudges an
+        # exactly-at-margin row above 0, matching torch (and the pytorch
+        # parity test, which fails under the clamp_min form). Mirror the true
+        # torch formula so JAX and PyTorch agree on the boundary row.
+        d_ap = jnp.sqrt(jnp.sum((av - p_j + 1e-6) ** 2, axis=1))
+        d_an = jnp.sqrt(jnp.sum((av - n_j + 1e-6) ** 2, axis=1))
         return jnp.mean(jnp.maximum(0.0, d_ap - d_an + 1.0))
 
     a_j = jnp.asarray(a, dtype=jnp.float64).reshape(2, 2)


### PR DESCRIPTION
PyTorch's `F.pairwise_distance` is `at::norm(x1 - x2 + eps, p)` — `eps` is added to the **difference**, keeping the summed norm strictly positive (finite `s^(1/p-1)` gradient) and nudging a boundary row above zero. coeus used `max(sum, eps)` (clamp_min), which matches on common-magnitude rows but resolves boundary rows differently — so `triplet_margin_loss` (which composes `pairwise_distance`) disagreed with torch, and `test_triplet_margin_matches_pytorch` was red.

Switched to the torch-exact eps-in-difference form (verified against aten `pairwise_distance`). Corrected the two unit tests that had baked in the clamp_min reference — the Rust pairwise test and the jax triplet reference `f` — to the same formula, with derivations in-comment.

## Verification
- `test_triplet_margin_matches_pytorch` + `_jax`: **pass**
- `pairwise_distance` fwd/bwd parity: still green; 24/24 coeus-nn loss tests
- fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a subtle discrepancy in `pairwise_distance` to match PyTorch's exact implementation. Previously, epsilon (`eps`) was applied as a clamp to the summed norm (`max(sum, eps)`), but PyTorch actually adds `eps` to the difference **before** computing the norm (`at::norm(x1 - x2 + eps, p)`). This distinction matters for boundary cases and gradient stability, causing `triplet_margin_loss` tests to fail against PyTorch. The fix updates the core implementation and corrects two unit tests (Rust pairwise test and JAX triplet reference) that had baked in the old clamp-based formula, with detailed derivations added as comments explaining the PyTorch semantics.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/nn/loss/pairwise_distance.rs` |
| 2 | `coeus-nn/tests/nn_loss_tests.rs` |
| 3 | `coeus-python/tests/test_jax_parity.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->