### PR TITLE
test(nn): Burn parity for hardsigmoid/softmin/log_sigmoid

### DIFF
--- a/coeus-nn/tests/burn_live_parity.rs
+++ b/coeus-nn/tests/burn_live_parity.rs
@@ -2,7 +2,7 @@ use burn::backend::ndarray::{NdArray, NdArrayDevice};
 use burn::tensor::{activation as burn_act, Tensor as BurnTensor, TensorData};
 use coeus_autograd::Var;
 use coeus_core::SequentialBackend;
-use coeus_nn::{cross_entropy_loss, softmax, Module};
+use coeus_nn::{cross_entropy_loss, log_sigmoid, softmax, Module};
 use coeus_ops::{leaky_relu, log_softmax_axis, mish, sigmoid, silu, softplus, tanh};
 use coeus_tensor::Tensor as CoeusTensor;
 
@@ -311,6 +311,50 @@ fn mish_softplus_leaky_relu_match_burn() {
         "leaky_relu",
         coeus_ops::leaky_relu(&xc, &backend, 0.01).as_slice(),
         &bvec(burn::tensor::activation::leaky_relu(xb, 0.01)),
+    );
+}
+
+#[test]
+fn hardsigmoid_softmin_logsigmoid_match_burn() {
+    use burn::backend::autodiff::Autodiff;
+    type AB = Autodiff<NdArray<f32>>;
+    let device: NdArrayDevice = Default::default();
+    let data = vec![-4.0f32, -1.0, -0.5, 0.5, 1.0, 4.0];
+
+    let xv = || Var::new(CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2, 3], &data), false);
+    let xb: BurnTensor<BurnBackend, 2> =
+        BurnTensor::from_data(TensorData::new(data.clone(), [2, 3]), &dev());
+
+    // hardsigmoid: coeus is the parameter-free clamp((x+3)/6, 0, 1); Burn's
+    // parameterised form with (alpha, beta) = (1/6, 1/2) is identical.
+    assert_close(
+        "hardsigmoid",
+        coeus_autograd::hardsigmoid(&xv()).tensor.as_slice(),
+        &bvec(burn_act::hard_sigmoid(xb.clone(), 1.0 / 6.0, 0.5)),
+    );
+    // softmin(x, dim) = softmax(-x, dim).
+    assert_close(
+        "softmin",
+        coeus_autograd::softmin(&xv(), 1).tensor.as_slice(),
+        &bvec(burn_act::softmin(xb.clone(), 1)),
+    );
+    // log_sigmoid(x) = log(sigmoid(x)) = -softplus(-x).
+    assert_close(
+        "log_sigmoid",
+        log_sigmoid(&xv()).tensor.as_slice(),
+        &bvec(burn_act::log_sigmoid(xb)),
+    );
+
+    // Backward parity for log_sigmoid vs burn autodiff: d/dx log σ(x) = σ(-x).
+    let xg = Var::new(CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2, 3], &data), true);
+    coeus_autograd::sum(&log_sigmoid(&xg)).backward();
+    let xb_ad: BurnTensor<AB, 2> =
+        BurnTensor::from_data(TensorData::new(data.clone(), [2, 3]), &device).require_grad();
+    let grads = burn_act::log_sigmoid(xb_ad.clone()).sum().backward();
+    assert_close(
+        "log_sigmoid_bwd",
+        xg.grad().unwrap().as_slice(),
+        &xb_ad.grad(&grads).unwrap().into_data().to_vec::<f32>().unwrap(),
     );
 }
 


### PR DESCRIPTION
## Summary
Extends the live Burn parity harness (`burn_live_parity`) to three activations coeus already implements but never verified against Burn — closing testing-coverage gaps toward "complete parity as Burn with testing against Burn."

- `hardsigmoid` — coeus parameter-free `clamp((x+3)/6, 0, 1)` vs Burn `hard_sigmoid(x, 1/6, 1/2)` (identical form).
- `softmin` — `softmax(-x)`.
- `log_sigmoid` — `-softplus(-x) = log σ(x)`, forward + backward vs Burn autodiff (`d/dx = σ(-x)`).

## Verification
`cargo test -p coeus-nn --test burn_live_parity hardsigmoid_softmin_logsigmoid` — passes. clippy clean. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extends the Burn parity testing harness to verify three activation functions (`hardsigmoid`, `softmin`, and `log_sigmoid`) that were already implemented in coeus but lacked verification against the Burn framework. The new test confirms that coeus implementations match Burn's behavior for forward passes and includes backward pass verification for `log_sigmoid` using Burn's autodiff.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/burn_live_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added parity coverage for additional activation functions.
  * Verified forward results for `hardsigmoid`, `softmin`, and `log_sigmoid` against a reference implementation.
  * Added gradient comparison checks for `log_sigmoid` to confirm autograd matches the reference behavior under a summed loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->