### PR TITLE
feat(autograd): add tracked element-wise remainder

### DIFF
--- a/coeus-autograd/src/lib.rs
+++ b/coeus-autograd/src/lib.rs
@@ -155,6 +155,7 @@ pub use ops::{
     prod,
     recip,
     relu,
+    remainder,
     reshape,
     rmsnorm,
     roll,

--- a/coeus-autograd/src/ops/arithmetic/binary.rs
+++ b/coeus-autograd/src/ops/arithmetic/binary.rs
@@ -175,6 +175,62 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
     }
 }
 
+/// ZST tag for element-wise remainder (Python/torch modulo) autograd.
+///
+/// `remainder(a, b) = a - floor(a / b) * b` (result carries the sign of the
+/// divisor `b`, matching `torch.remainder` and NumPy `remainder`, in contrast
+/// to the C-style `fmod` which carries the sign of the dividend).
+///
+/// The quotient `q = floor(a / b)` is piecewise-constant in both operands, so
+/// its own derivative is zero almost everywhere and the gradient reduces to
+/// that of `a - q * b` with `q` held constant:
+///   ∂/∂a = 1        (identity)
+///   ∂/∂b = −q       (matches PyTorch `-grad * self.div(other, floor)`)
+pub struct RemainderOp;
+impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> for RemainderOp {
+    const OP_NAME: &'static str = "remainder";
+
+    #[inline(always)]
+    fn forward(a: &Tensor<T, B>, b: &Tensor<T, B>, backend: &B) -> Tensor<T, B> {
+        let q = coeus_ops::floor(&coeus_ops::div(a, b, backend), backend);
+        coeus_ops::sub(a, &coeus_ops::mul(&q, b, backend), backend)
+    }
+
+    #[inline(always)]
+    fn backward(
+        grad_out: &Tensor<T, B>,
+        a: &Tensor<T, B>,
+        b: &Tensor<T, B>,
+        _a_shape: &Shape,
+        _b_shape: &Shape,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+        backend: &B,
+    ) {
+        // ∂/∂a = 1: identity passthrough (broadcast-reduced to a's shape).
+        if let Some(Some(ref g)) = input_grads.get(0) {
+            let gl = g.write();
+            if grad_out.shape() == a.shape() {
+                coeus_ops::add_assign(gl, grad_out, backend);
+            } else {
+                let reduced = reduce_broadcast(grad_out.clone(), a.shape());
+                coeus_ops::add_assign(gl, &reduced, backend);
+            }
+        }
+        // ∂/∂b = −floor(a / b): subtract grad_out · q (broadcast-reduced to b).
+        if let Some(Some(ref g)) = input_grads.get(1) {
+            let q = coeus_ops::floor(&coeus_ops::div(a, b, backend), backend);
+            let prod = coeus_ops::mul(grad_out, &q, backend);
+            let gl = g.write();
+            if prod.shape() == b.shape() {
+                coeus_ops::sub_assign(gl, &prod, backend);
+            } else {
+                let reduced = reduce_broadcast(prod, b.shape());
+                coeus_ops::sub_assign(gl, &reduced, backend);
+            }
+        }
+    }
+}
+
 /// Tracked element-wise addition.
 ///
 /// # Examples
@@ -258,4 +314,36 @@ pub fn div<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
     b: &Var<T, B>,
 ) -> Var<T, B> {
     binary_op::<T, B, DivOp>(a, b)
+}
+
+/// Tracked element-wise remainder (`torch.remainder` / NumPy `remainder`):
+/// `a - floor(a / b) * b`, carrying the sign of the divisor `b`.
+///
+/// Gradient flows to `a` as the identity and to `b` as `-floor(a / b)`
+/// (the floor quotient is held constant, matching PyTorch).
+///
+/// # Examples
+///
+/// `7 % -3 = -2` (sign of the divisor); `d/da = 1`, `d/db = -floor(7/-3) = 3`.
+///
+/// ```
+/// use coeus_autograd::{remainder, sum, Var};
+/// use coeus_core::MoiraiBackend;
+/// use coeus_tensor::Tensor;
+///
+/// let a = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([1], &[7.0]), true);
+/// let b = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([1], &[-3.0]), true);
+/// let r = remainder(&a, &b);
+/// assert!((r.tensor.as_slice()[0] - (-2.0)).abs() < 1e-12);
+/// sum(&r).backward();
+/// assert!((a.grad().unwrap().as_slice()[0] - 1.0).abs() < 1e-12);
+/// assert!((b.grad().unwrap().as_slice()[0] - 3.0).abs() < 1e-12);
+/// ```
+#[must_use]
+#[inline]
+pub fn remainder<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
+    a: &Var<T, B>,
+    b: &Var<T, B>,
+) -> Var<T, B> {
+    binary_op::<T, B, RemainderOp>(a, b)
 }

--- a/coeus-autograd/src/ops/mod.rs
+++ b/coeus-autograd/src/ops/mod.rs
@@ -25,7 +25,7 @@ pub use activation::{
     threshold, trunc,
 };
 pub use arithmetic::{
-    add, div, mean, mean_axis, mul, nanmean, nansum, scalar_add, scalar_div, scalar_mul,
+    add, div, mean, mean_axis, mul, nanmean, nansum, remainder, scalar_add, scalar_div, scalar_mul,
     scalar_sub, sub, sum, sum_axis,
 };
 pub use reduction::{

--- a/coeus-autograd/tests/autograd/mod.rs
+++ b/coeus-autograd/tests/autograd/mod.rs
@@ -7,6 +7,7 @@ mod linalg;
 mod nn_conv;
 mod ops_overloads;
 mod reductions;
+mod remainder;
 mod scatter_add;
 mod shape_ops;
 mod sparse;

--- a/coeus-autograd/tests/autograd/remainder.rs
+++ b/coeus-autograd/tests/autograd/remainder.rs
@@ -1,0 +1,71 @@
+use coeus_autograd::{remainder, sum, Var};
+use coeus_core::MoiraiBackend;
+use coeus_tensor::Tensor;
+
+// remainder(a, b) = a - floor(a / b) * b  (sign of the divisor, torch/NumPy).
+//   ∂/∂a = 1,  ∂/∂b = -floor(a / b).
+
+#[test]
+fn test_remainder_forward_and_backward_positive() {
+    let backend = MoiraiBackend::new();
+    // a=[5,7,8], b=[3,4,3]:
+    //   q = floor([5/3, 7/4, 8/3]) = [1, 1, 2]
+    //   out = a - q*b = [5-3, 7-4, 8-6] = [2, 3, 2]
+    //   grad_a = [1,1,1], grad_b = -q = [-1,-1,-2]
+    let a = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![3], &[5.0, 7.0, 8.0], &backend),
+        true,
+    );
+    let b = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![3], &[3.0, 4.0, 3.0], &backend),
+        true,
+    );
+    let out = remainder(&a, &b);
+    assert_eq!(out.tensor.as_slice(), &[2.0, 3.0, 2.0], "fwd remainder");
+    sum(&out).backward();
+    assert_eq!(a.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0], "grad_a");
+    assert_eq!(b.grad().unwrap().as_slice(), &[-1.0, -1.0, -2.0], "grad_b");
+}
+
+#[test]
+fn test_remainder_sign_of_divisor() {
+    let backend = MoiraiBackend::new();
+    // Python/torch modulo carries the divisor's sign:
+    //   7 % -3 = -2  (q = floor(7/-3) = floor(-2.333) = -3; 7 - (-3)*(-3) = -2)
+    //   grad_a = 1, grad_b = -q = 3
+    let a = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![1], &[7.0], &backend),
+        true,
+    );
+    let b = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![1], &[-3.0], &backend),
+        true,
+    );
+    let out = remainder(&a, &b);
+    assert_eq!(out.tensor.as_slice(), &[-2.0], "fwd sign-of-divisor");
+    sum(&out).backward();
+    assert_eq!(a.grad().unwrap().as_slice(), &[1.0], "grad_a");
+    assert_eq!(b.grad().unwrap().as_slice(), &[3.0], "grad_b");
+}
+
+#[test]
+fn test_remainder_broadcast_scalar_divisor() {
+    let backend = MoiraiBackend::new();
+    // Broadcasting a [4] dividend against a [1] divisor: grad_b sums the
+    // per-element contributions -q over the broadcast axis.
+    //   a=[1,2,3,4], b=[3]: q=floor([1,2,3,4]/3)=[0,0,1,1]
+    //   out=[1,2,0,1]; grad_a=[1,1,1,1]; grad_b = -sum(q) = -(0+0+1+1) = -2
+    let a = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![4], &[1.0, 2.0, 3.0, 4.0], &backend),
+        true,
+    );
+    let b = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![1], &[3.0], &backend),
+        true,
+    );
+    let out = remainder(&a, &b);
+    assert_eq!(out.tensor.as_slice(), &[1.0, 2.0, 0.0, 1.0], "fwd broadcast");
+    sum(&out).backward();
+    assert_eq!(a.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0, 1.0], "grad_a bcast");
+    assert_eq!(b.grad().unwrap().as_slice(), &[-2.0], "grad_b bcast reduced");
+}

--- a/coeus-nn/src/linear.rs
+++ b/coeus-nn/src/linear.rs
@@ -53,4 +53,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Linear<T
             out
         }
     }
+
+    fn load_parameters(&mut self, params: &[Var<T, B>]) {
+        self.weight = params[0].clone();
+        if self.bias.is_some() {
+            self.bias = Some(params[1].clone());
+        }
+    }
 }

--- a/coeus-nn/src/module.rs
+++ b/coeus-nn/src/module.rs
@@ -11,6 +11,24 @@ pub trait Module<T: Scalar, B: coeus_ops::BackendOps<T> + Default = MoiraiBacken
     /// Forward pass.
     fn forward(&self, input: &Var<T, B>) -> Var<T, B>;
 
+    /// Write optimizer-updated parameter values back into this module's own
+    /// fields, consuming `params` in the same order `parameters()` enumerates
+    /// them (i.e. `params.len() == parameters().len()`).
+    ///
+    /// This exists because `Var::clone()` shares gradient state but not the
+    /// value storage: `coeus_optim::{SGD, Adam}::step` mutates its own owned
+    /// `Vec<Var<T, B>>` in place (via copy-on-write on first mutation), so a
+    /// module that read `parameters()` to build an optimizer must call this
+    /// after each `step()` to see the updated values, unless the module's own
+    /// fields *are* the optimizer's `Var`s (as in a flat training loop that
+    /// never separately clones them into a named struct).
+    ///
+    /// Default is a no-op, which is correct for parameterless modules
+    /// (activations, dropout, pooling, reshape/view layers, ...). Any module
+    /// whose `parameters()` returns a non-empty `Vec` must override this.
+    #[inline]
+    fn load_parameters(&mut self, _params: &[Var<T, B>]) {}
+
     /// Zero all parameter gradients.
     #[inline]
     fn zero_grad(&self) {

--- a/coeus-nn/src/normalization/layernorm.rs
+++ b/coeus-nn/src/normalization/layernorm.rs
@@ -101,6 +101,16 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for LayerNorm
         vec![self.weight.clone(), self.bias.clone()]
     }
 
+    /// Write updated `(weight, bias)` values back. Overrides the
+    /// default no-op: `coeus_tensor::Tensor`'s copy-on-write storage
+    /// means a clone taken via `parameters()` detaches from this
+    /// module on first mutation, so an optimizer that mutates its own
+    /// owned copy needs this round-trip to propagate updates back.
+    fn load_parameters(&mut self, params: &[Var<T, B>]) {
+        self.weight = params[0].clone();
+        self.bias = params[1].clone();
+    }
+
     /// Forward pass for 2-D input `[N, D]`.
     ///
     /// For inputs with rank ≥ 3 (e.g. `[batch, seq, D]`) use

--- a/coeus-nn/src/sequential.rs
+++ b/coeus-nn/src/sequential.rs
@@ -73,6 +73,15 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Sequenti
             m.train(mode);
         }
     }
+
+    fn load_parameters(&mut self, params: &[Var<T, B>]) {
+        let mut offset = 0;
+        for m in &mut self.layers {
+            let n = m.parameters().len();
+            m.load_parameters(&params[offset..offset + n]);
+            offset += n;
+        }
+    }
 }
 
 /// A compile-time static sequential container that chains modules.
@@ -115,6 +124,13 @@ impl<
     fn train(&mut self, mode: bool) {
         self.0.train(mode);
         self.1.train(mode);
+    }
+
+    #[inline]
+    fn load_parameters(&mut self, params: &[Var<ScalarType, B>]) {
+        let n0 = self.0.parameters().len();
+        self.0.load_parameters(&params[..n0]);
+        self.1.load_parameters(&params[n0..]);
     }
 }
 

--- a/coeus-nn/tests/nn/linear_activation_loss.rs
+++ b/coeus-nn/tests/nn/linear_activation_loss.rs
@@ -1,5 +1,6 @@
 use coeus_autograd::Var;
 use coeus_nn::{cross_entropy_loss, gelu, init, mse_loss, relu, sigmoid, tanh, Linear, Module};
+use coeus_optim::{Optimizer, SGD};
 use coeus_tensor::Tensor;
 
 fn assert_slice_close(label: &str, actual: &[f64], expected: &[f64], tolerance: f64) {
@@ -94,6 +95,55 @@ fn test_linear_layer() {
             &[1.0, 1.0]
         );
     }
+}
+
+#[test]
+fn test_load_parameters_applies_optimizer_step_to_the_module() {
+    // Regression pin for `Module::load_parameters`: `SGD::step` mutates its own
+    // owned `Vec<Var>` in place (copy-on-write detaches it from any clone taken
+    // via `parameters()`), so without `load_parameters` writing the updated
+    // values back into the layer's own fields, this would silently leave
+    // `layer.weight`/`layer.bias` unchanged after training.
+    let mut layer = Linear::<f64>::new(2, 1, true);
+    init::constant(&mut layer.weight, 1.0);
+    if let Some(ref mut b) = layer.bias {
+        init::constant(b, 0.0);
+    }
+
+    let x = Var::new(Tensor::from_slice(vec![1, 2], &[3.0f64, 4.0]), false);
+    let output = layer.forward(&x); // w . x + b = 1*3 + 1*4 + 0 = 7
+    output.backward(); // d(output)/d(weight) = x = [3, 4]; d(output)/d(bias) = 1
+
+    let lr = 0.1;
+    let mut opt = SGD::new(layer.parameters(), lr, 0.0);
+    opt.step();
+    layer.load_parameters(&opt.params);
+
+    // w' = w - lr * grad = [1,1] - 0.1*[3,4] = [0.7, 0.6]
+    assert_slice_close(
+        "weight_after_sgd_step",
+        layer.weight.tensor.as_slice(),
+        &[0.7, 0.6],
+        1e-12,
+    );
+    // b' = b - lr * grad = 0 - 0.1*1 = -0.1
+    assert_slice_close(
+        "bias_after_sgd_step",
+        layer.bias.as_ref().unwrap().tensor.as_slice(),
+        &[-0.1],
+        1e-12,
+    );
+
+    // The updated layer must actually be used on the next forward pass:
+    // w' . x + b' = 0.7*3 + 0.6*4 - 0.1 = 2.1 + 2.4 - 0.1 = 4.4
+    let x2 = Var::new(Tensor::from_slice(vec![1, 2], &[3.0f64, 4.0]), false);
+    let output2 = layer.forward(&x2);
+    assert_slice_close(
+        "forward_after_load_parameters",
+        output2.tensor.as_slice(),
+        &[4.4],
+        1e-12,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Adds `remainder(a, b) = a - floor(a/b)*b` (torch/NumPy modulo, carrying the sign of the divisor) as a tracked autograd op — closing a coeus↔Burn/torch elementwise-op parity gap.

Implemented as a `RemainderOp` in the existing `BinaryAutogradOp` framework, composed from `coeus_ops` floor/div/mul/sub. It therefore runs on every backend (CPU/wgpu/cuda) with **no core, dtype, or kernel changes**.

## Gradient
The floor quotient `q = floor(a/b)` is piecewise-constant, so the gradient reduces to that of `a - q*b` with `q` held constant:
- `∂/∂a = grad_out` (identity)
- `∂/∂b = -q * grad_out` (matches PyTorch `-grad * self.div(other, rounding_mode="floor")`)

both broadcast-reduced to their operand shapes.

## Verification
Rust autograd tests (`coeus-autograd/tests/autograd/remainder.rs`), all green:
- value + both-operand gradients (positive operands)
- sign-of-divisor: `7 % -3 = -2`, `db = 3`
- broadcast reduction of `grad_b` over a scalar divisor

Plus a runnable doctest on the public `remainder` fn. Full coeus-autograd suite: 59 passed.

The Python binding + pytorch/jax parity tests are prepared as a follow-up increment (blocked locally by an in-flight `coeus-core` migration breaking the wheel build; the Rust op is independently complete and verified).

> Note: this branch also carries two already-committed `coeus-nn` `load_parameters` commits that were local-only ahead of `origin/main`; they are unrelated to the remainder change and ride along only because the working tree could not be stashed to rebase them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds element-wise `remainder` (modulo operation carrying the sign of the divisor, matching PyTorch/NumPy semantics) as a tracked autograd operation. The implementation is composed from existing `floor`, `div`, `mul`, and `sub` operations, with gradients flowing as identity to the dividend and as `-floor(a/b)` to the divisor. Comprehensive Rust tests verify forward pass values and gradient correctness for positive operands, negative divisor sign handling, and broadcast reduction scenarios.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/arithmetic/binary.rs` |
| 2 | `coeus-autograd/tests/autograd/remainder.rs` |
| 3 | `coeus-autograd/src/ops/mod.rs` |
| 4 | `coeus-autograd/src/lib.rs` |
| 5 | `coeus-autograd/tests/autograd/mod.rs` |
| 6 | `coeus-nn/src/module.rs` |
| 7 | `coeus-nn/src/linear.rs` |
| 8 | `coeus-nn/src/normalization/layernorm.rs` |
| 9 | `coeus-nn/src/sequential.rs` |
| 10 | `coeus-nn/tests/nn/linear_activation_loss.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `coeus-nn/src/module.rs` | Adds `load_parameters` method to Module trait - this appears to be an unrelated module parameter loading feature not mentioned in the PR's remainder operation scope |
| `coeus-nn/src/linear.rs` | Implements `load_parameters` for Linear module - unrelated to remainder operation, addresses optimizer parameter synchronization |
| `coeus-nn/src/normalization/layernorm.rs` | Implements `load_parameters` for LayerNorm module - unrelated to remainder operation |
| `coeus-nn/src/sequential.rs` | Implements `load_parameters` for Sequential modules - unrelated to remainder operation |
| `coeus-nn/tests/nn/linear_activation_loss.rs` | Adds test for `load_parameters` optimizer integration - unrelated to remainder operation, tests the parameter loading feature |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new differentiable remainder/modulo operation for autograd, including support for forward and backward passes.
  * Added module parameter loading support so updated values can be written back into layers and containers after optimization steps.

* **Bug Fixes**
  * Improved handling of broadcasted parameters and gradient propagation for the new remainder operation.
  * Ensured updated parameters are reflected in subsequent model forward passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->