### PR TITLE
feat(nn)!: make PReLU a true learnable per-channel activation

### DIFF
--- a/coeus-autograd/src/ops/activation/relu.rs
+++ b/coeus-autograd/src/ops/activation/relu.rs
@@ -3,6 +3,7 @@ use super::UnaryAutogradOp;
 use crate::grad_buffer::GradBuffer;
 use crate::node::BackwardNode;
 use crate::var::Var;
+use crate::{mul, reshape, where_cond};
 use coeus_core::{Float, Scalar};
 use coeus_tensor::Tensor;
 use std::sync::Arc;
@@ -205,26 +206,58 @@ pub fn selu<T: Float, B: coeus_ops::BackendOps<T> + Default>(a: &Var<T, B>) -> V
     unary_op::<T, B, SeluOp>(a)
 }
 
-// ── PReLU (scalar α) ──
+// ── PReLU (learnable weight) ──
 //
-// The single-scalar-α PReLU is mathematically identical to LeakyReLU with the
-// same negative slope (`y = max(0,x) + α·min(0,x)`, `dy/dx = 1` where `x ≥ 0`
-// else `α`), so it delegates to the tracked `leaky_relu` rather than carrying a
-// byte-identical duplicate backward node. A learnable per-channel PReLU (a
-// differentiable weight `Var`, PyTorch/Burn semantics) is tracked separately as
-// a [major] item.
+// `y = x` where `x > 0`, else `weight · x` (PyTorch/Burn `PReLU` semantics —
+// note the *kink at x = 0 lands on the negative branch*: PyTorch's `F.prelu`
+// backward returns `weight`, not `1`, at x = 0). Expressed via the tracked
+// `where_cond(cond, on_true, on_false)` — itself an existing composition of
+// relu/mul/add with no custom `BackwardNode` of its own — selecting on
+// `cond = relu(x)`, which is nonzero exactly where `x > 0`:
+//   y = where_cond(relu(x), x, weight · x)
+// `where_cond`'s own backward routes `grad_out` entirely to `on_true` where
+// `cond ≠ 0` and entirely to `on_false` elsewhere (INCLUDING x = 0, since
+// `relu(0) = 0`), so both PReLU gradients fall out correctly:
+//   ∂y/∂x      = 1 where x > 0, else weight   (weight at the kink, matching
+//                PyTorch — a plain `relu(x) - weight·relu(-x)` composition
+//                would give 0 at the kink instead, since relu's own
+//                subgradient there is 0, not a routed selection)
+//   ∂y/∂weight = Σ_{x≤0} x   (broadcast-reduced to weight's shape; the x > 0
+//                region contributes 0 since on_true doesn't depend on weight)
+//
+// `weight` has shape `[1]` (one shared slope) or `[C]` (per-channel,
+// PyTorch/Burn `num_parameters=C`). For rank > 2 inputs a `[C]` weight must
+// broadcast against the CHANNEL axis (dim 1), not NumPy's default
+// right-aligned trailing axis — e.g. `[N,C,H,W]` needs the weight reshaped to
+// `[1,C,1,1]`. Burn's `activation::prelu` does the identical reshape; see
+// `burn-tensor-0.16.1/src/tensor/activation/base.rs`.
 
-/// Tracked PReLU with a single scalar α slope.
+/// Tracked PReLU with a learnable per-channel (or shared-scalar) weight.
 ///
-/// `y = max(0, x) + α · min(0, x)`; the gradient is `1` where `x ≥ 0`, else
-/// `α`. This is identical to [`leaky_relu`] with `negative_slope = α`, to which
-/// it delegates so the scalar negative-slope kernel has a single source of
-/// truth.
+/// `y = x` where `x > 0`, else `weight · x`. Gradient flows to both `x` (`1`
+/// where `x > 0`, else `weight` — including at the kink `x = 0`, matching
+/// PyTorch) and `weight` (`Σ_{x≤0} x`, broadcast-reduced).
+///
+/// # Panics
+/// Panics (via the underlying broadcast) if `weight`'s channel count is
+/// neither `1` nor `x`'s size along dim `1`.
 #[must_use]
-#[inline]
 pub fn prelu<T: Float, B: coeus_ops::BackendOps<T> + Default>(
-    a: &Var<T, B>,
-    alpha: f64,
-) -> Var<T, B> {
-    leaky_relu(a, alpha)
+    x: &Var<T, B>,
+    weight: &Var<T, B>,
+) -> Var<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    let input_rank = x.tensor.ndim();
+    let channels = weight.tensor.shape()[0];
+    let w = if channels > 1 && input_rank > 2 {
+        let mut shape = vec![1usize; input_rank];
+        shape[1] = channels;
+        reshape(weight, shape)
+    } else {
+        weight.clone()
+    };
+    where_cond(&relu(x), x, &mul(&w, x))
 }

--- a/coeus-autograd/tests/autograd/mod.rs
+++ b/coeus-autograd/tests/autograd/mod.rs
@@ -7,6 +7,7 @@ mod linalg;
 mod minmax;
 mod nn_conv;
 mod ops_overloads;
+mod prelu;
 mod reductions;
 mod remainder;
 mod scatter_add;

--- a/coeus-autograd/tests/autograd/prelu.rs
+++ b/coeus-autograd/tests/autograd/prelu.rs
@@ -1,0 +1,98 @@
+use coeus_autograd::{prelu, sum, Var};
+use coeus_core::MoiraiBackend;
+use coeus_tensor::Tensor;
+
+// prelu(x, w) = x where x > 0, else w*x. PyTorch's kink convention: the
+// gradient at x = 0 is w (the negative-branch slope), not 1.
+
+#[test]
+fn test_prelu_scalar_weight_forward_and_backward() {
+    let backend = MoiraiBackend::new();
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(
+            vec![5],
+            &[-2.0, -1.0, 0.0, 0.5, 1.0],
+            &backend,
+        ),
+        true,
+    );
+    let w = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![1], &[0.25], &backend),
+        true,
+    );
+    let out = prelu(&x, &w);
+    assert_eq!(
+        out.tensor.as_slice(),
+        &[-0.5, -0.25, 0.0, 0.5, 1.0],
+        "fwd prelu"
+    );
+    sum(&out).backward();
+    // dx = w at x<=0 (INCLUDING the kink x=0), 1 at x>0.
+    assert_eq!(
+        x.grad().unwrap().as_slice(),
+        &[0.25, 0.25, 0.25, 1.0, 1.0],
+        "grad_x (kink lands on the negative branch)"
+    );
+    // dw = sum of x over the x<=0 region: -2 + -1 + 0 = -3.
+    assert_eq!(w.grad().unwrap().as_slice(), &[-3.0], "grad_w");
+}
+
+/// A per-channel weight `[C]` on a rank-4 `[N,C,H,W]` input must broadcast
+/// against the CHANNEL axis (dim 1), not NumPy's default right-aligned
+/// trailing axis (which would incorrectly align `C` with `W`).
+#[test]
+fn test_prelu_per_channel_weight_broadcasts_on_channel_axis() {
+    let backend = MoiraiBackend::new();
+    // [N=1, C=2, H=1, W=2]: channel 0 = [-1,-2], channel 1 = [-3,-4].
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(
+            vec![1, 2, 1, 2],
+            &[-1.0, -2.0, -3.0, -4.0],
+            &backend,
+        ),
+        true,
+    );
+    // Distinct per-channel slopes: channel 0 -> 0.1, channel 1 -> 0.9. If the
+    // weight broadcast against the trailing (W) axis instead of the channel
+    // axis, channel 1's second element would incorrectly reuse channel 0's
+    // slope (weight index 0 has only 2 elements, W-broadcast would wrap/panic
+    // on shape mismatch) — this test fails loudly if the axis is wrong.
+    let w = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![2], &[0.1, 0.9], &backend),
+        true,
+    );
+    let out = prelu(&x, &w);
+    assert_eq!(
+        out.tensor.as_slice(),
+        &[-0.1, -0.2, -2.7, -3.6],
+        "channel 0 scaled by 0.1, channel 1 by 0.9"
+    );
+    sum(&out).backward();
+    // dw[0] = sum over channel 0's elements (both negative): -1 + -2 = -3.
+    // dw[1] = sum over channel 1's elements: -3 + -4 = -7.
+    assert_eq!(w.grad().unwrap().as_slice(), &[-3.0, -7.0], "grad_w per-channel");
+}
+
+/// A scalar weight `[1]` on a rank-4 input broadcasts trivially against every
+/// element regardless of axis.
+#[test]
+fn test_prelu_scalar_weight_broadcasts_over_rank4_input() {
+    let backend = MoiraiBackend::new();
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(
+            vec![1, 2, 1, 2],
+            &[-1.0, -2.0, 3.0, -4.0],
+            &backend,
+        ),
+        true,
+    );
+    let w = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice_on(vec![1], &[0.5], &backend),
+        true,
+    );
+    let out = prelu(&x, &w);
+    assert_eq!(out.tensor.as_slice(), &[-0.5, -1.0, 3.0, -2.0], "scalar weight fwd");
+    sum(&out).backward();
+    // dw = sum of x over x<=0 elements: -1 + -2 + -4 = -7.
+    assert_eq!(w.grad().unwrap().as_slice(), &[-7.0], "grad_w scalar over rank4");
+}

--- a/coeus-nn/benches/nn_bench.rs
+++ b/coeus-nn/benches/nn_bench.rs
@@ -1292,16 +1292,19 @@ fn bench_prelu_forward(c: &mut Criterion) {
         Tensor::<f32, MoiraiBackend>::from_slice(vec![BATCH, FEATURES], &input_data),
         false,
     );
+    // Matches Burn's PReluConfig default: num_parameters=1, alpha=0.25.
+    let w_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![1], &[0.25]), false);
+    let w_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![1], &[0.25]), false);
 
     let mut group = c.benchmark_group("Burn vs Coeus — PReLU forward (128x256)");
     group.bench_function("Burn NdArray", |b| {
         b.iter(|| black_box(burn_prelu.forward(black_box(x_burn.clone()))))
     });
     group.bench_function("Coeus Sequential", |b| {
-        b.iter(|| black_box(prelu(black_box(&x_seq), 0.25)))
+        b.iter(|| black_box(prelu(black_box(&x_seq), black_box(&w_seq))))
     });
     group.bench_function("Coeus Moirai", |b| {
-        b.iter(|| black_box(prelu(black_box(&x_moirai), 0.25)))
+        b.iter(|| black_box(prelu(black_box(&x_moirai), black_box(&w_moirai))))
     });
     group.finish();
 }
@@ -4915,15 +4918,17 @@ fn bench_prelu2_forward(c: &mut Criterion) {
         TensorData::new(input_data.clone(), [BATCH, FEATURES]),
         &device,
     );
+    let w_seq = Var::new(Tensor::<f32, SequentialBackend>::from_slice(vec![1], &[0.01]), false);
+    let w_moirai = Var::new(Tensor::<f32, MoiraiBackend>::from_slice(vec![1], &[0.01]), false);
     let mut group = c.benchmark_group("Burn vs Coeus - prelu2(0.01) forward (128x256)");
     group.bench_function("Burn NdArray (leaky_relu proxy)", |b| {
         b.iter(|| black_box(burn::tensor::activation::relu(black_box(x_burn.clone()))))
     });
     group.bench_function("Coeus Sequential", |b| {
-        b.iter(|| black_box(coeus_autograd::prelu(&x_seq, 0.01)))
+        b.iter(|| black_box(coeus_autograd::prelu(&x_seq, &w_seq)))
     });
     group.bench_function("Coeus Moirai", |b| {
-        b.iter(|| black_box(coeus_autograd::prelu(&x_moirai, 0.01)))
+        b.iter(|| black_box(coeus_autograd::prelu(&x_moirai, &w_moirai)))
     });
     group.finish();
 }

--- a/coeus-nn/src/activation/parametric.rs
+++ b/coeus-nn/src/activation/parametric.rs
@@ -433,47 +433,68 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for Celu {
     }
 }
 
-/// Functional PReLU activation (single scalar α per tensor).
+/// Functional PReLU activation with a learnable per-channel (or
+/// shared-scalar) weight — see [`coeus_autograd::prelu`] for the composition
+/// and gradient derivation.
 #[inline]
 pub fn prelu<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     input: &Var<T, B>,
-    alpha: f64,
-) -> Var<T, B> {
-    coeus_autograd::prelu(input, alpha)
+    weight: &Var<T, B>,
+) -> Var<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
+    coeus_autograd::prelu(input, weight)
 }
 
-/// PReLU activation module with a single scalar α.
-///
-/// PyTorch's channel-wise PReLU (with a learnable `[num_parameters]` α
-/// parameter) can be composed via `coeus_ops::broadcast_to` so the channel
-/// axis matches `input`.
-#[derive(Clone, Debug)]
-pub struct PReLU {
-    /// Scalar α slope shared across the tensor.
-    pub alpha: f64,
+/// PReLU activation module with a learnable weight (PyTorch/Burn semantics:
+/// `num_parameters = 1` for one shared slope, or the channel count for a
+/// per-channel slope broadcasting against dim 1 of the input).
+#[derive(Clone)]
+pub struct PReLU<T: Float, B: coeus_ops::BackendOps<T> + Default = coeus_core::MoiraiBackend> {
+    /// Learnable slope(s); shape `[1]` (shared) or `[num_parameters]`
+    /// (per-channel).
+    pub weight: Var<T, B>,
 }
 
-impl PReLU {
-    /// Create a PReLU module with custom α.
-    pub fn new(alpha: f64) -> Self {
-        Self { alpha }
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> PReLU<T, B> {
+    /// Create a PReLU module with `num_parameters` learnable slopes (`1` for
+    /// a shared scalar, or the channel count for per-channel slopes), each
+    /// initialized to `init` (PyTorch/Burn default: `0.25`).
+    pub fn new(num_parameters: usize, init: f64) -> Self {
+        let backend = B::default();
+        let weight = Var::new(
+            coeus_tensor::Tensor::full_on([num_parameters], T::from_f64(init), &backend),
+            true,
+        );
+        Self { weight }
     }
 }
 
-impl Default for PReLU {
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Default for PReLU<T, B> {
     fn default() -> Self {
-        Self { alpha: 0.25 }
+        Self::new(1, 0.25)
     }
 }
 
-impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for PReLU {
+impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for PReLU<T, B>
+where
+    B::DeviceBuffer<T>:
+        coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
+{
     #[inline]
     fn parameters(&self) -> Vec<Var<T, B>> {
-        vec![]
+        vec![self.weight.clone()]
+    }
+
+    #[inline]
+    fn load_parameters(&mut self, params: &[Var<T, B>]) {
+        self.weight = params[0].clone();
     }
 
     #[inline]
     fn forward(&self, input: &Var<T, B>) -> Var<T, B> {
-        prelu(input, self.alpha)
+        prelu(input, &self.weight)
     }
 }

--- a/coeus-nn/tests/act_extended_tests.rs
+++ b/coeus-nn/tests/act_extended_tests.rs
@@ -13,8 +13,9 @@ use coeus_autograd::Var;
 use coeus_core::MoiraiBackend;
 use coeus_nn::{
     celu, hardshrink, hardsigmoid, hardswish, hardtanh, log_sigmoid, prelu, softshrink, softsign,
-    tanhshrink, threshold, Hardsigmoid, Hardswish, Module, Softsign,
+    tanhshrink, threshold, Hardsigmoid, Hardswish, Module, PReLU, Softsign,
 };
+use coeus_optim::{Optimizer, SGD};
 use coeus_tensor::Tensor;
 
 fn close(a: f64, b: f64, tol: f64) {
@@ -421,11 +422,57 @@ fn prelu_forward_and_backward() {
         Tensor::<f64, MoiraiBackend>::from_slice([data.len()], &data),
         true,
     );
-    let output = prelu(&input, alpha);
+    let weight = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([1], &[alpha]),
+        true,
+    );
+    let output = prelu(&input, &weight);
     assert_close_slice("prelu_forward", output.tensor.as_slice(), &expected, 1e-12);
     output.backward();
     let grad = input.grad().expect("prelu requires grad");
     assert_close_slice("prelu_backward", grad.as_slice(), &expected_grad, 1e-12);
+    // grad_weight = sum of x over the x<=0 region: -2 + -1 + 0 = -3.0.
+    let grad_w = weight.grad().expect("prelu weight requires grad");
+    close(grad_w.as_slice()[0], -3.0, 1e-12);
+}
+
+#[test]
+fn prelu_module_weight_learns_via_optimizer_round_trip() {
+    // Regression pin (mirrors `test_load_parameters_applies_optimizer_step_to_
+    // the_module` for Linear): SGD::step mutates its own owned Vec<Var> in
+    // place, detached (copy-on-write) from the clone taken via parameters(),
+    // so without PReLU::load_parameters writing the update back into
+    // module.weight, the module's own field would silently stay unchanged.
+    let mut module = PReLU::<f64, MoiraiBackend>::new(1, 0.25);
+    let x = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2], &[-2.0, 3.0]),
+        false,
+    );
+    let output = module.forward(&x); // prelu([-2,3], w=0.25) = [-0.5, 3.0]
+    coeus_autograd::sum(&output).backward();
+
+    let lr = 0.1;
+    let mut opt = SGD::new(module.parameters(), lr, 0.0);
+    opt.step();
+    module.load_parameters(&opt.params);
+
+    // grad_w = sum over x<=0 of x = -2.0 (only the first element).
+    // w' = w - lr * grad_w = 0.25 - 0.1*(-2.0) = 0.45.
+    close(module.weight.tensor.as_slice()[0], 0.45, 1e-12);
+
+    // The updated weight must actually be used on the next forward pass:
+    // prelu([-2,3], w=0.45) = [-0.9, 3.0].
+    let x2 = Var::new(
+        Tensor::<f64, MoiraiBackend>::from_slice([2], &[-2.0, 3.0]),
+        false,
+    );
+    let output2 = module.forward(&x2);
+    assert_close_slice(
+        "prelu_after_sgd_step",
+        output2.tensor.as_slice(),
+        &[-0.9, 3.0],
+        1e-12,
+    );
 }
 
 // ── LeakyReLU subgradient at x = 0 (documented contract parity vs PyTorch) ──

--- a/coeus-nn/tests/burn_live_parity.rs
+++ b/coeus-nn/tests/burn_live_parity.rs
@@ -249,6 +249,66 @@ fn relu_matches_burn() {
 }
 
 #[test]
+fn prelu_learnable_weight_matches_burn() {
+    use burn::backend::autodiff::Autodiff;
+    type AB = Autodiff<NdArray<f32>>;
+    let device: NdArrayDevice = Default::default();
+
+    // Per-channel weight on a rank-4 [N,C,H,W] input, so this also verifies
+    // the channel-axis (dim 1) broadcast reshape against Burn's own.
+    let x_data = vec![-1.0f32, -2.0, 3.0, -4.0, -5.0, 6.0, -7.0, -8.0];
+    let w_data = vec![0.1f32, 0.9];
+    let shape = [1usize, 2, 2, 2];
+
+    // ── Forward parity ──
+    let x_pyc = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(shape.to_vec(), &x_data),
+        false,
+    );
+    let w_pyc = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &w_data),
+        false,
+    );
+    let xb: BurnTensor<BurnBackend, 4> =
+        BurnTensor::from_data(TensorData::new(x_data.clone(), shape), &dev());
+    let wb: BurnTensor<BurnBackend, 1> =
+        BurnTensor::from_data(TensorData::new(w_data.clone(), [2]), &dev());
+    assert_close(
+        "prelu_fwd",
+        coeus_nn::prelu(&x_pyc, &w_pyc).tensor.as_slice(),
+        &bvec(burn_act::prelu(xb, wb)),
+    );
+
+    // ── Backward parity vs burn autodiff (both x and weight) ──
+    let x_g = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(shape.to_vec(), &x_data),
+        true,
+    );
+    let w_g = Var::new(
+        CoeusTensor::<f32, SequentialBackend>::from_slice(vec![2], &w_data),
+        true,
+    );
+    coeus_autograd::sum(&coeus_nn::prelu(&x_g, &w_g)).backward();
+
+    let xb_ad: BurnTensor<AB, 4> =
+        BurnTensor::from_data(TensorData::new(x_data.clone(), shape), &device).require_grad();
+    let wb_ad: BurnTensor<AB, 1> =
+        BurnTensor::from_data(TensorData::new(w_data.clone(), [2]), &device).require_grad();
+    let grads = burn_act::prelu(xb_ad.clone(), wb_ad.clone()).sum().backward();
+
+    assert_close(
+        "prelu_bwd dx",
+        x_g.grad().unwrap().as_slice(),
+        &xb_ad.grad(&grads).unwrap().into_data().to_vec::<f32>().unwrap(),
+    );
+    assert_close(
+        "prelu_bwd dweight",
+        w_g.grad().unwrap().as_slice(),
+        &wb_ad.grad(&grads).unwrap().into_data().to_vec::<f32>().unwrap(),
+    );
+}
+
+#[test]
 fn sigmoid_tanh_match_burn() {
     let backend = SequentialBackend::new();
     let data = vec![-2.0f32, 0.0, 1.0, -1.0, 2.0, -3.0];

--- a/coeus-python/src/activations.rs
+++ b/coeus-python/src/activations.rs
@@ -216,11 +216,27 @@ pub fn celu(input: &PyTensor, alpha: f64, py: Python<'_>) -> PyTensor {
     PyTensor::from_var(inner)
 }
 
-/// PReLU activation (single scalar α).
+/// PReLU activation (single scalar α, non-learnable through this functional
+/// entry point).
+///
+/// `coeus_autograd::prelu` now takes a learnable weight `Var` (matching
+/// PyTorch/Burn `nn.PReLU`'s per-channel learnable slope); this binding
+/// constructs a fixed (`requires_grad = false`) scalar weight internally so
+/// the existing `prelu(input, alpha: float)` Python surface keeps working
+/// unchanged. A `PReLU` module class exposing the learnable weight as a
+/// registered parameter is deferred to the Python binding pass (blocked on
+/// the coeus-python wheel build).
 #[pyfunction]
 #[pyo3(signature = (input, alpha = 0.25))]
 pub fn prelu(input: &PyTensor, alpha: f64, py: Python<'_>) -> PyTensor {
-    let inner = py.allow_threads(|| coeus_autograd::prelu(&input.inner, alpha));
+    let inner = py.allow_threads(|| {
+        let backend = coeus_core::MoiraiBackend::new();
+        let weight = coeus_autograd::Var::new(
+            coeus_tensor::Tensor::full_on([1], alpha, &backend),
+            false,
+        );
+        coeus_autograd::prelu(&input.inner, &weight)
+    });
     PyTensor::from_var(inner)
 }
 


### PR DESCRIPTION
## Summary
coeus's `PReLU` was a mislabeled LeakyReLU: `PReLU { alpha: f64 }` held a fixed scalar slope and `Module::parameters()` returned `vec![]` — it could not learn. `torch.nn.PReLU` / Burn `prelu(tensor, weight)` have a **learnable** weight (shape `[1]` or `[C]`) with gradient flowing to it — that learnable slope is the entire point of PReLU vs LeakyReLU.

**BREAKING:** `coeus_autograd::prelu` / `coeus_nn::prelu` now take `weight: &Var` instead of `alpha: f64`; `coeus_nn::PReLU` is now generic `PReLU<T, B>` holding a learnable `weight: Var<T, B>`.

## Composition (no custom `BackwardNode`)
```
y = where_cond(relu(x), x, weight * x)
```
`relu(x)` is nonzero exactly where `x > 0`, so `where_cond` routes `grad_out` entirely to the `x` branch there and entirely to the `weight*x` branch everywhere else — **including the kink `x = 0`**, since `relu(0) = 0`.

This distinction matters: a naive `relu(x) - weight*relu(-x)` composition (the literal reading of the acceptance criteria) gives gradient **0** at the kink, since `relu`'s own subgradient there is 0 — but PyTorch's actual `F.prelu` convention (and this codebase's own pre-existing test) requires gradient = `weight` at `x = 0`. I verified this by direct inspection of the `ReluGrad` kernel (strict `x > 0`) and empirically via a probe test, before settling on the `where_cond` composition, which reproduces the correct convention exactly while staying a pure composition of existing tracked ops.

## Channel-axis broadcast
A `[C]` per-channel weight must broadcast against the **channel axis (dim 1)**, not NumPy's default right-aligned trailing axis, for rank > 2 inputs — reshaped to `[1,C,1,...,1]` before the multiply, matching Burn's `activation::prelu`.

## Verification
- **Burn parity** (`burn_live_parity`, Rust-level, no python wheel needed): forward matches Burn `prelu` on a per-channel rank-4 case (exercises the channel-axis reshape); backward matches **Burn autodiff** for both `x` and `weight`.
- **Optimizer round-trip**: SGD + `load_parameters` confirms the weight actually updates and the new value is used on the next forward pass.
- Dedicated Rust tests: scalar-weight kink gradient, per-channel channel-axis broadcast, scalar-weight-over-rank4 broadcast.
- `cargo nextest -p coeus-autograd -p coeus-nn`: 489/489. Doctests: 24/24. clippy clean.

## No compat shim
All call sites updated in the same change: the nn-level `prelu`/`PReLU` free fn+struct (was a byte-identical duplicate of the old naive composition), `act_extended_tests.rs`, `nn_bench.rs` (both PReLU benches), and the coeus-python binding — adapted internally to preserve its `prelu(input, alpha: float)` surface. A Python module class exposing the learnable weight as a registered parameter is deferred to the python binding pass (blocked on the orphaned `coeus-core` migration currently breaking the wheel build — see prior session notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR transforms `PReLU` from a fixed-scalar LeakyReLU alias into a true learnable activation matching PyTorch/Burn semantics. The core change replaces `prelu(x, alpha: f64)` with `prelu(x, weight: &Var)`, where `weight` is a learnable parameter (shape `[1]` for shared slope or `[C]` for per-channel) with gradient flowing through it. The implementation composes existing tracked ops (`where_cond`, `relu`, `mul`) to correctly handle the kink at `x = 0` (gradient = `weight`, not `1`, matching PyTorch's convention). Per-channel weights broadcast against the channel axis (dim 1) for rank > 2 inputs via explicit reshape. Breaking changes are absorbed across all call sites: the `PReLU` module now holds a learnable `weight: Var` and implements `parameters()`/`load_parameters()`, benchmarks pass weight variables instead of scalars, and the Python binding internally constructs a non-learnable weight to preserve its `prelu(input, alpha: float)` surface. Verification includes Burn autodiff parity (both forward and gradients for `x` and `weight`), optimizer round-trip tests confirming the weight actually updates, and dedicated tests for kink gradient and channel-axis broadcast correctness.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-autograd/src/ops/activation/relu.rs` |
| 2 | `coeus-autograd/tests/autograd/prelu.rs` |
| 3 | `coeus-nn/src/activation/parametric.rs` |
| 4 | `coeus-nn/tests/act_extended_tests.rs` |
| 5 | `coeus-nn/tests/burn_live_parity.rs` |
| 6 | `coeus-nn/benches/nn_bench.rs` |
| 7 | `coeus-python/src/activations.rs` |
| 8 | `coeus-autograd/tests/autograd/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PReLU now supports learnable weights, including shared scalar or per-channel parameters.
  * Module parameters can now be saved, loaded, and updated during training.
  * Python usage keeps the same `prelu(input, alpha=...)` style while adapting behind the scenes.

* **Bug Fixes**
  * Improved broadcasting behavior for PReLU on higher-rank tensors.
  * Added gradient coverage for input and weight values, including edge cases at zero.

* **Tests**
  * Added new checks for forward/backward correctness, optimizer round-trips, and parity with another framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->