### PR TITLE
test(optim): global-norm coverage + dead-code cleanup for clip_grad_norm

### DIFF
--- a/coeus-optim/src/clip.rs
+++ b/coeus-optim/src/clip.rs
@@ -63,10 +63,8 @@ where
     let total_norm = total_sq.sqrt_val();
 
     // Pass 2: scale if over the limit.
-    let one = T::one();
     if total_norm > max_norm {
         let clip_coef = max_norm / total_norm;
-        let backend = B::default();
         for param in params {
             let Some(ref grad_arc) = param.grad else {
                 continue;
@@ -77,7 +75,6 @@ where
                 *v *= clip_coef;
             }
         }
-        let _ = (one, backend); // suppress unused warnings when no params have grad
     }
 
     total_norm

--- a/coeus-optim/tests/optim_tests.rs
+++ b/coeus-optim/tests/optim_tests.rs
@@ -1,6 +1,6 @@
 use coeus_autograd::Var;
 use coeus_core::SequentialBackend;
-use coeus_optim::{Adam, AdamW, Optimizer, RMSProp, SGD};
+use coeus_optim::{clip_grad_norm, Adam, AdamW, Optimizer, RMSProp, SGD};
 use coeus_tensor::Tensor;
 
 #[test]
@@ -495,4 +495,104 @@ fn test_adagrad_convergence_quadratic_400steps() {
         x_n.abs() < 1e-5,
         "AdaGrad failed to converge after 400 steps: {x_n}"
     );
+}
+
+// ── clip_grad_norm ──
+//
+// `clip_grad_norm` had no dedicated test coverage beyond a single-parameter
+// doctest; the defining "global" behavior — one L2 norm computed across ALL
+// parameters' gradients, as if concatenated into one vector, then every
+// gradient scaled by the same factor — was entirely unverified.
+
+/// Global norm spans two parameters: grads [3,4] and [0,0,12] concatenate to
+/// [3,4,0,0,12], L2 norm = sqrt(9+16+144) = sqrt(169) = 13 (not 5, the norm of
+/// the first parameter alone — this is what "global" must mean).
+/// Clipping to max_norm=6.5 scales every gradient by 6.5/13 = 0.5.
+#[test]
+fn test_clip_grad_norm_is_global_across_parameters() {
+    let a = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[10.0f32, 20.0]),
+        true,
+    );
+    a.set_grad(Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[3.0f32, 4.0]));
+    let b = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![3], &[1.0f32, 2.0, 3.0]),
+        true,
+    );
+    b.set_grad(Tensor::<f32, SequentialBackend>::from_slice(
+        vec![3],
+        &[0.0f32, 0.0, 12.0],
+    ));
+
+    let pre_norm = clip_grad_norm(&[a.clone(), b.clone()], 6.5f32);
+    assert!(
+        (pre_norm - 13.0).abs() < 1e-4,
+        "global norm across both params: got {pre_norm}, expected 13.0"
+    );
+
+    let ga = a.grad().unwrap();
+    assert!((ga.as_slice()[0] - 1.5).abs() < 1e-4, "a[0] scaled by 0.5");
+    assert!((ga.as_slice()[1] - 2.0).abs() < 1e-4, "a[1] scaled by 0.5");
+    let gb = b.grad().unwrap();
+    assert!((gb.as_slice()[2] - 6.0).abs() < 1e-4, "b[2] scaled by 0.5");
+}
+
+/// Below `max_norm`, gradients pass through unscaled (no-op clip).
+#[test]
+fn test_clip_grad_norm_below_threshold_is_noop() {
+    let x = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[1.0f32, 1.0]),
+        true,
+    );
+    x.set_grad(Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[3.0f32, 4.0]));
+
+    let pre_norm = clip_grad_norm(std::slice::from_ref(&x), 10.0f32);
+    assert!((pre_norm - 5.0).abs() < 1e-5);
+
+    let g = x.grad().unwrap();
+    assert!((g.as_slice()[0] - 3.0).abs() < 1e-6, "unscaled: {}", g.as_slice()[0]);
+    assert!((g.as_slice()[1] - 4.0).abs() < 1e-6, "unscaled: {}", g.as_slice()[1]);
+}
+
+/// At exactly `max_norm` the strict `>` comparison must not trigger scaling
+/// (torch's `clip_grad_norm_` uses the same strict-greater convention).
+#[test]
+fn test_clip_grad_norm_exact_boundary_is_noop() {
+    let x = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[1.0f32, 1.0]),
+        true,
+    );
+    x.set_grad(Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[3.0f32, 4.0]));
+
+    let pre_norm = clip_grad_norm(std::slice::from_ref(&x), 5.0f32);
+    assert!((pre_norm - 5.0).abs() < 1e-5);
+
+    let g = x.grad().unwrap();
+    assert!((g.as_slice()[0] - 3.0).abs() < 1e-6, "boundary: no scaling expected");
+    assert!((g.as_slice()[1] - 4.0).abs() < 1e-6, "boundary: no scaling expected");
+}
+
+/// A parameter with no gradient is skipped (neither contributes to the norm
+/// nor panics), while parameters that do have gradients are still clipped.
+#[test]
+fn test_clip_grad_norm_skips_params_without_grad() {
+    let with_grad = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[1.0f32, 1.0]),
+        true,
+    );
+    with_grad.set_grad(Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[3.0f32, 4.0]));
+    // requires_grad = false: no grad buffer at all.
+    let without_grad = Var::new(
+        Tensor::<f32, SequentialBackend>::from_slice(vec![2], &[9.0f32, 9.0]),
+        false,
+    );
+
+    let pre_norm = clip_grad_norm(&[with_grad.clone(), without_grad.clone()], 2.5f32);
+    // Norm should reflect only `with_grad`'s [3,4] -> 5.0, not be perturbed by
+    // (or panic on) the grad-less parameter.
+    assert!((pre_norm - 5.0).abs() < 1e-5, "got {pre_norm}, expected 5.0");
+
+    let g = with_grad.grad().unwrap();
+    assert!((g.as_slice()[0] - 1.5).abs() < 1e-4);
+    assert!((g.as_slice()[1] - 2.0).abs() < 1e-4);
 }


### PR DESCRIPTION
## Summary
`clip_grad_norm` had no dedicated test coverage beyond a single-parameter doctest — its defining **"global"** behavior (one L2 norm computed across ALL parameters' gradients as if concatenated into one vector, every gradient scaled by the same factor) was entirely unverified.

## Tests added
- **Multi-parameter global norm**: grads `[3,4]` + `[0,0,12]` → norm `13` (not `5`, the norm of the first parameter alone — proves the "global" semantic, matching torch's `clip_grad_norm_`).
- **Below-threshold no-op**: gradients pass through unscaled.
- **Exact-boundary no-op**: `norm == max_norm` must not trigger the strict `>` comparison.
- **Skips grad-less params**: a parameter with no gradient buffer is neither counted toward the norm nor causes a panic.

## Cleanup
Removed `let one = T::one()` and `let backend = B::default()` from `clip_grad_norm` — both were computed and immediately discarded via a `let _ = (one, backend)` suppression, contributing nothing to the clipping logic.

## Verification
`cargo nextest run -p coeus-optim`: 20 passed (was 16). `cargo test --doc -p coeus-optim`: 10 passed (doctest still exercises the single-param case). clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive test coverage for the `clip_grad_norm` function and removes unused dead code. The new tests verify the *global* norm behavior (computing L2 norm across all parameters' gradients as a single concatenated vector), below-threshold and exact-boundary no-op behavior, and proper handling of parameters without gradients. The cleanup removes two unused local variables (`one` and `backend`) that were declared but never actually used in the clipping logic. The changes increase test count from 16 to 20 passing tests while maintaining all existing functionality.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-optim/src/clip.rs` |
| 2 | `coeus-optim/tests/optim_tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->