### PR TITLE
test(nn): Burn parity for sign (including sign(0) convention)

### DIFF
--- a/coeus-nn/tests/burn_live_parity.rs
+++ b/coeus-nn/tests/burn_live_parity.rs
@@ -397,6 +397,22 @@ fn exp_log_sqrt_neg_abs_match_burn() {
 }
 
 #[test]
+fn sign_matches_burn() {
+    // Includes zero to pin the sign(0) = 0 convention shared with Burn/torch
+    // (rather than +1), alongside the ±1 cases.
+    let backend = SequentialBackend::new();
+    let data = vec![-2.0f32, 0.0, 3.0, -0.5, 0.0, 1.5];
+    let xc = CoeusTensor::from_slice(vec![2, 3], &data);
+    let xb: BurnTensor<BurnBackend, 2> =
+        BurnTensor::from_data(TensorData::new(data.clone(), [2, 3]), &dev());
+    assert_close(
+        "sign",
+        coeus_ops::sign(&xc, &backend).as_slice(),
+        &bvec(xb.sign()),
+    );
+}
+
+#[test]
 fn sin_cos_match_burn() {
     let backend = SequentialBackend::new();
     let data = vec![0.0f32, 0.5, 1.0, 1.5, 2.0, core::f32::consts::PI];


### PR DESCRIPTION
## Summary
Adds a `sign` forward parity test against Burn's ndarray backend with a zero-containing input, pinning the shared `sign(0) = 0` convention (not `+1`) alongside the `±1` cases.

Completes Burn numeric-op parity coverage: clamp, max_pair, min_pair, powf, powi, remainder, sign are all now verified against Burn.

## Verification
`cargo test -p coeus-nn --test burn_live_parity sign_matches_burn` — passes. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a parity test for the `sign` operation against Burn's ndarray backend. The test explicitly includes zero-valued inputs to verify that both Coeus and Burn share the `sign(0) = 0` convention (rather than `+1`), alongside testing the standard positive and negative cases. This completes the numeric operation parity coverage for several operations including clamp, max_pair, min_pair, powf, powi, remainder, and sign.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-nn/tests/burn_live_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->