### PR TITLE
ci(coeus): Add Python release wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,0 +1,54 @@
+name: Python Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  wheels:
+    if: startsWith(github.event.release.tag_name, 'coeus-python-v')
+    name: Build and attach wheels
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+    uses: ryancinsight/atlas/.github/workflows/python-wheels.yml@b20a1b494672759c39503daf5687b1de2062f9a0
+    with:
+      distribution: coeus-python
+      import-name: pycoeus
+      manifest-path: coeus-python/Cargo.toml
+      atlas-ref: b20a1b494672759c39503daf5687b1de2062f9a0
+      tag-prefix: coeus-python-v
+      abi3: false
+      python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+
+  publish:
+    if: startsWith(github.event.release.tag_name, 'coeus-python-v')
+    name: Publish wheels to PyPI
+    needs: wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/coeus-python
+    permissions:
+      id-token: write
+    steps:
+      - name: Download validated release wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-wheels
+          path: dist
+
+      - name: Publish wheels through PyPI Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        with:
+          packages-dir: dist/
+          print-hash: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- [patch] GitHub Releases tagged `coeus-python-v<version>` now build, install,
+  attest, and attach locked CPython 3.9–3.13 wheels for Linux, Windows, and
+  macOS, then publish the exact wheel set to PyPI through OIDC.
+
 - [patch] Replaces external sibling paths and repository-owned local patches
   with Git-addressable Atlas provider dependencies, allowing Coeus packages to
   resolve from a standalone Git consumer while the lockfile pins one coherent

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Run doctests separately because nextest does not execute them:
 cargo test --doc --workspace
 ```
 
+## Python Releases
+
+GitHub Releases tagged `coeus-python-v<version>` build locked CPython 3.9–3.13
+wheels for Linux, Windows, and macOS. The workflow installs and imports each
+wheel as `pycoeus`, verifies that its `coeus-python` metadata version matches
+the release tag, attests and attaches the exact wheel set to the GitHub
+Release, then publishes those same artifacts to PyPI through OIDC Trusted
+Publishing. The tag version must equal the workspace Cargo version.
+
 ### Run Clippy Lints
 ```bash
 cargo clippy --all-targets --all-features -- -D warnings

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,21 @@
 # Coeus Project Backlog & Historical Archives
 
+## MS-445 Python release wheels [patch] — in-progress
+
+- Owner: Codex `/root`; scope: the `coeus-python` release workflow, protected
+  GitHub environment, distribution documentation, and PyPI trusted publisher.
+  Python binding behavior is a non-goal.
+- Acceptance: a GitHub Release tagged `coeus-python-v<version>` builds locked
+  Linux, Windows, and universal macOS wheels for CPython 3.9–3.13, installs and
+  imports each wheel as `pycoeus`, validates Cargo-owned distribution identity,
+  attests and attaches the exact artifacts, then publishes the same wheels to
+  the `coeus-python` PyPI project through OIDC.
+- Current evidence: the release workflow and synchronized distribution contract
+  are implemented, and GitHub environment `pypi` accepts only
+  `coeus-python-v*` tags. A locked CPython 3.13 wheel builds as `coeus-python`
+  0.9.0, installs into an isolated target, and imports as `pycoeus`. Hosted CI
+  and pending-publisher registration remain open.
+
 ## MS-444 standalone Git dependency graph [patch] — done
 
 - Owner: Codex `/root`; scope: workspace dependency declarations,

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,17 @@
 # Global Progress Checklist: Coeus
 
+## MS-445 Python release wheels [patch]
+
+- [x] Add the pinned build-once GitHub Release and PyPI workflow.
+- [x] Document the `coeus-python` distribution, `pycoeus` import, Cargo version
+      source, supported CPython range, and OIDC publication contract.
+- [x] Build, install, import, and inspect a production CPython 3.13 wheel
+      locally as `coeus-python` 0.9.0 / `pycoeus`.
+- [x] Create the protected `pypi` environment restricted to
+      `coeus-python-v*` tags.
+- [ ] Pass hosted CI on the exact release-automation head.
+- [ ] Register the PyPI pending trusted publisher.
+
 ## MS-444 standalone Git dependency graph [patch]
 
 - [x] Replace external sibling paths with remote provider identities and retain


### PR DESCRIPTION
## Summary
- build one locked coeus-python wheel set for CPython 3.9-3.13 across Linux, Windows, and macOS
- validate, attest, and attach those wheels to GitHub Releases
- publish the same artifacts through PyPI OIDC
- protect publishing with the coeus-python-v* environment tag policy

## Verification
- cargo metadata --no-deps --locked --format-version 1
- cargo fmt --all -- --check
- maturin build --release --locked --manifest-path coeus-python/Cargo.toml --interpreter D:\miniforge3\python.exe
- isolated install confirms coeus-python 0.9.0 imports as pycoeus
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR sets up automated CI/CD infrastructure for releasing Python wheels of the `coeus-python` package. When a GitHub Release is tagged with `coeus-python-v*`, it will build locked wheels for CPython 3.9-3.13 across Linux, Windows, and macOS, validate and attest them, attach them to the GitHub Release, and publish them to PyPI using OIDC trusted publishing. The workflow is protected by environment policies to ensure only properly tagged releases trigger publication.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
| 2 | `docs/checklist.md` |
| 3 | `docs/backlog.md` |
| 4 | `.github/workflows/python-release.yml` |
| 5 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->