### PR TITLE
fix(autograd): make index_put a tracked autograd op

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -107,6 +107,7 @@ pub use ops::{
     hardswish,
     hardtanh,
     huber_loss,
+    index_put,
     index_select,
     kl_divergence,
     l1_loss,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -49,6 +49,6 @@ pub use nn::{
 pub use embedding::{embedding, embedding_with_padding_idx};
 pub use shape::{
     broadcast_to, cat, contiguous, cumprod, cumsum, diag, diagonal, diff, einsum, einsum3, flatten,
-    flip, gather, index_select, masked_fill, movedim, pad, permute, reshape, roll, slice, split,
+    flip, gather, index_put, index_select, masked_fill, movedim, pad, permute, reshape, roll, slice, split,
     squeeze, stack, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,
 };

--- a/coeus-autograd/src/ops/shape/mod.rs
+++ b/coeus-autograd/src/ops/shape/mod.rs
@@ -2,7 +2,7 @@
 pub mod cat_split_stack;
 /// Masking operations (tril, triu, masked_fill, where).
 pub mod mask;
-/// Selection and indexing operations (gather, index_select, slice, flip).
+/// Selection and indexing operations (gather, index_put, index_select, slice, flip).
 pub mod select;
 /// Shape transformation operations (reshape, permute, pad, tile, roll, etc.).
 pub mod transform;
@@ -11,7 +11,7 @@ pub mod util;
 
 pub use cat_split_stack::{cat, split, stack};
 pub use mask::masked_fill;
-pub use select::{gather, index_select};
+pub use select::{gather, index_put, index_select};
 pub use transform::{
     broadcast_to, diag, diagonal, flatten, flip, movedim, pad, permute, reshape, roll, slice,
     squeeze, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,

--- a/coeus-autograd/src/ops/shape/select/index_put.rs
+++ b/coeus-autograd/src/ops/shape/select/index_put.rs
@@ -1,0 +1,132 @@
+// ── Tracked index_put ──
+//
+// Forward: `out = index_put(x, idx, v, accumulate)` — positions `idx` (a 1-D
+// index vector) of `x` are replaced by `v` (`accumulate = false`) or have `v`
+// added to them (`accumulate = true`); all other positions keep `x`.
+//
+// Backward (two tracked inputs, `x` and `v`):
+//   grad_x = grad_out with the `idx` positions zeroed  (accumulate = false)
+//          = grad_out                                   (accumulate = true; x
+//                                                        is fully preserved)
+//   grad_v = grad_out gathered at `idx` (`index_select`) — each replaced/added
+//            output position feeds its gradient back to the source value.
+//
+// Matches PyTorch `Tensor.index_put((idx,), v, accumulate)` autograd.
+
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::Scalar;
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+pub struct IndexPutNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// `[x, v]` — the destination tensor and the inserted values.
+    pub inputs: Vec<Var<T, B>>,
+    /// The 1-D index tensor (f64-encoded integer indices).
+    pub index_tensor: Tensor<T, B>,
+    /// Whether the forward accumulated (`+=`) rather than overwrote.
+    pub accumulate: bool,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for IndexPutNode<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    fn op_name(&self) -> &'static str {
+        "index_put"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+
+        // ∂/∂x: overwrite zeroes the replaced positions (they no longer depend
+        // on x); accumulation preserves x everywhere, so the gradient passes
+        // through unchanged.
+        if let Some(Some(ref g)) = input_grads.first() {
+            let grad_x = if self.accumulate {
+                grad_out.to_contiguous_on(&backend)
+            } else {
+                let k = self.index_tensor.numel();
+                let zeros = Tensor::zeros_on([k], &backend);
+                coeus_ops::index_put(grad_out, &self.index_tensor, &zeros, false, &backend)
+            };
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_x, &backend);
+        }
+
+        // ∂/∂v: each value lands at its `idx` position, so its gradient is the
+        // output gradient gathered there.
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let grad_v = coeus_ops::index_select(grad_out, 0, &self.index_tensor, &backend);
+            let gl = g.write();
+            coeus_ops::add_assign(gl, &grad_v, &backend);
+        }
+    }
+}
+
+/// Tracked `index_put` (`torch.Tensor.index_put`): returns `x` with the 1-D
+/// index positions `indices` set to (`accumulate = false`) or increased by
+/// (`accumulate = true`) `values`.
+///
+/// Gradient flows to both `x` (identity, minus the overwritten positions when
+/// not accumulating) and `values` (gathered at `indices`).
+#[must_use]
+pub fn index_put<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    indices: &Var<T, B>,
+    values: &Var<T, B>,
+    accumulate: bool,
+) -> Var<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    let backend = B::default();
+    let out_tensor = coeus_ops::index_put(
+        &input.tensor,
+        &indices.tensor,
+        &values.tensor,
+        accumulate,
+        &backend,
+    );
+
+    let requires_grad =
+        crate::grad_mode::should_track_var(input) || crate::grad_mode::should_track_var(values);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on(
+            out_tensor.shape_cloned(),
+            &backend,
+        ))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let node = IndexPutNode {
+            output_grad: grad.as_ref().unwrap().clone(),
+            inputs: vec![input.clone(), values.clone()],
+            index_tensor: indices.tensor.clone(),
+            accumulate,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/src/ops/shape/select/mod.rs
+++ b/coeus-autograd/src/ops/shape/select/mod.rs
@@ -1,5 +1,7 @@
 mod gather;
+mod index_put;
 mod index_select;
 
 pub use gather::gather;
+pub use index_put::index_put;
 pub use index_select::index_select;

--- a/coeus-autograd/tests/autograd/index_put.rs
+++ b/coeus-autograd/tests/autograd/index_put.rs
@@ -1,0 +1,53 @@
+use coeus_autograd::{index_put, Var};
+use coeus_core::MoiraiBackend;
+use coeus_tensor::Tensor;
+
+#[test]
+fn test_index_put_backward_overwrite() {
+    let backend = MoiraiBackend::new();
+    // x=[1,2,3,4,5], idx=[1,3], v=[10,20], accumulate=false.
+    // out = [1,10,3,20,5]. sum().backward():
+    //   grad_x = 1 at kept positions {0,2,4}, 0 at overwritten {1,3}.
+    //   grad_v = 1 at each inserted position.
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![5], &[1.0, 2.0, 3.0, 4.0, 5.0], &backend),
+        true,
+    );
+    let idx = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![2], &[1.0, 3.0], &backend),
+        false,
+    );
+    let v = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![2], &[10.0, 20.0], &backend),
+        true,
+    );
+    let out = index_put(&x, &idx, &v, false);
+    assert_eq!(out.tensor.as_slice(), &[1.0, 10.0, 3.0, 20.0, 5.0], "fwd overwrite");
+    out.backward();
+    assert_eq!(x.grad().unwrap().as_slice(), &[1.0, 0.0, 1.0, 0.0, 1.0], "grad_x");
+    assert_eq!(v.grad().unwrap().as_slice(), &[1.0, 1.0], "grad_v");
+}
+
+#[test]
+fn test_index_put_backward_accumulate() {
+    let backend = MoiraiBackend::new();
+    // accumulate=true: out = x with v ADDED at idx = [1,12,3,24,5].
+    //   grad_x = 1 everywhere (x fully preserved); grad_v = 1 at each idx.
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![5], &[1.0, 2.0, 3.0, 4.0, 5.0], &backend),
+        true,
+    );
+    let idx = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![2], &[1.0, 3.0], &backend),
+        false,
+    );
+    let v = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![2], &[10.0, 20.0], &backend),
+        true,
+    );
+    let out = index_put(&x, &idx, &v, true);
+    assert_eq!(out.tensor.as_slice(), &[1.0, 12.0, 3.0, 24.0, 5.0], "fwd accumulate");
+    out.backward();
+    assert_eq!(x.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0, 1.0, 1.0], "grad_x accum");
+    assert_eq!(v.grad().unwrap().as_slice(), &[1.0, 1.0], "grad_v accum");
+}

--- a/coeus-autograd/tests/autograd/mod.rs
+++ b/coeus-autograd/tests/autograd/mod.rs
@@ -2,6 +2,7 @@ mod embedding;
 mod exp_log;
 mod float16;
 mod grad_mode;
+mod index_put;
 mod linalg;
 mod nn_conv;
 mod ops_overloads;

--- a/coeus-python/src/ops/indexing.rs
+++ b/coeus-python/src/ops/indexing.rs
@@ -289,10 +289,8 @@ pub fn index_put(
     let x = input.inner.clone();
     let idx = indices.inner.clone();
     let vals = values.inner.clone();
-    let inner = py.allow_threads(move || {
-        let backend = MoiraiBackend::new();
-        let t = coeus_ops::index_put(&x.tensor, &idx.tensor, &vals.tensor, accumulate, &backend);
-        coeus_autograd::Var::new(t, false)
-    });
+    // Tracked so gradients flow to both the destination and the inserted
+    // values (torch index_put autograd contract).
+    let inner = py.allow_threads(move || coeus_autograd::index_put(&x, &idx, &vals, accumulate));
     Ok(PyTensor::from_var(inner))
 }

--- a/coeus-python/tests/test_pytorch_parity.py
+++ b/coeus-python/tests/test_pytorch_parity.py
@@ -7819,8 +7819,12 @@ def test_index_put_bwd_matches_pytorch() -> None:
     t = torch.tensor(inp, dtype=torch.float64, requires_grad=True)
     idx_t = torch.tensor([1, 3], dtype=torch.long)
     v_t = torch.tensor(values, dtype=torch.float64)
-    t[idx_t] = v_t
-    t.sum().backward()
+    # Functional (out-of-place) index_put: an in-place `t[idx] = v` on a leaf
+    # that requires grad raises "a leaf Variable ... in-place operation". The
+    # functional form is the autograd-compatible equivalent and yields the
+    # same gradient (1 at kept positions, 0 at overwritten ones).
+    out_t = t.index_put((idx_t,), v_t, accumulate=False)
+    out_t.sum().backward()
     _allclose("iput_bwd", list(x_pyc.grad), t.grad.tolist())
 
 


### PR DESCRIPTION
## Summary
The Python `index_put` binding routed through the untracked `coeus_ops::index_put` + `Var::new(t, false)`, so gradients to both the destination tensor and the inserted values were zero (dx=0 class), failing `test_index_put_bwd_matches_pytorch`.

## Change
- New tracked `IndexPutNode` in `coeus-autograd`: backward routes `grad_out` to the destination (overwrite zeroes the written positions, accumulate passes through) and gathers the inserted-value gradient via `index_select` over the same indices.
- Repoint the PyO3 binding to the tracked `coeus_autograd::index_put` entry point.
- Fix the torch reference in the parity test to the functional `index_put((idx,), v)` form (in-place `t[idx] = v` on a grad-requiring leaf raises).

## Verification
- Rust autograd tests (`coeus-autograd/tests/autograd/index_put.rs`): overwrite → grad_x=[1,0,1,0,1], grad_v=[1,1]; accumulate → grad_x=[1,1,1,1,1], grad_v=[1,1]. Both green.
- `test_pytorch_parity.py::test_index_put_bwd_matches_pytorch` green against the rebuilt wheel (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where `index_put` was not tracking gradients in the autograd system, causing both the destination tensor and inserted values to have zero gradients. A new `IndexPutNode` is introduced in `coeus-autograd` that properly computes backward gradients: for the destination tensor, it either zeros out overwritten positions (when `accumulate=false`) or passes through all gradients (when `accumulate=true`), while for the inserted values it gathers gradients from the corresponding output positions. The Python binding is updated to route through the new tracked operation, and the PyTorch parity test is corrected to use the functional `index_put` form instead of the in-place assignment which raises an error on gradient-requiring leaves.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/tests/test_pytorch_parity.py` |
| 2 | `coeus-autograd/src/ops/shape/select/index_put.rs` |
| 3 | `coeus-autograd/tests/autograd/index_put.rs` |
| 4 | `coeus-autograd/src/ops/shape/select/mod.rs` |
| 5 | `coeus-autograd/src/ops/shape/mod.rs` |
| 6 | `coeus-autograd/src/ops/mod.rs` |
| 7 | `coeus-autograd/src/lib.rs` |
| 8 | `coeus-python/src/ops/indexing.rs` |
| 9 | `coeus-autograd/tests/autograd/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for indexed tensor updates with optional accumulation in autograd and Python bindings.
  * Gradients now flow correctly to both the destination tensor and inserted values for this operation.

* **Bug Fixes**
  * Improved gradient handling for overwritten positions versus accumulated updates.
  * Updated parity checks to compare against a safer reference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->