### PR TITLE
feat(coeus-tensor): Add borrowed host access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Changed
 
 - [minor] Adds backend-generic tensor host materialization through
-  `Tensor::to_vec_on` and `Tensor::to_vec`. Device backends use their canonical
-  `ComputeBackend::copy_to_host` contract, while host-addressable storage keeps
-  the direct path; strided and offset views materialize in logical row-major
-  order.
+  `Tensor::to_vec_on`, `Tensor::to_vec`, `Tensor::host_cow_on`, and
+  `Tensor::host_cow`. Device backends use their canonical
+  `ComputeBackend::copy_to_host` contract, contiguous host storage stays
+  borrowed, and strided views materialize in logical row-major order.
 
 - [patch] Removes Burn comparison rows and the benchmark-only dependency from
   `coeus-nn` while retaining all 211 NN operation groups and their 424 native

--- a/coeus-tensor/src/tensor.rs
+++ b/coeus-tensor/src/tensor.rs
@@ -176,6 +176,21 @@ impl<T: Scalar, B: ComputeBackend> Tensor<T, B> {
         coeus_leto::contiguous_values(&self.layout, &physical)
             .expect("tensor host materialization requires a valid layout")
     }
+
+    /// Expose logical row-major host values, borrowing when storage permits.
+    ///
+    /// Contiguous CPU-addressable tensors borrow their storage. Offset,
+    /// strided, and device-backed tensors materialize through the backend.
+    #[must_use]
+    pub fn host_cow_on<'a>(&'a self, backend: &B) -> std::borrow::Cow<'a, [T]> {
+        if self.is_contiguous() {
+            if let Some(host_slice) = self.storage.try_as_slice() {
+                let start = self.layout.offset();
+                return std::borrow::Cow::Borrowed(&host_slice[start..start + self.numel()]);
+            }
+        }
+        std::borrow::Cow::Owned(self.to_vec_on(backend))
+    }
 }
 
 impl<T: Scalar, B: ComputeBackend> Tensor<T, B>
@@ -237,6 +252,13 @@ where
 }
 
 impl<T: Scalar, B: ComputeBackend + Default> Tensor<T, B> {
+    /// Expose logical row-major host values on `B::default()`.
+    #[must_use]
+    #[inline]
+    pub fn host_cow(&self) -> std::borrow::Cow<'_, [T]> {
+        self.host_cow_on(&B::default())
+    }
+
     /// Materialize logical tensor values in row-major order on the host.
     #[must_use]
     #[inline]

--- a/coeus-tensor/tests/parity_tests.rs
+++ b/coeus-tensor/tests/parity_tests.rs
@@ -321,3 +321,25 @@ fn host_materialization_respects_view_layout() {
         vec![1.0, 5.0, 9.0, 2.0, 6.0, 10.0, 3.0, 7.0, 11.0]
     );
 }
+
+#[test]
+fn host_cow_borrows_contiguous_and_materializes_strided_storage() {
+    let values = (0..12).map(|value| value as f32).collect::<Vec<_>>();
+    let tensor = Tensor::<f32, SequentialBackend>::from_slice([3, 4], &values);
+    let contiguous = tensor.slice(&[(1, 3), (0, 4)]);
+    let strided = tensor.slice(&[(0, 3), (1, 4)]).transpose();
+
+    assert!(matches!(
+        contiguous.host_cow(),
+        std::borrow::Cow::Borrowed(_)
+    ));
+    assert_eq!(
+        contiguous.host_cow().as_ref(),
+        &[4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]
+    );
+    assert!(matches!(strided.host_cow(), std::borrow::Cow::Owned(_)));
+    assert_eq!(
+        strided.host_cow().as_ref(),
+        &[1.0, 5.0, 9.0, 2.0, 6.0, 10.0, 3.0, 7.0, 11.0]
+    );
+}


### PR DESCRIPTION
Adds backend-generic host Cow access. Contiguous host storage is borrowed; strided and device storage materialize through the backend.\n\nVerified with formatting, warning-denied Clippy, 58 Nextest tests, five doctests, and Rustdoc.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds **Copy-on-Write (CoW)** host access methods to the tensor API, allowing efficient zero-copy access to contiguous host-backed tensors while gracefully falling back to materialization for strided or device-backed storage. The new `host_cow_on` and `host_cow` methods complement the existing `to_vec_on` and `to_vec` methods by borrowing contiguous CPU-addressable tensor storage when possible, avoiding unnecessary copies. The implementation includes proper documentation and comprehensive test coverage verifying the borrowing behavior for contiguous views and owned materialization for strided layouts.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `coeus-tensor/src/tensor.rs` |
| 3 | `coeus-tensor/tests/parity_tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->