### PR TITLE
Add ROCm and Metal Coeus providers

### DIFF
--- a/.github/workflows/backend-parity.yml
+++ b/.github/workflows/backend-parity.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      run_rocm_hardware:
+        description: Run the ROCm Coeus contracts on the registered AMD runner
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -267,3 +273,343 @@ jobs:
                 -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-cuda --features cuda --doc
             '
+
+  rocm:
+    name: ROCm Coeus provider contracts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      ROCM_IMAGE: rocm/dev-ubuntu-24.04:7.2.4
+    steps:
+      - name: Check out Coeus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: coeus
+          persist-credentials: false
+
+      - name: Check out Apollo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/apollo
+          path: apollo
+          persist-credentials: false
+
+      - name: Check out Aequitas
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/aequitas
+          path: aequitas
+          persist-credentials: false
+
+      - name: Check out Hephaestus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/hephaestus
+          path: hephaestus
+          persist-credentials: false
+
+      - name: Check out Hermes
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/hermes
+          path: hermes
+          persist-credentials: false
+
+      - name: Check out Leto
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/leto
+          path: leto
+          persist-credentials: false
+
+      - name: Check out Melinoe
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/melinoe
+          path: melinoe
+          persist-credentials: false
+
+      - name: Check out Mnemosyne
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/Mnemosyne
+          path: mnemosyne
+          persist-credentials: false
+
+      - name: Check out Moirai
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/Moirai
+          path: moirai
+          persist-credentials: false
+
+      - name: Check out Eunomia
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/eunomia
+          path: eunomia
+          persist-credentials: false
+
+      - name: Check out Themis
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/themis
+          path: themis
+          persist-credentials: false
+
+      - name: Build and test in the AMD ROCm development image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "$ROCM_IMAGE"
+          docker run --rm --network host \
+            --env "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace/coeus \
+            "$ROCM_IMAGE" \
+            bash -c '
+              set -euo pipefail
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install --yes --no-install-recommends ca-certificates curl git build-essential pkg-config rocm-hip-runtime-dev
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+              . "$HOME/.cargo/env"
+              rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+              rustup component add rustfmt clippy --toolchain "$RUST_TOOLCHAIN"
+              rustup toolchain install stable --profile minimal
+              cargo +stable install cargo-nextest --locked
+              mkdir -p /workspace/.cargo
+              cp /workspace/hephaestus/.github/rocm-cargo-config.toml /workspace/.cargo/config.toml
+              rustfmt --check --edition 2024 \
+                crates/coeus-hephaestus/src/lib.rs \
+                crates/coeus-hephaestus/src/error.rs \
+                crates/coeus-hephaestus/src/layout.rs \
+                crates/coeus-hephaestus/src/reduction.rs \
+                crates/coeus-hephaestus/src/storage.rs \
+                crates/coeus-rocm/src/lib.rs \
+                crates/coeus-rocm/src/backend.rs \
+                crates/coeus-rocm/tests/reduction.rs
+              cargo "+$RUST_TOOLCHAIN" update --manifest-path /workspace/coeus/Cargo.toml --workspace
+              cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-hephaestus --all-targets
+              cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-hephaestus --all-targets --no-deps -- -D warnings
+              cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-rocm --features rocm --all-targets
+              cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-rocm --features rocm --all-targets --no-deps -- -D warnings
+              cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-rocm --features rocm \
+                -E "test(native_reductions_and_scans_match_leto)"
+              cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-rocm --features rocm --doc
+            '
+
+  metal:
+    name: Metal Coeus provider contracts
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - name: Check out Coeus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: coeus
+          persist-credentials: false
+
+      - name: Check out Apollo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/apollo
+          path: apollo
+          persist-credentials: false
+
+      - name: Check out Aequitas
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/aequitas
+          path: aequitas
+          persist-credentials: false
+
+      - name: Check out Hephaestus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/hephaestus
+          path: hephaestus
+          persist-credentials: false
+
+      - name: Check out Hermes
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/hermes
+          path: hermes
+          persist-credentials: false
+
+      - name: Check out Leto
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/leto
+          path: leto
+          persist-credentials: false
+
+      - name: Check out Melinoe
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/melinoe
+          path: melinoe
+          persist-credentials: false
+
+      - name: Check out Mnemosyne
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/Mnemosyne
+          path: mnemosyne
+          persist-credentials: false
+
+      - name: Check out Moirai
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/Moirai
+          path: moirai
+          persist-credentials: false
+
+      - name: Check out Eunomia
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/eunomia
+          path: eunomia
+          persist-credentials: false
+
+      - name: Check out Themis
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/themis
+          path: themis
+          persist-credentials: false
+
+      - name: Install the pinned Rust toolchain and nextest
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable action
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy
+
+      - name: Install nextest
+        shell: bash
+        run: cargo install cargo-nextest --locked
+
+      - name: Run Metal and Leto provider contracts
+        working-directory: coeus
+        env:
+          HEPHAESTUS_METAL_REQUIRE_DEVICE: "1"
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/.cargo"
+          sed "s|/workspace|$GITHUB_WORKSPACE|g" \
+            "$GITHUB_WORKSPACE/hephaestus/.github/rocm-cargo-config.toml" \
+            > "$GITHUB_WORKSPACE/.cargo/config.toml"
+          rustfmt --check --edition 2024 \
+            crates/coeus-hephaestus/src/lib.rs \
+            crates/coeus-hephaestus/src/error.rs \
+            crates/coeus-hephaestus/src/layout.rs \
+            crates/coeus-hephaestus/src/reduction.rs \
+            crates/coeus-hephaestus/src/storage.rs \
+            crates/coeus-metal/src/lib.rs \
+            crates/coeus-metal/src/backend.rs \
+            crates/coeus-metal/tests/reduction.rs
+          cargo "+$RUST_TOOLCHAIN" update --manifest-path "$GITHUB_WORKSPACE/coeus/Cargo.toml" --workspace
+          cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-hephaestus --all-targets
+          cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-hephaestus --all-targets --no-deps -- -D warnings
+          cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-metal --all-targets
+          cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-metal --all-targets --no-deps -- -D warnings
+          cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-metal \
+            -E "test(native_reductions_and_scans_match_leto)"
+          cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-metal --doc
+
+  rocm-hardware:
+    name: ROCm Coeus required-device contracts
+    if: github.event_name == 'workflow_dispatch' && inputs.run_rocm_hardware
+    runs-on: [self-hosted, linux, x64, rocm]
+    timeout-minutes: 30
+    steps:
+      - name: Check out Coeus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: coeus
+          persist-credentials: false
+      - name: Check out Apollo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/apollo
+          path: apollo
+          persist-credentials: false
+      - name: Check out Hephaestus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/hephaestus
+          path: hephaestus
+          persist-credentials: false
+      - name: Check out Leto
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/leto
+          path: leto
+          persist-credentials: false
+      - name: Check out Melinoe
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/melinoe
+          path: melinoe
+          persist-credentials: false
+      - name: Check out Hermes
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/hermes
+          path: hermes
+          persist-credentials: false
+      - name: Check out Eunomia
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/eunomia
+          path: eunomia
+          persist-credentials: false
+      - name: Check out Aequitas
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/aequitas
+          path: aequitas
+          persist-credentials: false
+      - name: Check out Themis
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/themis
+          path: themis
+          persist-credentials: false
+      - name: Check out Mnemosyne
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/Mnemosyne
+          path: mnemosyne
+          persist-credentials: false
+      - name: Check out Moirai
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ryancinsight/Moirai
+          path: moirai
+          persist-credentials: false
+      - name: Install the pinned Rust toolchain and nextest
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable action
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy
+      - name: Install nextest
+        shell: bash
+        run: cargo install cargo-nextest --locked
+      - name: Configure the checkout-local Cargo graph
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/.cargo"
+          sed "s|/workspace|$GITHUB_WORKSPACE|g" \
+            "$GITHUB_WORKSPACE/hephaestus/.github/rocm-cargo-config.toml" \
+            > "$GITHUB_WORKSPACE/.cargo/config.toml"
+          cargo "+$RUST_TOOLCHAIN" update --manifest-path "$GITHUB_WORKSPACE/coeus/Cargo.toml" --workspace
+      - name: Run required-device ROCm provider contracts
+        working-directory: coeus
+        env:
+          HEPHAESTUS_ROCM_REQUIRE_DEVICE: "1"
+        run: cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-rocm --features rocm \
+          -E "test(native_reductions_and_scans_match_leto)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,11 +540,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "coeus-hephaestus"
+version = "0.9.0"
+dependencies = [
+ "bytemuck",
+ "coeus-core",
+ "coeus-ops",
+ "hephaestus-core",
+ "leto",
+ "leto-ops",
+ "themis",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "coeus-leto"
 version = "0.9.0"
 dependencies = [
  "coeus-core",
  "leto",
+ "leto-ops",
+]
+
+[[package]]
+name = "coeus-metal"
+version = "0.9.0"
+dependencies = [
+ "coeus-core",
+ "coeus-hephaestus",
+ "coeus-leto",
+ "coeus-ops",
+ "hephaestus-core",
+ "hephaestus-metal",
  "leto-ops",
 ]
 
@@ -609,6 +636,19 @@ dependencies = [
  "moirai",
  "pyo3",
  "smallvec",
+]
+
+[[package]]
+name = "coeus-rocm"
+version = "0.9.0"
+dependencies = [
+ "coeus-core",
+ "coeus-hephaestus",
+ "coeus-leto",
+ "coeus-ops",
+ "hephaestus-core",
+ "hephaestus-rocm",
+ "leto-ops",
 ]
 
 [[package]]
@@ -766,6 +806,16 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cubecl-hip-sys"
+version = "7.2.5321100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58887c6d217859c2261a868a3a6b66aa8f44ea2f4bfa51d0dbe4dcb0d1f5768d"
+dependencies = [
+ "libc",
+ "regex",
 ]
 
 [[package]]
@@ -1222,6 +1272,38 @@ dependencies = [
  "mnemosyne-core",
  "moirai-gpu",
  "moirai-sync",
+ "themis",
+]
+
+[[package]]
+name = "hephaestus-metal"
+version = "0.18.0"
+dependencies = [
+ "aequitas",
+ "bytemuck",
+ "eunomia",
+ "hephaestus-core",
+ "hephaestus-wgpu",
+ "leto",
+ "leto-ops",
+ "mnemosyne-core",
+ "moirai-gpu",
+ "moirai-sync",
+ "themis",
+ "wgpu",
+]
+
+[[package]]
+name = "hephaestus-rocm"
+version = "0.18.0"
+dependencies = [
+ "aequitas",
+ "bytemuck",
+ "cubecl-hip-sys",
+ "eunomia",
+ "hephaestus-core",
+ "leto",
+ "leto-ops",
  "themis",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ members = [
     "crates/coeus-sparse",
     "crates/coeus-wgpu",
     "crates/coeus-cuda",
+    "crates/coeus-hephaestus",
+    "crates/coeus-rocm",
+    "crates/coeus-metal",
     "crates/coeus-dist",
     "crates/coeus-leto",
     "crates/coeus-fft",
@@ -54,6 +57,8 @@ wgpu       = { version = "30.0", default-features = false, features = ["wgsl", "
 hephaestus-wgpu = { path = "../hephaestus/crates/hephaestus-wgpu" }
 hephaestus-core = { path = "../hephaestus/crates/hephaestus-core" }
 hephaestus-cuda = { path = "../hephaestus/crates/hephaestus-cuda" }
+hephaestus-rocm = { path = "../hephaestus/crates/hephaestus-rocm" }
+hephaestus-metal = { path = "../hephaestus/crates/hephaestus-metal" }
 themis = { path = "../themis", version = "0.10.1" }
 melinoe = { path = "../melinoe", version = "0.9.0" }
 

--- a/crates/coeus-hephaestus/Cargo.toml
+++ b/crates/coeus-hephaestus/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "coeus-hephaestus"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Generic Coeus integration layer for Hephaestus device providers."
+
+[dependencies]
+coeus-core = { workspace = true }
+coeus-ops = { workspace = true, default-features = false }
+hephaestus-core = { workspace = true }
+leto = { workspace = true }
+leto-ops = { workspace = true }
+bytemuck = { workspace = true }
+themis = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/coeus-hephaestus/src/error.rs
+++ b/crates/coeus-hephaestus/src/error.rs
@@ -1,0 +1,27 @@
+use coeus_core::BackendError;
+use hephaestus_core::HephaestusError;
+use thiserror::Error;
+
+/// Error returned by the generic Coeus-Hephaestus integration boundary.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum HephaestusBackendError {
+    /// A Coeus layout or storage contract rejected the operation.
+    #[error(transparent)]
+    Backend(#[from] BackendError),
+    /// The selected Hephaestus provider rejected device execution or transfer.
+    #[error("{operation} Hephaestus dispatch failed: {source}")]
+    Device {
+        /// Operation family that reached the provider.
+        operation: &'static str,
+        /// Provider error with its original failure category preserved.
+        #[source]
+        source: HephaestusError,
+    },
+}
+
+impl HephaestusBackendError {
+    pub(crate) fn device(operation: &'static str, source: HephaestusError) -> Self {
+        Self::Device { operation, source }
+    }
+}

--- a/crates/coeus-hephaestus/src/layout.rs
+++ b/crates/coeus-hephaestus/src/layout.rs
@@ -1,0 +1,37 @@
+use coeus_core::{BackendError, Layout};
+use leto::Layout as LetoLayout;
+
+/// Convert a Coeus layout to the rank-2 layout consumed by the current
+/// Hephaestus reduction and scan kernels.
+pub(crate) fn rank_two(
+    operation: &'static str,
+    layout: &Layout,
+) -> Result<LetoLayout<2>, BackendError> {
+    let [rows, columns] = layout.shape() else {
+        return Err(BackendError::UnsupportedRank {
+            operation,
+            rank: layout.ndim(),
+            max_rank: 2,
+        });
+    };
+    let [row_stride, column_stride] = layout.strides() else {
+        return Err(BackendError::LayoutRankMismatch {
+            operation,
+            lhs: layout.shape().len(),
+            rhs: layout.strides().len(),
+        });
+    };
+    let row_stride = isize::try_from(*row_stride).map_err(|_| BackendError::Overflow {
+        operation,
+        reason: "row stride exceeds isize range",
+    })?;
+    let column_stride = isize::try_from(*column_stride).map_err(|_| BackendError::Overflow {
+        operation,
+        reason: "column stride exceeds isize range",
+    })?;
+    Ok(LetoLayout::new(
+        [*rows, *columns],
+        [row_stride, column_stride],
+        layout.offset(),
+    ))
+}

--- a/crates/coeus-hephaestus/src/lib.rs
+++ b/crates/coeus-hephaestus/src/lib.rs
@@ -1,0 +1,17 @@
+//! Generic Coeus integration for Hephaestus device providers.
+//!
+//! This crate owns storage, transfer, layout validation, and the Coeus
+//! reduction/scan dispatch contract once. Vendor crates implement
+//! [`HephaestusProvider`] and the scalar-specific [`ReductionProvider`] seam;
+//! they do not copy the consumer-side operation orchestration.
+#![deny(missing_docs)]
+
+mod error;
+mod layout;
+mod reduction;
+mod storage;
+
+pub use error::HephaestusBackendError;
+pub use reduction::HephaestusBackend;
+pub use reduction::{HephaestusProvider, RankTwoOperand, ReductionProvider, ScanOperation};
+pub use storage::HephaestusStorage;

--- a/crates/coeus-hephaestus/src/reduction.rs
+++ b/crates/coeus-hephaestus/src/reduction.rs
@@ -1,0 +1,295 @@
+use crate::{error::HephaestusBackendError, layout::rank_two, storage::HephaestusStorage};
+use coeus_core::{ComputeBackend, Layout, Scalar};
+use coeus_ops::ReductionOp;
+use hephaestus_core::{ComputeDevice, DeviceBuffer, ScanDirection};
+use leto::Layout as LetoLayout;
+use std::future::Ready;
+
+/// Common provider identity and device acquisition seam.
+///
+/// # Safety
+///
+/// An implementation must ensure that every typed buffer exposed by its
+/// [`hephaestus_core::ComputeDevice`] remains safe to retain behind an
+/// `Arc` and to move between Coeus worker threads. Provider kernels must also
+/// synchronize access according to their device API's contract.
+pub unsafe trait HephaestusProvider: Send + Sync + Clone + Copy + Default + 'static {
+    /// Concrete Hephaestus device type selected by this provider.
+    type Device: ComputeDevice + Send + Sync + 'static;
+
+    /// Stable backend name used by Coeus diagnostics.
+    const NAME: &'static str;
+
+    /// Return the lazily acquired device owned by this provider.
+    fn device() -> &'static Self::Device;
+}
+
+/// Cumulative operation selected by a provider scan dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanOperation {
+    /// Inclusive cumulative addition.
+    Sum,
+    /// Inclusive cumulative multiplication.
+    Product,
+}
+
+/// A rank-2 Hephaestus buffer paired with its logical Leto layout.
+#[derive(Clone, Copy)]
+pub struct RankTwoOperand<'a, B> {
+    /// Typed device buffer handle.
+    pub buffer: &'a B,
+    /// Logical shape, strides, and offset.
+    pub layout: &'a LetoLayout<2>,
+}
+
+/// Provider implementation of scalar-specific rank-2 reduction and scan
+/// kernels.
+pub trait ReductionProvider<T>: HephaestusProvider
+where
+    T: Scalar + leto_ops::Scalar,
+{
+    /// Reduce a rank-2 strided input into a keep-dimension output.
+    fn reduce(
+        device: &Self::Device,
+        op: ReductionOp,
+        input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+        axis: usize,
+        output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+    ) -> hephaestus_core::Result<()>;
+
+    /// Execute an inclusive prefix or suffix scan over a rank-2 strided input.
+    fn scan(
+        device: &Self::Device,
+        input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+        axis: usize,
+        operation: ScanOperation,
+        direction: ScanDirection,
+        output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+    ) -> hephaestus_core::Result<()>;
+}
+
+/// Generic Coeus backend implementation over one Hephaestus provider.
+#[derive(Debug)]
+pub struct HephaestusBackend<P>(std::marker::PhantomData<P>);
+
+struct ScanRequest<'a, P, T>
+where
+    P: HephaestusProvider,
+    T: bytemuck::Pod,
+{
+    input: &'a HephaestusStorage<P, T>,
+    input_layout: &'a Layout,
+    axis: usize,
+    operation_kind: ScanOperation,
+    direction: ScanDirection,
+    output: &'a mut HephaestusStorage<P, T>,
+    output_layout: &'a Layout,
+    operation: &'static str,
+}
+
+impl<P> Copy for HephaestusBackend<P> {}
+
+impl<P> Clone for HephaestusBackend<P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<P> Default for HephaestusBackend<P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<P> HephaestusBackend<P> {
+    /// Construct the zero-sized generic backend selector.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(std::marker::PhantomData)
+    }
+}
+
+impl<P> coeus_core::backend::private::Sealed for HephaestusBackend<P> where P: HephaestusProvider {}
+
+impl<P> ComputeBackend for HephaestusBackend<P>
+where
+    P: HephaestusProvider,
+{
+    type Error = HephaestusBackendError;
+    type DeviceBuffer<T: Scalar> = HephaestusStorage<P, T>;
+    type KernelDescriptor = ();
+    type DispatchFuture<T: Scalar> = Ready<T>;
+
+    fn name(&self) -> &'static str {
+        P::NAME
+    }
+
+    fn num_threads(&self) -> usize {
+        1
+    }
+
+    fn allocate<T: Scalar>(&self, len: usize) -> Self::DeviceBuffer<T> {
+        HephaestusStorage::new(len)
+    }
+
+    fn fill<T: Scalar>(&self, dst: &mut Self::DeviceBuffer<T>, val: T) {
+        let values = vec![val; dst.buffer().len()];
+        P::device()
+            .write_buffer(dst.buffer(), &values)
+            .expect("Hephaestus fill failed");
+    }
+
+    fn copy_to_device<T: Scalar>(&self, src: &[T], dst: &mut Self::DeviceBuffer<T>) {
+        P::device()
+            .write_buffer(dst.buffer(), src)
+            .expect("Hephaestus host-to-device copy failed");
+    }
+
+    fn copy_to_host<T: Scalar>(&self, src: &Self::DeviceBuffer<T>, dst: &mut [T]) {
+        P::device()
+            .download(src.buffer(), dst)
+            .expect("Hephaestus device-to-host copy failed");
+    }
+}
+
+impl<P, T> coeus_ops::ReductionOps<T> for HephaestusBackend<P>
+where
+    P: ReductionProvider<T>,
+    T: Scalar + leto_ops::Scalar,
+{
+    fn reduce(
+        &self,
+        op: ReductionOp,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        let input_layout = rank_two("reduce", a_layout)?;
+        let output_layout = rank_two("reduce", c_layout)?;
+        P::reduce(
+            P::device(),
+            op,
+            RankTwoOperand {
+                buffer: a.buffer(),
+                layout: &input_layout,
+            },
+            axis,
+            RankTwoOperand {
+                buffer: c.buffer(),
+                layout: &output_layout,
+            },
+        )
+        .map_err(|source| HephaestusBackendError::device("reduce", source))
+    }
+
+    fn cumsum(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.scan(ScanRequest {
+            input: a,
+            input_layout: a_layout,
+            axis,
+            operation_kind: ScanOperation::Sum,
+            direction: ScanDirection::Forward,
+            output: c,
+            output_layout: c_layout,
+            operation: "cumsum",
+        })
+    }
+
+    fn suffix_sum(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.scan(ScanRequest {
+            input: a,
+            input_layout: a_layout,
+            axis,
+            operation_kind: ScanOperation::Sum,
+            direction: ScanDirection::Reverse,
+            output: c,
+            output_layout: c_layout,
+            operation: "suffix_sum",
+        })
+    }
+
+    fn cumprod(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.scan(ScanRequest {
+            input: a,
+            input_layout: a_layout,
+            axis,
+            operation_kind: ScanOperation::Product,
+            direction: ScanDirection::Forward,
+            output: c,
+            output_layout: c_layout,
+            operation: "cumprod",
+        })
+    }
+
+    fn suffix_prod(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.scan(ScanRequest {
+            input: a,
+            input_layout: a_layout,
+            axis,
+            operation_kind: ScanOperation::Product,
+            direction: ScanDirection::Reverse,
+            output: c,
+            output_layout: c_layout,
+            operation: "suffix_prod",
+        })
+    }
+}
+
+impl<P> HephaestusBackend<P>
+where
+    P: HephaestusProvider,
+{
+    fn scan<T>(&self, request: ScanRequest<'_, P, T>) -> Result<(), HephaestusBackendError>
+    where
+        P: ReductionProvider<T>,
+        T: Scalar + leto_ops::Scalar,
+    {
+        let input_layout = rank_two(request.operation, request.input_layout)?;
+        let output_layout = rank_two(request.operation, request.output_layout)?;
+        P::scan(
+            P::device(),
+            RankTwoOperand {
+                buffer: request.input.buffer(),
+                layout: &input_layout,
+            },
+            request.axis,
+            request.operation_kind,
+            request.direction,
+            RankTwoOperand {
+                buffer: request.output.buffer(),
+                layout: &output_layout,
+            },
+        )
+        .map_err(|source| HephaestusBackendError::device(request.operation, source))
+    }
+}

--- a/crates/coeus-hephaestus/src/storage.rs
+++ b/crates/coeus-hephaestus/src/storage.rs
@@ -1,0 +1,119 @@
+use crate::reduction::HephaestusProvider;
+use coeus_core::{Scalar, Storage, StorageMut};
+use hephaestus_core::{ComputeDevice, DeviceBuffer};
+use std::{marker::PhantomData, sync::Arc};
+use themis::{MemoryTier, PlacementHint};
+
+/// Reference-counted Coeus storage backed by one Hephaestus device buffer.
+pub struct HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: bytemuck::Pod,
+{
+    pub(crate) buffer: Arc<<P::Device as ComputeDevice>::Buffer<T>>,
+    marker: PhantomData<P>,
+}
+
+impl<P, T> Clone for HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: bytemuck::Pod,
+{
+    fn clone(&self) -> Self {
+        Self {
+            buffer: Arc::clone(&self.buffer),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, T> HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: Scalar + bytemuck::Pod,
+{
+    /// Allocate zeroed storage in the provider's device tier.
+    #[must_use]
+    pub fn new(len: usize) -> Self {
+        let buffer = P::device()
+            .alloc_zeroed_with_hint(len, PlacementHint::Tier(MemoryTier::Device))
+            .expect("Hephaestus provider allocation failed");
+        Self {
+            buffer: Arc::new(buffer),
+            marker: PhantomData,
+        }
+    }
+
+    /// Borrow the typed Hephaestus buffer for provider dispatch.
+    #[must_use]
+    pub fn buffer(&self) -> &<P::Device as ComputeDevice>::Buffer<T> {
+        self.buffer.as_ref()
+    }
+}
+
+impl<P, T> coeus_core::storage::private::Sealed for HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: bytemuck::Pod,
+{
+}
+
+// SAFETY: `HephaestusProvider` requires its device buffers to be safe to move
+// between threads while the provider owns the device synchronization contract.
+unsafe impl<P, T> Send for HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: bytemuck::Pod + Send,
+{
+}
+
+// SAFETY: `HephaestusProvider` requires shared buffer handles to be safe to
+// retain behind an Arc; mutable access remains mediated by `StorageMut`.
+unsafe impl<P, T> Sync for HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: bytemuck::Pod + Sync,
+{
+}
+
+impl<P, T> Storage<T> for HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: Scalar + bytemuck::Pod,
+{
+    fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    fn allocate(len: usize) -> Self {
+        Self::new(len)
+    }
+
+    fn try_as_slice(&self) -> Option<&[T]> {
+        None
+    }
+}
+
+impl<P, T> StorageMut<T> for HephaestusStorage<P, T>
+where
+    P: HephaestusProvider,
+    T: Scalar + bytemuck::Pod,
+{
+    fn try_as_mut_slice(&mut self) -> Option<&mut [T]> {
+        None
+    }
+
+    fn make_unique(&mut self) {
+        if Arc::strong_count(&self.buffer) <= 1 {
+            return;
+        }
+        let mut host = vec![T::zero(); self.buffer.len()];
+        P::device()
+            .download(self.buffer.as_ref(), &mut host)
+            .expect("Hephaestus storage uniqueness download failed");
+        let replacement = P::device()
+            .upload(&host)
+            .expect("Hephaestus storage uniqueness upload failed");
+        self.buffer = Arc::new(replacement);
+    }
+}

--- a/crates/coeus-metal/Cargo.toml
+++ b/crates/coeus-metal/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "coeus-metal"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Metal backend integration for Coeus through Hephaestus."
+
+[dependencies]
+coeus-core = { workspace = true }
+coeus-hephaestus = { path = "../coeus-hephaestus" }
+coeus-ops = { workspace = true, default-features = false }
+hephaestus-core = { workspace = true }
+hephaestus-metal = { workspace = true }
+leto-ops = { workspace = true }
+
+[dev-dependencies]
+coeus-leto = { path = "../coeus-leto" }

--- a/crates/coeus-metal/src/backend.rs
+++ b/crates/coeus-metal/src/backend.rs
@@ -1,0 +1,236 @@
+use coeus_core::{ComputeBackend, Layout, Scalar};
+use coeus_hephaestus::{
+    HephaestusBackend, HephaestusBackendError, HephaestusProvider, HephaestusStorage,
+    RankTwoOperand, ReductionProvider, ScanOperation,
+};
+use coeus_ops::{ReductionOp, ReductionOps};
+use hephaestus_core::{ComputeDevice, ScanDirection};
+use hephaestus_metal::{MetalDevice, StridedOperand};
+use std::sync::OnceLock;
+
+/// Provider marker for the native Metal device.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MetalProvider;
+
+// SAFETY: Metal buffers retain the WGPU/Metal device context and WGPU queue
+// submission supplies the synchronization boundary required by the handle.
+unsafe impl HephaestusProvider for MetalProvider {
+    type Device = MetalDevice;
+    const NAME: &'static str = "metal";
+
+    fn device() -> &'static Self::Device {
+        static DEVICE: OnceLock<MetalDevice> = OnceLock::new();
+        DEVICE.get_or_init(|| MetalDevice::try_default().expect("Metal device acquisition failed"))
+    }
+}
+
+macro_rules! impl_reduction_provider {
+    ($scalar:ty) => {
+        impl ReductionProvider<$scalar> for MetalProvider {
+            fn reduce(
+                device: &Self::Device,
+                op: ReductionOp,
+                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                axis: usize,
+                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+            ) -> hephaestus_core::Result<()> {
+                let input = StridedOperand {
+                    buffer: input.buffer,
+                    layout: input.layout,
+                };
+                let output = StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match op {
+                    ReductionOp::Sum => hephaestus_metal::sum_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Prod => hephaestus_metal::prod_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Mean => hephaestus_metal::mean_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Max => hephaestus_metal::max_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Min => hephaestus_metal::min_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                }
+            }
+
+            fn scan(
+                device: &Self::Device,
+                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                axis: usize,
+                operation: ScanOperation,
+                direction: ScanDirection,
+                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+            ) -> hephaestus_core::Result<()> {
+                let input = StridedOperand {
+                    buffer: input.buffer,
+                    layout: input.layout,
+                };
+                let output = StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match operation {
+                    ScanOperation::Sum => {
+                        hephaestus_metal::scan_axis_into::<hephaestus_metal::CumSumOp, $scalar>(
+                            device,
+                            input,
+                            axis,
+                            direction,
+                            output,
+                            hephaestus_core::BlockWidth::DEFAULT,
+                        )
+                    }
+                    ScanOperation::Product => {
+                        hephaestus_metal::scan_axis_into::<hephaestus_metal::CumProdOp, $scalar>(
+                            device,
+                            input,
+                            axis,
+                            direction,
+                            output,
+                            hephaestus_core::BlockWidth::DEFAULT,
+                        )
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_reduction_provider!(f32);
+impl_reduction_provider!(u32);
+impl_reduction_provider!(i32);
+
+/// Coeus Metal backend with native Hephaestus storage and rank-2 reductions.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MetalBackend(HephaestusBackend<MetalProvider>);
+
+impl coeus_core::backend::private::Sealed for MetalBackend {}
+
+impl MetalBackend {
+    /// Construct the Metal backend selector.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(HephaestusBackend::new())
+    }
+}
+
+impl ComputeBackend for MetalBackend {
+    type Error = HephaestusBackendError;
+    type DeviceBuffer<T: Scalar> = HephaestusStorage<MetalProvider, T>;
+    type KernelDescriptor = ();
+    type DispatchFuture<T: Scalar> = std::future::Ready<T>;
+
+    fn name(&self) -> &'static str {
+        self.0.name()
+    }
+
+    fn num_threads(&self) -> usize {
+        self.0.num_threads()
+    }
+
+    fn allocate<T: Scalar>(&self, len: usize) -> Self::DeviceBuffer<T> {
+        self.0.allocate(len)
+    }
+
+    fn fill<T: Scalar>(&self, dst: &mut Self::DeviceBuffer<T>, val: T) {
+        self.0.fill(dst, val)
+    }
+
+    fn copy_to_device<T: Scalar>(&self, src: &[T], dst: &mut Self::DeviceBuffer<T>) {
+        self.0.copy_to_device(src, dst)
+    }
+
+    fn copy_to_host<T: Scalar>(&self, src: &Self::DeviceBuffer<T>, dst: &mut [T]) {
+        self.0.copy_to_host(src, dst)
+    }
+}
+
+impl<T> ReductionOps<T> for MetalBackend
+where
+    T: Scalar + leto_ops::Scalar,
+    MetalProvider: ReductionProvider<T>,
+{
+    fn reduce(
+        &self,
+        op: ReductionOp,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.reduce(op, a, a_layout, axis, c, c_layout)
+    }
+
+    fn cumsum(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.cumsum(a, a_layout, axis, c, c_layout)
+    }
+
+    fn suffix_sum(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.suffix_sum(a, a_layout, axis, c, c_layout)
+    }
+
+    fn cumprod(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.cumprod(a, a_layout, axis, c, c_layout)
+    }
+
+    fn suffix_prod(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.suffix_prod(a, a_layout, axis, c, c_layout)
+    }
+}

--- a/crates/coeus-metal/src/lib.rs
+++ b/crates/coeus-metal/src/lib.rs
@@ -1,0 +1,10 @@
+//! Coeus Metal backend integration through the Hephaestus Metal provider.
+//!
+//! The backend currently exposes the native rank-2 reduction and cumulative
+//! scan/product contract. It uses the shared Coeus-Hephaestus storage and
+//! dispatch layer, with no host fallback for unsupported layouts.
+#![deny(missing_docs)]
+
+mod backend;
+
+pub use backend::{MetalBackend, MetalProvider};

--- a/crates/coeus-metal/tests/reduction.rs
+++ b/crates/coeus-metal/tests/reduction.rs
@@ -1,0 +1,124 @@
+use coeus_core::{ComputeBackend, Layout, ReductionOp};
+use coeus_metal::MetalBackend;
+use coeus_ops::ReductionOps;
+
+fn require_device() {
+    if hephaestus_metal::MetalDevice::try_default().is_err() {
+        assert_ne!(
+            std::env::var("HEPHAESTUS_METAL_REQUIRE_DEVICE").as_deref(),
+            Ok("1"),
+            "Metal CI requires an acquired device"
+        );
+    }
+}
+
+#[test]
+fn native_reductions_and_scans_match_leto() {
+    require_device();
+    if hephaestus_metal::MetalDevice::try_default().is_err() {
+        return;
+    }
+
+    let backend = MetalBackend::new();
+    assert_eq!(backend.name(), "metal");
+    let layout = Layout::new([2, 3].into());
+    let input = [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let mut device_input = backend.allocate::<f32>(input.len());
+    backend.copy_to_device(&input, &mut device_input);
+
+    for (op, expected) in [
+        (ReductionOp::Sum, [6.0_f32, 15.0]),
+        (ReductionOp::Prod, [6.0_f32, 120.0]),
+        (ReductionOp::Mean, [2.0_f32, 5.0]),
+        (ReductionOp::Min, [1.0_f32, 4.0]),
+        (ReductionOp::Max, [3.0_f32, 6.0]),
+    ] {
+        let mut expected_values = [0.0_f32; 2];
+        coeus_leto::reduce_into(
+            op,
+            &layout,
+            &input,
+            1,
+            &Layout::new([2, 1].into()),
+            &mut expected_values,
+        )
+        .expect("Leto reduction oracle failed");
+        assert_eq!(expected_values, expected, "Leto oracle contract");
+
+        let mut actual = backend.allocate::<f32>(2);
+        ReductionOps::reduce(
+            &backend,
+            op,
+            &device_input,
+            &layout,
+            1,
+            &mut actual,
+            &Layout::new([2, 1].into()),
+        )
+        .expect("Metal reduction failed");
+        let mut actual_values = [0.0_f32; 2];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_eq!(actual_values, expected_values, "Metal {op:?} parity");
+    }
+
+    let mut expected_scan = [0.0_f32; 6];
+    coeus_leto::cumsum_into(&layout, &input, 1, &layout, &mut expected_scan)
+        .expect("Leto cumulative-sum oracle failed");
+    let mut scan = backend.allocate::<f32>(input.len());
+    ReductionOps::cumsum(&backend, &device_input, &layout, 1, &mut scan, &layout)
+        .expect("Metal cumulative sum failed");
+    let mut actual_scan = [0.0_f32; 6];
+    backend.copy_to_host(&scan, &mut actual_scan);
+    assert_eq!(actual_scan, expected_scan);
+
+    let mut expected_suffix_sum = [0.0_f32; 6];
+    coeus_leto::suffix_sum_into(&layout, &input, 1, &layout, &mut expected_suffix_sum)
+        .expect("Leto suffix-sum oracle failed");
+    let mut suffix_sum = backend.allocate::<f32>(input.len());
+    ReductionOps::suffix_sum(
+        &backend,
+        &device_input,
+        &layout,
+        1,
+        &mut suffix_sum,
+        &layout,
+    )
+    .expect("Metal suffix sum failed");
+    let mut actual_suffix_sum = [0.0_f32; 6];
+    backend.copy_to_host(&suffix_sum, &mut actual_suffix_sum);
+    assert_eq!(actual_suffix_sum, expected_suffix_sum);
+
+    let mut expected_product_scan = [0.0_f32; 6];
+    coeus_leto::cumprod_into(&layout, &input, 1, &layout, &mut expected_product_scan)
+        .expect("Leto cumulative-product oracle failed");
+    let mut product_scan = backend.allocate::<f32>(input.len());
+    ReductionOps::cumprod(
+        &backend,
+        &device_input,
+        &layout,
+        1,
+        &mut product_scan,
+        &layout,
+    )
+    .expect("Metal cumulative product failed");
+    let mut actual_product_scan = [0.0_f32; 6];
+    backend.copy_to_host(&product_scan, &mut actual_product_scan);
+    assert_eq!(actual_product_scan, expected_product_scan);
+
+    let mut expected_suffix_product = [0.0_f32; 6];
+    coeus_leto::suffix_prod_into(&layout, &input, 1, &layout, &mut expected_suffix_product)
+        .expect("Leto suffix-product oracle failed");
+    let mut suffix_product = backend.allocate::<f32>(input.len());
+    ReductionOps::suffix_prod(
+        &backend,
+        &device_input,
+        &layout,
+        1,
+        &mut suffix_product,
+        &layout,
+    )
+    .expect("Metal suffix product failed");
+    let mut actual_suffix_product = [0.0_f32; 6];
+    backend.copy_to_host(&suffix_product, &mut actual_suffix_product);
+    assert_eq!(actual_suffix_product, expected_suffix_product);
+}

--- a/crates/coeus-rocm/Cargo.toml
+++ b/crates/coeus-rocm/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "coeus-rocm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "ROCm backend integration for Coeus through Hephaestus."
+
+[features]
+default = []
+rocm = ["hephaestus-rocm/rocm"]
+
+[dependencies]
+coeus-core = { workspace = true }
+coeus-hephaestus = { path = "../coeus-hephaestus" }
+coeus-ops = { workspace = true, default-features = false }
+hephaestus-core = { workspace = true }
+hephaestus-rocm = { workspace = true }
+leto-ops = { workspace = true }
+
+[dev-dependencies]
+coeus-leto = { path = "../coeus-leto" }

--- a/crates/coeus-rocm/src/backend.rs
+++ b/crates/coeus-rocm/src/backend.rs
@@ -1,0 +1,236 @@
+use coeus_core::{ComputeBackend, Layout, Scalar};
+use coeus_hephaestus::{
+    HephaestusBackend, HephaestusBackendError, HephaestusProvider, HephaestusStorage,
+    RankTwoOperand, ReductionProvider, ScanOperation,
+};
+use coeus_ops::{ReductionOp, ReductionOps};
+use hephaestus_core::{ComputeDevice, ScanDirection};
+use hephaestus_rocm::{RocmDevice, StridedOperand};
+use std::sync::OnceLock;
+
+/// Provider marker for the native ROCm device.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RocmProvider;
+
+// SAFETY: ROCm buffers retain their owning context and HIP launches bind that
+// context before accessing the allocation; the handle is thread-transferable.
+unsafe impl HephaestusProvider for RocmProvider {
+    type Device = RocmDevice;
+    const NAME: &'static str = "rocm";
+
+    fn device() -> &'static Self::Device {
+        static DEVICE: OnceLock<RocmDevice> = OnceLock::new();
+        DEVICE.get_or_init(|| RocmDevice::try_default().expect("ROCm device acquisition failed"))
+    }
+}
+
+macro_rules! impl_reduction_provider {
+    ($scalar:ty) => {
+        impl ReductionProvider<$scalar> for RocmProvider {
+            fn reduce(
+                device: &Self::Device,
+                op: ReductionOp,
+                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                axis: usize,
+                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+            ) -> hephaestus_core::Result<()> {
+                let input = StridedOperand {
+                    buffer: input.buffer,
+                    layout: input.layout,
+                };
+                let output = StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match op {
+                    ReductionOp::Sum => hephaestus_rocm::sum_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Prod => hephaestus_rocm::prod_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Mean => hephaestus_rocm::mean_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Max => hephaestus_rocm::max_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    ReductionOp::Min => hephaestus_rocm::min_axis_into::<$scalar>(
+                        device,
+                        input,
+                        axis,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                }
+            }
+
+            fn scan(
+                device: &Self::Device,
+                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                axis: usize,
+                operation: ScanOperation,
+                direction: ScanDirection,
+                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+            ) -> hephaestus_core::Result<()> {
+                let input = StridedOperand {
+                    buffer: input.buffer,
+                    layout: input.layout,
+                };
+                let output = StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match operation {
+                    ScanOperation::Sum => {
+                        hephaestus_rocm::scan_axis_into::<hephaestus_rocm::CumSumOp, $scalar>(
+                            device,
+                            input,
+                            axis,
+                            direction,
+                            output,
+                            hephaestus_core::BlockWidth::DEFAULT,
+                        )
+                    }
+                    ScanOperation::Product => {
+                        hephaestus_rocm::scan_axis_into::<hephaestus_rocm::CumProdOp, $scalar>(
+                            device,
+                            input,
+                            axis,
+                            direction,
+                            output,
+                            hephaestus_core::BlockWidth::DEFAULT,
+                        )
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_reduction_provider!(f32);
+impl_reduction_provider!(u32);
+impl_reduction_provider!(i32);
+
+/// Coeus ROCm backend with native Hephaestus storage and rank-2 reductions.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RocmBackend(HephaestusBackend<RocmProvider>);
+
+impl coeus_core::backend::private::Sealed for RocmBackend {}
+
+impl RocmBackend {
+    /// Construct the ROCm backend selector.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(HephaestusBackend::new())
+    }
+}
+
+impl ComputeBackend for RocmBackend {
+    type Error = HephaestusBackendError;
+    type DeviceBuffer<T: Scalar> = HephaestusStorage<RocmProvider, T>;
+    type KernelDescriptor = ();
+    type DispatchFuture<T: Scalar> = std::future::Ready<T>;
+
+    fn name(&self) -> &'static str {
+        self.0.name()
+    }
+
+    fn num_threads(&self) -> usize {
+        self.0.num_threads()
+    }
+
+    fn allocate<T: Scalar>(&self, len: usize) -> Self::DeviceBuffer<T> {
+        self.0.allocate(len)
+    }
+
+    fn fill<T: Scalar>(&self, dst: &mut Self::DeviceBuffer<T>, val: T) {
+        self.0.fill(dst, val)
+    }
+
+    fn copy_to_device<T: Scalar>(&self, src: &[T], dst: &mut Self::DeviceBuffer<T>) {
+        self.0.copy_to_device(src, dst)
+    }
+
+    fn copy_to_host<T: Scalar>(&self, src: &Self::DeviceBuffer<T>, dst: &mut [T]) {
+        self.0.copy_to_host(src, dst)
+    }
+}
+
+impl<T> ReductionOps<T> for RocmBackend
+where
+    T: Scalar + leto_ops::Scalar,
+    RocmProvider: ReductionProvider<T>,
+{
+    fn reduce(
+        &self,
+        op: ReductionOp,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.reduce(op, a, a_layout, axis, c, c_layout)
+    }
+
+    fn cumsum(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.cumsum(a, a_layout, axis, c, c_layout)
+    }
+
+    fn suffix_sum(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.suffix_sum(a, a_layout, axis, c, c_layout)
+    }
+
+    fn cumprod(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.cumprod(a, a_layout, axis, c, c_layout)
+    }
+
+    fn suffix_prod(
+        &self,
+        a: &Self::DeviceBuffer<T>,
+        a_layout: &Layout,
+        axis: usize,
+        c: &mut Self::DeviceBuffer<T>,
+        c_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.suffix_prod(a, a_layout, axis, c, c_layout)
+    }
+}

--- a/crates/coeus-rocm/src/lib.rs
+++ b/crates/coeus-rocm/src/lib.rs
@@ -1,0 +1,10 @@
+//! Coeus ROCm backend integration through the Hephaestus ROCm provider.
+//!
+//! This increment exposes the native rank-2 reduction and cumulative
+//! scan/product contract. Unsupported ranks are returned as typed errors at
+//! the Coeus layout boundary; no host fallback is used.
+#![deny(missing_docs)]
+
+mod backend;
+
+pub use backend::{RocmBackend, RocmProvider};

--- a/crates/coeus-rocm/tests/reduction.rs
+++ b/crates/coeus-rocm/tests/reduction.rs
@@ -1,0 +1,124 @@
+use coeus_core::{ComputeBackend, Layout, ReductionOp};
+use coeus_ops::ReductionOps;
+use coeus_rocm::RocmBackend;
+
+fn require_device() {
+    if hephaestus_rocm::RocmDevice::try_default().is_err() {
+        assert_ne!(
+            std::env::var("HEPHAESTUS_ROCM_REQUIRE_DEVICE").as_deref(),
+            Ok("1"),
+            "ROCm CI requires an acquired device"
+        );
+    }
+}
+
+#[test]
+fn native_reductions_and_scans_match_leto() {
+    require_device();
+    if hephaestus_rocm::RocmDevice::try_default().is_err() {
+        return;
+    }
+
+    let backend = RocmBackend::new();
+    assert_eq!(backend.name(), "rocm");
+    let layout = Layout::new([2, 3].into());
+    let input = [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let mut device_input = backend.allocate::<f32>(input.len());
+    backend.copy_to_device(&input, &mut device_input);
+
+    for (op, expected) in [
+        (ReductionOp::Sum, [6.0_f32, 15.0]),
+        (ReductionOp::Prod, [6.0_f32, 120.0]),
+        (ReductionOp::Mean, [2.0_f32, 5.0]),
+        (ReductionOp::Min, [1.0_f32, 4.0]),
+        (ReductionOp::Max, [3.0_f32, 6.0]),
+    ] {
+        let mut expected_values = [0.0_f32; 2];
+        coeus_leto::reduce_into(
+            op,
+            &layout,
+            &input,
+            1,
+            &Layout::new([2, 1].into()),
+            &mut expected_values,
+        )
+        .expect("Leto reduction oracle failed");
+        assert_eq!(expected_values, expected, "Leto oracle contract");
+
+        let mut actual = backend.allocate::<f32>(2);
+        ReductionOps::reduce(
+            &backend,
+            op,
+            &device_input,
+            &layout,
+            1,
+            &mut actual,
+            &Layout::new([2, 1].into()),
+        )
+        .expect("ROCm reduction failed");
+        let mut actual_values = [0.0_f32; 2];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_eq!(actual_values, expected_values, "ROCm {op:?} parity");
+    }
+
+    let mut expected_scan = [0.0_f32; 6];
+    coeus_leto::cumsum_into(&layout, &input, 1, &layout, &mut expected_scan)
+        .expect("Leto cumulative-sum oracle failed");
+    let mut scan = backend.allocate::<f32>(input.len());
+    ReductionOps::cumsum(&backend, &device_input, &layout, 1, &mut scan, &layout)
+        .expect("ROCm cumulative sum failed");
+    let mut actual_scan = [0.0_f32; 6];
+    backend.copy_to_host(&scan, &mut actual_scan);
+    assert_eq!(actual_scan, expected_scan);
+
+    let mut expected_suffix_sum = [0.0_f32; 6];
+    coeus_leto::suffix_sum_into(&layout, &input, 1, &layout, &mut expected_suffix_sum)
+        .expect("Leto suffix-sum oracle failed");
+    let mut suffix_sum = backend.allocate::<f32>(input.len());
+    ReductionOps::suffix_sum(
+        &backend,
+        &device_input,
+        &layout,
+        1,
+        &mut suffix_sum,
+        &layout,
+    )
+    .expect("ROCm suffix sum failed");
+    let mut actual_suffix_sum = [0.0_f32; 6];
+    backend.copy_to_host(&suffix_sum, &mut actual_suffix_sum);
+    assert_eq!(actual_suffix_sum, expected_suffix_sum);
+
+    let mut expected_product_scan = [0.0_f32; 6];
+    coeus_leto::cumprod_into(&layout, &input, 1, &layout, &mut expected_product_scan)
+        .expect("Leto cumulative-product oracle failed");
+    let mut product_scan = backend.allocate::<f32>(input.len());
+    ReductionOps::cumprod(
+        &backend,
+        &device_input,
+        &layout,
+        1,
+        &mut product_scan,
+        &layout,
+    )
+    .expect("ROCm cumulative product failed");
+    let mut actual_product_scan = [0.0_f32; 6];
+    backend.copy_to_host(&product_scan, &mut actual_product_scan);
+    assert_eq!(actual_product_scan, expected_product_scan);
+
+    let mut expected_suffix_product = [0.0_f32; 6];
+    coeus_leto::suffix_prod_into(&layout, &input, 1, &layout, &mut expected_suffix_product)
+        .expect("Leto suffix-product oracle failed");
+    let mut suffix_product = backend.allocate::<f32>(input.len());
+    ReductionOps::suffix_prod(
+        &backend,
+        &device_input,
+        &layout,
+        1,
+        &mut suffix_product,
+        &layout,
+    )
+    .expect("ROCm suffix product failed");
+    let mut actual_suffix_product = [0.0_f32; 6];
+    backend.copy_to_host(&suffix_product, &mut actual_suffix_product);
+    assert_eq!(actual_suffix_product, expected_suffix_product);
+}

--- a/docs/adr/0022-coeus-hephaestus-provider-layer.md
+++ b/docs/adr/0022-coeus-hephaestus-provider-layer.md
@@ -1,0 +1,47 @@
+# ADR-0022: Share Coeus Hephaestus provider integration
+
+## Status
+
+Accepted; implemented as the first ROCm/Metal reduction increment.
+
+## Decision
+
+Coeus owns one generic `coeus-hephaestus` integration layer for Hephaestus
+storage, transfers, rank validation, and the `ReductionOps` dispatch contract.
+`coeus-rocm` and `coeus-metal` provide only typed provider implementations over
+their native Hephaestus device APIs. The provider seam is scalar-specific so
+unsupported scalar/kernel combinations fail at compile time rather than being
+converted to a different precision or routed through a host implementation.
+
+This increment exposes native rank-2 reductions (`sum`, `product`, `mean`,
+`min`, `max`) and forward/reverse cumulative sum/product scans. Ranks above
+two return the existing typed Coeus unsupported-rank error. Higher operation
+families remain separate increments until their Hephaestus contracts are
+integrated.
+
+## Constraints
+
+- Leto is the CPU value-semantic oracle for every provider contract.
+- Device buffers remain owned by Hephaestus; Coeus stores reference-counted
+  typed handles and does not import vendor runtime types into operation logic.
+- A missing device is an unavailable capability. Tests may skip on ordinary
+  developer hosts, while CI hardware lanes set a required-device environment
+  variable and fail when acquisition is unavailable.
+- No CPU fallback is used for a rank or operation unsupported by the native
+  provider dispatch.
+
+## Alternatives rejected
+
+Duplicating the existing CUDA/WGPU reduction implementations in two new backend
+crates was rejected because it creates three consumer-owned operation trees and
+allows semantic drift between provider backends. Making ROCm and Metal aliases
+of one public backend type was rejected because it hides the backend identity
+and prevents backend-specific capability reporting.
+
+## Verification
+
+The vendor tests compare all five rank-2 reductions and forward/reverse
+cumulative sum/product results against `coeus-leto`. Hosted CI compiles the
+ROCm feature in the AMD development image, runs a required-device ROCm lane on
+the registered runner when manually requested, and runs the required-device
+Metal contracts on `macos-15`.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,21 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers [arch]
+
+- Owner: Codex; scope: `coeus-hephaestus`, `coeus-rocm`, `coeus-metal`, their
+  Leto differential tests, workspace manifests, and backend-parity CI.
+- Outcome: integrate real Hephaestus ROCm and Metal storage plus rank-2
+  reduction/scan kernels into Coeus through one generic consumer-facing layer.
+- Non-goals: higher-rank dispatch and non-reduction operation families remain
+  separate vertical increments.
+- Acceptance: all five reductions and forward/reverse sum/product scans match
+  `coeus-leto`; unsupported ranks return typed errors; ROCm feature CI and
+  macOS Metal CI pass; no CPU fallback or vendor algorithm clone is added.
+- Status: in-progress; local package checks pass, hosted exact-head CI remains
+  to be run after the workflow increment.
+- Decision: ADR-0022 selects the shared generic provider layer over duplicated
+  vendor operation trees.
+
 ## ATLAS-COEUS-BUILD-001 — Reconcile locked provider source graph [patch] — done
 
 - Owner: Codex `/coeus`; scope: `Cargo.lock` and the provider-graph evidence for

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -11,10 +11,12 @@
 - Acceptance: all five reductions and forward/reverse sum/product scans match
   `coeus-leto`; unsupported ranks return typed errors; ROCm feature CI and
   macOS Metal CI pass; no CPU fallback or vendor algorithm clone is added.
-- Status: in-progress; local package checks pass and the first exact-head run
-  exposed the upstream ROCm device thread-safety contract. Hephaestus PR #109
-  merged as `95eeaa5`; the Coeus exact-head matrix is being rerun against that
-  merged substrate.
+- Status: complete for the rank-2 reduction and scan scope. Local package
+  checks pass, Hephaestus PR #109 merged as `95eeaa5`, and exact-head hosted
+  run `30221620203` passed at `f8bb4c7e`: ROCm job `89844922811`, Metal job
+  `89844922775`, WGPU job `89844922827`, and CUDA job `89844922774`. The
+  required-device ROCm hardware job `89844923036` was skipped on this pull
+  request because it requires manual dispatch.
 - Decision: ADR-0022 selects the shared generic provider layer over duplicated
   vendor operation trees.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -11,8 +11,10 @@
 - Acceptance: all five reductions and forward/reverse sum/product scans match
   `coeus-leto`; unsupported ranks return typed errors; ROCm feature CI and
   macOS Metal CI pass; no CPU fallback or vendor algorithm clone is added.
-- Status: in-progress; local package checks pass, hosted exact-head CI remains
-  to be run after the workflow increment.
+- Status: in-progress; local package checks pass and the first exact-head run
+  exposed the upstream ROCm device thread-safety contract. Hephaestus PR #109
+  merged as `95eeaa5`; the Coeus exact-head matrix is being rerun against that
+  merged substrate.
 - Decision: ADR-0022 selects the shared generic provider layer over duplicated
   vendor operation trees.
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,17 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers
+
+- [x] Add one generic `coeus-hephaestus` storage and reduction/scan dispatch
+      layer shared by vendor backends.
+- [x] Add native Coeus ROCm and Metal backends for rank-2 reductions and
+      forward/reverse cumulative sum/product scans.
+- [x] Compare every provider reduction and scan result with the Leto CPU
+      oracle, including product identity and suffix direction.
+- [ ] Run exact-head hosted ROCm feature and macOS Metal CI, plus the optional
+      required-device ROCm lane; record the final run IDs here.
+
+
 ## ATLAS-HEPHAESTUS-SCAN-001 — Native cumulative scans
 
 - [x] `ReductionOps::cumsum` and `suffix_sum` expose typed backend results.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -10,8 +10,12 @@
       oracle, including product identity and suffix direction.
 - [x] Fix the owning Hephaestus ROCm device cache so the Coeus backend device
       satisfies `Send + Sync`; Hephaestus PR #109 merged as `95eeaa5`.
-- [ ] Run exact-head hosted ROCm feature and macOS Metal CI, plus the optional
-      required-device ROCm lane; record the final run IDs here.
+- [x] Run exact-head hosted ROCm feature and macOS Metal CI with the WGPU/CUDA
+      matrix. Run `30221620203` passed at `f8bb4c7e`:
+      ROCm `89844922811`, Metal `89844922775`, WGPU `89844922827`, and CUDA
+      `89844922774`. The optional required-device ROCm lane
+      (`89844923036`) was skipped because this pull request did not request a
+      hardware dispatch.
 
 
 ## ATLAS-HEPHAESTUS-SCAN-001 — Native cumulative scans

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -8,6 +8,8 @@
       forward/reverse cumulative sum/product scans.
 - [x] Compare every provider reduction and scan result with the Leto CPU
       oracle, including product identity and suffix direction.
+- [x] Fix the owning Hephaestus ROCm device cache so the Coeus backend device
+      satisfies `Send + Sync`; Hephaestus PR #109 merged as `95eeaa5`.
 - [ ] Run exact-head hosted ROCm feature and macOS Metal CI, plus the optional
       required-device ROCm lane; record the final run IDs here.
 


### PR DESCRIPTION
## Scope

- add the generic `coeus-hephaestus` storage and reduction/scan integration layer
- add native `coeus-rocm` and `coeus-metal` provider crates
- compare rank-2 sum, product, mean, min, max, forward/reverse sum scans, and forward/reverse product scans with the Coeus Leto CPU oracle
- add ROCm container CI, macOS Metal CI, and an opt-in required-device ROCm runner lane
- record the architecture decision and bounded rank-2 scope in the Coeus PM artifacts

## Verification

- local `cargo check --locked --package coeus-hephaestus --package coeus-rocm --package coeus-metal --all-targets`
- local Clippy with `-D warnings`
- local nextest: 2 provider tests passed; unavailable local devices are controlled skips
- local doctests and rustdoc passed

This is the next vertical increment toward backend capability parity. Higher-rank and non-reduction operation families remain explicit follow-up increments.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds ROCm and Metal backend providers to Coeus through a new shared `coeus-hephaestus` integration layer. The implementation introduces native rank-2 reduction operations (sum, product, mean, min, max) and cumulative scans (forward/reverse sum/product) that are validated against the Leto CPU oracle. The architecture uses a generic provider abstraction that eliminates code duplication between vendor backends while maintaining type-safe scalar-specific kernel dispatch. CI enhancements include a ROCm container workflow, macOS Metal testing on `macos-15`, and an opt-in hardware runner lane for required-device ROCm validation.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0022-coeus-hephaestus-provider-layer.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/checklist.md` |
| 4 | `Cargo.toml` |
| 5 | `crates/coeus-hephaestus/Cargo.toml` |
| 6 | `crates/coeus-hephaestus/src/lib.rs` |
| 7 | `crates/coeus-hephaestus/src/error.rs` |
| 8 | `crates/coeus-hephaestus/src/storage.rs` |
| 9 | `crates/coeus-hephaestus/src/layout.rs` |
| 10 | `crates/coeus-hephaestus/src/reduction.rs` |
| 11 | `crates/coeus-rocm/Cargo.toml` |
| 12 | `crates/coeus-rocm/src/lib.rs` |
| 13 | `crates/coeus-rocm/src/backend.rs` |
| 14 | `crates/coeus-rocm/tests/reduction.rs` |
| 15 | `crates/coeus-metal/Cargo.toml` |
| 16 | `crates/coeus-metal/src/lib.rs` |
| 17 | `crates/coeus-metal/src/backend.rs` |
| 18 | `crates/coeus-metal/tests/reduction.rs` |
| 19 | `.github/workflows/backend-parity.yml` |
| 20 | `Cargo.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->