### PR TITLE
fix(python): add EmbeddingBag.forward(indices, offsets) tensor API

### DIFF
--- a/coeus-python/src/nn/embedding.rs
+++ b/coeus-python/src/nn/embedding.rs
@@ -152,6 +152,28 @@ impl PyEmbeddingBag {
         })
     }
 
+    /// Forward pass from index and optional offset tensors (torch
+    /// `EmbeddingBag(input, offsets)` API). The integer indices are carried as
+    /// the elements of a float tensor; they are read back and truncated to
+    /// `usize`, then routed through the same tracked core as
+    /// [`Self::forward_with_offsets`].
+    #[pyo3(signature = (indices, offsets = None))]
+    pub fn forward(
+        &self,
+        indices: &PyTensor,
+        offsets: Option<&PyTensor>,
+        py: Python<'_>,
+    ) -> PyResult<PyTensor> {
+        let backend = coeus_core::MoiraiBackend::new();
+        let idx_c = indices.inner.tensor.to_contiguous_on(&backend);
+        let idx: Vec<usize> = idx_c.as_slice().iter().map(|&v| v as usize).collect();
+        let off: Option<Vec<usize>> = offsets.map(|o| {
+            let o_c = o.inner.tensor.to_contiguous_on(&backend);
+            o_c.as_slice().iter().map(|&v| v as usize).collect()
+        });
+        self.forward_with_offsets(idx, off, py)
+    }
+
     /// Forward pass from flat indices and optional bag offsets.
     #[pyo3(signature = (indices, offsets = None))]
     pub fn forward_with_offsets(


### PR DESCRIPTION
## Summary
`PyEmbeddingBag` only exposed `forward_with_offsets(Vec<usize>, ...)`, while the torch-parity contract used by every sibling nn module is `forward(&PyTensor, ...)`. So `embed.forward(idx_tensor, off_tensor)` raised `AttributeError`, failing `test_embedding_bag_sum_bwd_matches_pytorch` before it ever reached the gradient assertion.

## Change
Add `forward(indices: &PyTensor, offsets: Option<&PyTensor>)`: read the integer-valued float tensors back to `usize` and delegate to the already-tracked `forward_with_offsets` core. The sum-mode backward math in `coeus_nn` is unchanged and correct.

## Verification
`test_pytorch_parity.py::test_embedding_bag_sum_bwd_matches_pytorch` green against the rebuilt wheel (grad accumulates at used indices, atol 1e-9), alongside `index_put_bwd` and `scatter_add_bwd` (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Adds a missing `forward(indices, offsets)` method to `PyEmbeddingBag` that accepts tensor arguments instead of raw vectors. This fixes an `AttributeError` that was preventing the PyTorch-parity API contract from working correctly. The new method converts the integer-valued float tensors to `usize` vectors and delegates to the existing `forward_with_offsets` implementation, enabling the previously-failing `test_embedding_bag_sum_bwd_matches_pytorch` test to pass.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-python/src/nn/embedding.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->