### PR TITLE
fix(autograd): make scatter_add a tracked autograd op

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -164,6 +164,7 @@ pub use ops::{
     // New scalar arithmetic
     scalar_mul,
     scalar_sub,
+    scatter_add,
     sdp_attention,
     selu,
     sigmoid,

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -49,6 +49,7 @@ pub use nn::{
 pub use embedding::{embedding, embedding_with_padding_idx};
 pub use shape::{
     broadcast_to, cat, contiguous, cumprod, cumsum, diag, diagonal, diff, einsum, einsum3, flatten,
-    flip, gather, index_put, index_select, masked_fill, movedim, pad, permute, reshape, roll, slice, split,
-    squeeze, stack, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,
+    flip, gather, index_put, index_select, masked_fill, movedim, pad, permute, reshape, roll,
+    scatter_add, slice, split, squeeze, stack, swapaxes, tile, transpose, tril, triu, unsqueeze,
+    where_cond,
 };

--- a/coeus-autograd/src/ops/shape/mod.rs
+++ b/coeus-autograd/src/ops/shape/mod.rs
@@ -2,7 +2,7 @@
 pub mod cat_split_stack;
 /// Masking operations (tril, triu, masked_fill, where).
 pub mod mask;
-/// Selection and indexing operations (gather, index_put, index_select, slice, flip).
+/// Selection and indexing operations (gather, index_put, index_select, scatter_add, slice, flip).
 pub mod select;
 /// Shape transformation operations (reshape, permute, pad, tile, roll, etc.).
 pub mod transform;
@@ -11,7 +11,7 @@ pub mod util;
 
 pub use cat_split_stack::{cat, split, stack};
 pub use mask::masked_fill;
-pub use select::{gather, index_put, index_select};
+pub use select::{gather, index_put, index_select, scatter_add};
 pub use transform::{
     broadcast_to, diag, diagonal, flatten, flip, movedim, pad, permute, reshape, roll, slice,
     squeeze, swapaxes, tile, transpose, tril, triu, unsqueeze, where_cond,

--- a/coeus-autograd/src/ops/shape/select/mod.rs
+++ b/coeus-autograd/src/ops/shape/select/mod.rs
@@ -1,7 +1,9 @@
 mod gather;
 mod index_put;
 mod index_select;
+mod scatter_add;
 
 pub use gather::gather;
 pub use index_put::index_put;
 pub use index_select::index_select;
+pub use scatter_add::scatter_add;

--- a/coeus-autograd/src/ops/shape/select/scatter_add.rs
+++ b/coeus-autograd/src/ops/shape/select/scatter_add.rs
@@ -1,0 +1,130 @@
+// ── Tracked scatter_add ──
+//
+// Forward: `out = scatter_add(input, dim, index, src)` — `out` starts as a copy
+// of `input` and, for each `k` along `dim`, `src[…, k, …]` is added into
+// `out[…, index[…, k, …], …]`.
+//
+// Backward (two tracked inputs, `input` and `src`; `index` non-differentiable):
+//   grad_input = grad_out                       (input is copied through; the
+//                                                add does not scale it)
+//   grad_src   = gather(grad_out, dim, index)   (each scattered source element
+//                                                receives the output gradient
+//                                                at the position it landed in)
+//
+// This is the exact transpose of `gather` — gather's backward scatter_adds,
+// scatter_add's backward gathers. Matches PyTorch `Tensor.scatter_add`.
+
+use crate::grad_buffer::GradBuffer;
+use crate::node::BackwardNode;
+use crate::var::Var;
+use coeus_core::Scalar;
+use coeus_tensor::Tensor;
+use std::sync::Arc;
+
+pub struct ScatterAddNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    pub output_grad: Arc<GradBuffer<T, B>>,
+    /// `[input, src]` — the destination tensor and the scattered source.
+    pub inputs: Vec<Var<T, B>>,
+    /// The index tensor (T-encoded integer indices), stored for backward.
+    pub index: Tensor<T, B>,
+    pub dim: usize,
+}
+
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for ScatterAddNode<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    fn op_name(&self) -> &'static str {
+        "scatter_add"
+    }
+    fn output_grad(&self) -> &Arc<GradBuffer<T, B>> {
+        &self.output_grad
+    }
+    fn inputs(&self) -> &[Var<T, B>] {
+        &self.inputs
+    }
+
+    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+        let backend = B::default();
+
+        // ∂/∂input: input is copied into the output unchanged, so its gradient
+        // is the output gradient verbatim.
+        if let Some(Some(ref g)) = input_grads.first() {
+            let grad_input = grad_out.to_contiguous_on(&backend);
+            coeus_ops::add_assign(g.write(), &grad_input, &backend);
+        }
+
+        // ∂/∂src: each source element lands at `index`, so its gradient gathers
+        // the output gradient from that position.
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let grad_src = coeus_ops::gather(grad_out, self.dim, &self.index, &backend);
+            coeus_ops::add_assign(g.write(), &grad_src, &backend);
+        }
+    }
+}
+
+/// Tracked `scatter_add` (`torch.Tensor.scatter_add`): returns `input` with
+/// `src` added into the positions named by `index` along `dim`.
+///
+/// `index` must be a tensor of the same scalar type as `input` holding
+/// integer-valued elements (index tensors are not yet a first-class type in
+/// coeus).
+///
+/// # Backward
+/// Gradient flows to both `input` (identity) and `src` (gathered at `index`);
+/// `index` is treated as a constant.
+///
+/// # Panics
+/// Same as `coeus_ops::scatter_add`.
+#[must_use]
+pub fn scatter_add<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    input: &Var<T, B>,
+    dim: usize,
+    index: &Var<T, B>,
+    src: &Var<T, B>,
+) -> Var<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    let backend = B::default();
+    let out_tensor = coeus_ops::scatter_add(
+        &input.tensor,
+        dim,
+        &index.tensor,
+        &src.tensor,
+        &backend,
+    );
+
+    let requires_grad =
+        crate::grad_mode::should_track_var(input) || crate::grad_mode::should_track_var(src);
+    let grad = if requires_grad {
+        Some(Arc::new(GradBuffer::new(Tensor::zeros_on(
+            out_tensor.shape_cloned(),
+            &backend,
+        ))))
+    } else {
+        None
+    };
+    let creator = if requires_grad {
+        let node = ScatterAddNode {
+            output_grad: grad.as_ref().unwrap().clone(),
+            inputs: vec![input.clone(), src.clone()],
+            index: index.tensor.clone(),
+            dim,
+        };
+        Some(Arc::new(node) as Arc<dyn BackwardNode<T, B>>)
+    } else {
+        None
+    };
+    Var {
+        tensor: out_tensor,
+        grad,
+        creator,
+    }
+}

--- a/coeus-autograd/tests/autograd/mod.rs
+++ b/coeus-autograd/tests/autograd/mod.rs
@@ -7,6 +7,7 @@ mod linalg;
 mod nn_conv;
 mod ops_overloads;
 mod reductions;
+mod scatter_add;
 mod shape_ops;
 mod sparse;
 mod unary_math;

--- a/coeus-autograd/tests/autograd/scatter_add.rs
+++ b/coeus-autograd/tests/autograd/scatter_add.rs
@@ -1,0 +1,59 @@
+use coeus_autograd::{scatter_add, Var};
+use coeus_core::MoiraiBackend;
+use coeus_tensor::Tensor;
+
+#[test]
+fn test_scatter_add_backward_src_and_input() {
+    let backend = MoiraiBackend::new();
+    // input=[0,0,0,0,0], idx=[4,1,3], src=[1,2,3], dim=0.
+    // out = [0, 2, 0, 3, 1]. sum().backward() (output grad all ones):
+    //   grad_input = 1 everywhere (input copied through unchanged).
+    //   grad_src   = gather(ones, idx) = [1,1,1] (each src lands once).
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![5], &[0.0; 5], &backend),
+        true,
+    );
+    let idx = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![3], &[4.0, 1.0, 3.0], &backend),
+        false,
+    );
+    let src = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![3], &[1.0, 2.0, 3.0], &backend),
+        true,
+    );
+    let out = scatter_add(&input, 0, &idx, &src);
+    assert_eq!(out.tensor.as_slice(), &[0.0, 2.0, 0.0, 3.0, 1.0], "fwd scatter_add");
+    out.backward();
+    assert_eq!(
+        input.grad().unwrap().as_slice(),
+        &[1.0, 1.0, 1.0, 1.0, 1.0],
+        "grad_input"
+    );
+    assert_eq!(src.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0], "grad_src");
+}
+
+#[test]
+fn test_scatter_add_backward_duplicate_indices() {
+    let backend = MoiraiBackend::new();
+    // Duplicate index 1: two src elements land in the same output slot; each
+    // still receives the (single) output gradient there, so grad_src stays
+    // [1,1,1] and grad_input = 1 everywhere.
+    let input = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![4], &[10.0, 20.0, 30.0, 40.0], &backend),
+        true,
+    );
+    let idx = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![3], &[1.0, 1.0, 2.0], &backend),
+        false,
+    );
+    let src = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![3], &[1.0, 2.0, 3.0], &backend),
+        true,
+    );
+    let out = scatter_add(&input, 0, &idx, &src);
+    // out[1] = 20 + 1 + 2 = 23, out[2] = 30 + 3 = 33.
+    assert_eq!(out.tensor.as_slice(), &[10.0, 23.0, 33.0, 40.0], "fwd dup");
+    out.backward();
+    assert_eq!(input.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0, 1.0], "grad_input dup");
+    assert_eq!(src.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0], "grad_src dup");
+}

--- a/coeus-python/src/ops/indexing.rs
+++ b/coeus-python/src/ops/indexing.rs
@@ -17,19 +17,13 @@ pub fn scatter_add(
     src: &PyTensor,
     py: Python<'_>,
 ) -> PyTensor {
-    let backend = MoiraiBackend::new();
-    let t = py.allow_threads(|| {
-        coeus_ops::scatter_add(
-            &input.inner.tensor,
-            dim,
-            &index.inner.tensor,
-            &src.inner.tensor,
-            &backend,
-        )
-    });
-    PyTensor {
-        inner: coeus_autograd::Var::new(t, false),
-    }
+    let x = input.inner.clone();
+    let idx = index.inner.clone();
+    let s = src.inner.clone();
+    // Tracked so gradients flow to both the destination and the scattered
+    // source (torch scatter_add autograd contract).
+    let inner = py.allow_threads(move || coeus_autograd::scatter_add(&x, dim, &idx, &s));
+    PyTensor::from_var(inner)
 }
 
 #[pyfunction]


### PR DESCRIPTION
## Summary
The Python `scatter_add` binding routed through the untracked `coeus_ops::scatter_add` + `Var::new(t, false)`, so gradients to both the destination and the scattered source were zero (dx=0 class), failing `test_scatter_add_bwd_matches_pytorch`.

## Change
- New tracked `ScatterAddNode` in `coeus-autograd` — the exact transpose of `gather`: backward passes `grad_out` through to `input` (copied through unchanged) and gathers `grad_out` at `index` for `src`.
- Repoint the PyO3 binding to the tracked `coeus_autograd::scatter_add` entry point.

## Verification
- Rust autograd tests (`coeus-autograd/tests/autograd/scatter_add.rs`): grad_input=[1,1,1,1,1], grad_src=[1,1,1]; plus a duplicate-index case. Both green.
- `test_pytorch_parity.py::test_scatter_add_bwd_matches_pytorch` green against the rebuilt wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes gradient computation for the `scatter_add` operation by converting it from an untracked operation to a tracked autograd node. Previously, the Python binding routed through the untracked `coeus_ops::scatter_add` which resulted in zero gradients for both the destination and source tensors. The fix introduces a new `ScatterAddNode` in the autograd module that properly implements backward passes (passing `grad_out` through to `input` unchanged and gathering `grad_out` at `index` positions for `src`), and updates the PyO3 binding to use the tracked version. The implementation includes comprehensive tests covering both normal and duplicate-index cases.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/shape/select/scatter_add.rs` |
| 2 | `coeus-autograd/tests/autograd/scatter_add.rs` |
| 3 | `coeus-python/src/ops/indexing.rs` |
| 4 | `coeus-autograd/src/ops/shape/select/mod.rs` |
| 5 | `coeus-autograd/src/ops/shape/mod.rs` |
| 6 | `coeus-autograd/src/ops/mod.rs` |
| 7 | `coeus-autograd/src/lib.rs` |
| 8 | `coeus-autograd/tests/autograd/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->