### PR TITLE
feat(coeus-tensor): Add host extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- [minor] Adds backend-generic tensor host materialization through
+  `Tensor::to_vec_on` and `Tensor::to_vec`. Device backends use their canonical
+  `ComputeBackend::copy_to_host` contract, while host-addressable storage keeps
+  the direct path; strided and offset views materialize in logical row-major
+  order.
+
 - [patch] Removes Burn comparison rows and the benchmark-only dependency from
   `coeus-nn` while retaining all 211 NN operation groups and their 424 native
   Sequential/Moirai measurements. The committed lock graph contains no Burn.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,10 @@
 # Coeus Development Roadmap Checklist
 
+## Backend-generic host extraction [minor]
+- [x] Materialize tensor views through the selected backend's host-copy seam.
+- [x] Preserve logical row-major values for offset and strided layouts.
+- [x] Verify 57/57 tensor tests and warning-denied Clippy.
+
 This document tracks the high-level roadmap and feature validation checklist for the Coeus tensor library. For detailed task lists, sprint archives, and progress tracking, see:
 - [docs/checklist.md](file:///d:/coeus/docs/checklist.md)
 - [docs/backlog.md](file:///d:/coeus/docs/backlog.md)

--- a/coeus-tensor/src/tensor.rs
+++ b/coeus-tensor/src/tensor.rs
@@ -158,6 +158,24 @@ impl<T: Scalar, B: ComputeBackend> Tensor<T, B> {
     pub fn is_contiguous(&self) -> bool {
         self.layout.is_contiguous()
     }
+
+    /// Materialize logical tensor values in row-major order on the host.
+    ///
+    /// The backend performs the device-to-host transfer when its storage is
+    /// not directly CPU-addressable. Views are compacted according to their
+    /// layout, so offsets and strides do not leak into the returned buffer.
+    #[must_use]
+    pub fn to_vec_on(&self, backend: &B) -> Vec<T> {
+        if let Some(host_slice) = self.storage.try_as_slice() {
+            return coeus_leto::contiguous_values(&self.layout, host_slice)
+                .expect("tensor host materialization requires a valid layout");
+        }
+
+        let mut physical = vec![T::zero(); Storage::len(&self.storage)];
+        backend.copy_to_host(&self.storage, &mut physical);
+        coeus_leto::contiguous_values(&self.layout, &physical)
+            .expect("tensor host materialization requires a valid layout")
+    }
 }
 
 impl<T: Scalar, B: ComputeBackend> Tensor<T, B>
@@ -219,6 +237,13 @@ where
 }
 
 impl<T: Scalar, B: ComputeBackend + Default> Tensor<T, B> {
+    /// Materialize logical tensor values in row-major order on the host.
+    #[must_use]
+    #[inline]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.to_vec_on(&B::default())
+    }
+
     /// Make this tensor contiguous in-place on the given backend.
     #[inline]
     pub fn make_contiguous_on(&mut self, backend: &B) {

--- a/coeus-tensor/tests/parity_tests.rs
+++ b/coeus-tensor/tests/parity_tests.rs
@@ -309,3 +309,15 @@ fn test_sliced_tensor_reshape_and_reduction() {
     let sum_val = coeus_ops::sum(&slice_a, &backend);
     assert_eq!(sum_val, 18.0); // 3 + 4 + 5 + 6 = 18
 }
+
+#[test]
+fn host_materialization_respects_view_layout() {
+    let values = (0..12).map(|value| value as f32).collect::<Vec<_>>();
+    let tensor = Tensor::<f32, SequentialBackend>::from_slice([3, 4], &values);
+    let view = tensor.slice(&[(0, 3), (1, 4)]).transpose();
+
+    assert_eq!(
+        view.to_vec(),
+        vec![1.0, 5.0, 9.0, 2.0, 6.0, 10.0, 3.0, 7.0, 11.0]
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,16 @@
 # Coeus Project Backlog & Historical Archives
 
+## MS-443 backend-generic host extraction [minor] — done
+
+- Owner: Codex `/root`; scope: `coeus-tensor` host materialization and
+  synchronized Coeus PM records.
+- Acceptance: any `ComputeBackend` can materialize a tensor through its
+  provider-owned device-to-host contract; offset and strided views preserve
+  logical row-major value order without a consumer-owned adapter.
+- Evidence: exact transposed-slice values pass with the complete 57/57
+  `coeus-tensor` Nextest suite; package format and warning-denied all-targets
+  Clippy pass.
+
 ## MS-441 remove tensor legacy benchmark [patch] — done
 
 - Owner: Codex `/root`; scope: `coeus-tensor/Cargo.toml`,

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,15 @@
 # Global Progress Checklist: Coeus
 
+## MS-443 backend-generic host extraction [minor]
+
+- [x] Route non-host storage through `ComputeBackend::copy_to_host`.
+- [x] Compact offset and strided views according to their logical layout.
+- [x] Verify exact transposed-slice values, package format, warning-denied
+      Clippy, and the complete tensor test suite.
+
+**Evidence:** `coeus-tensor` Nextest passes 57/57; format and warning-denied
+all-targets Clippy pass.
+
 ## MS-441 remove tensor Burn benchmark [patch]
 
 - [x] Delete the obsolete legacy-provider dev dependency and comparison


### PR DESCRIPTION
Adds backend-generic tensor host materialization through ComputeBackend::copy_to_host and preserves logical layout for views.\n\nVerification: cargo fmt, clippy -D warnings, 57/57 nextest, rustdoc, and 5/5 doctests.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds backend-agnostic tensor host materialization capabilities to the coeus-tensor library. The implementation introduces `to_vec_on` and `to_vec` methods that extract tensor data to the CPU, properly handling both host-addressable storage (direct path) and device storage (via `ComputeBackend::copy_to_host`). The key feature is that strided and offset views are automatically materialized in logical row-major order, preserving the expected data layout without requiring manual compaction by consumers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coeus-tensor/src/tensor.rs` |
| 2 | `coeus-tensor/tests/parity_tests.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `CHECKLIST.md` |
| 5 | `docs/checklist.md` |
| 6 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added host conversion for tensors through `to_vec()` and backend-aware extraction.
  - Supports tensors stored on different backends, including device-backed storage.
  - Preserves logical row-major ordering for sliced, transposed, strided, and offset views.

- **Bug Fixes**
  - Ensured host materialization returns values in view order rather than physical storage order.

- **Documentation**
  - Updated changelogs and checklists with host extraction behavior and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->