### PR TITLE
Add native ROCm and Metal elementwise providers

### DIFF
--- a/.github/workflows/backend-parity.yml
+++ b/.github/workflows/backend-parity.yml
@@ -142,7 +142,7 @@ jobs:
           cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-wgpu --all-targets
           cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-wgpu --all-targets --no-deps -- -D warnings
           cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-wgpu \
-            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors)"
+            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer)"
           cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-wgpu --doc
 
   cuda:
@@ -270,7 +270,7 @@ jobs:
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-cuda --features cuda --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-cuda --features cuda --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-cuda --features cuda \
-                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis)"
+                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-cuda --features cuda --doc
             '
 
@@ -383,19 +383,21 @@ jobs:
               rustfmt --check --edition 2024 \
                 crates/coeus-hephaestus/src/lib.rs \
                 crates/coeus-hephaestus/src/error.rs \
+                crates/coeus-hephaestus/src/elementwise.rs \
                 crates/coeus-hephaestus/src/layout.rs \
                 crates/coeus-hephaestus/src/reduction.rs \
                 crates/coeus-hephaestus/src/storage.rs \
                 crates/coeus-rocm/src/lib.rs \
                 crates/coeus-rocm/src/backend.rs \
-                crates/coeus-rocm/tests/reduction.rs
+                crates/coeus-rocm/tests/reduction.rs \
+                crates/coeus-rocm/tests/elementwise.rs
               cargo "+$RUST_TOOLCHAIN" update --manifest-path /workspace/coeus/Cargo.toml --workspace
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-hephaestus --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-hephaestus --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-rocm --features rocm --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-rocm --features rocm --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-rocm --features rocm \
-                -E "test(native_reductions_and_scans_match_leto)"
+                -E "test(native_reductions_and_scans_match_leto) or test(native_elementwise_operations_match_leto_with_broadcasting)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-rocm --features rocm --doc
             '
 
@@ -504,19 +506,21 @@ jobs:
           rustfmt --check --edition 2024 \
             crates/coeus-hephaestus/src/lib.rs \
             crates/coeus-hephaestus/src/error.rs \
+            crates/coeus-hephaestus/src/elementwise.rs \
             crates/coeus-hephaestus/src/layout.rs \
             crates/coeus-hephaestus/src/reduction.rs \
             crates/coeus-hephaestus/src/storage.rs \
             crates/coeus-metal/src/lib.rs \
             crates/coeus-metal/src/backend.rs \
-            crates/coeus-metal/tests/reduction.rs
+            crates/coeus-metal/tests/reduction.rs \
+            crates/coeus-metal/tests/elementwise.rs
           cargo "+$RUST_TOOLCHAIN" update --manifest-path "$GITHUB_WORKSPACE/coeus/Cargo.toml" --workspace
           cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-hephaestus --all-targets
           cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-hephaestus --all-targets --no-deps -- -D warnings
           cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-metal --all-targets
           cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-metal --all-targets --no-deps -- -D warnings
           cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-metal \
-            -E "test(native_reductions_and_scans_match_leto)"
+            -E "test(native_reductions_and_scans_match_leto) or test(native_elementwise_operations_match_leto_with_broadcasting)"
           cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-metal --doc
 
   rocm-hardware:
@@ -612,4 +616,4 @@ jobs:
         env:
           HEPHAESTUS_ROCM_REQUIRE_DEVICE: "1"
         run: cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-rocm --features rocm \
-          -E "test(native_reductions_and_scans_match_leto)"
+          -E "test(native_reductions_and_scans_match_leto) or test(native_elementwise_operations_match_leto_with_broadcasting)"

--- a/crates/coeus-hephaestus/src/elementwise.rs
+++ b/crates/coeus-hephaestus/src/elementwise.rs
@@ -1,0 +1,296 @@
+//! Generic ranked elementwise dispatch over Hephaestus providers.
+
+use crate::{
+    error::HephaestusBackendError,
+    layout::ranked,
+    reduction::{HephaestusBackend, HephaestusProvider, RankedOperand},
+    storage::HephaestusStorage,
+};
+use coeus_core::{BackendError, Layout, Scalar};
+use coeus_ops::{BinaryOp, ElementwiseOps, UnaryOp};
+use hephaestus_core::ComputeDevice;
+
+/// Provider implementation of the common ranked elementwise operation set.
+pub trait ElementwiseProvider<T>: HephaestusProvider
+where
+    T: Scalar + leto_ops::Scalar,
+{
+    /// Execute a binary operation over a fixed-rank strided output.
+    fn binary<const N: usize>(
+        device: &Self::Device,
+        operation: BinaryOp,
+        lhs: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, N>,
+        rhs: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, N>,
+        output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, N>,
+    ) -> hephaestus_core::Result<()>;
+
+    /// Execute a unary operation over a fixed-rank strided output.
+    fn unary<const N: usize>(
+        device: &Self::Device,
+        operation: UnaryOp,
+        input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, N>,
+        output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, N>,
+    ) -> hephaestus_core::Result<()>;
+}
+
+fn reject_broadcast_output(operation: &'static str, layout: &Layout) -> Result<(), BackendError> {
+    if layout
+        .shape()
+        .iter()
+        .zip(layout.strides())
+        .any(|(&extent, &stride)| extent > 1 && stride == 0)
+    {
+        return Err(BackendError::Storage {
+            operation,
+            reason: "output layout cannot broadcast a dimension larger than one".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+impl<P> HephaestusBackend<P>
+where
+    P: HephaestusProvider,
+{
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "dispatch preserves the common elementwise backend contract"
+    )]
+    fn dispatch_binary<T>(
+        &self,
+        operation: BinaryOp,
+        lhs: &HephaestusStorage<P, T>,
+        lhs_layout: &Layout,
+        rhs: &HephaestusStorage<P, T>,
+        rhs_layout: &Layout,
+        output: &mut HephaestusStorage<P, T>,
+        output_layout: &Layout,
+    ) -> Result<(), HephaestusBackendError>
+    where
+        P: ElementwiseProvider<T>,
+        T: Scalar + leto_ops::Scalar,
+    {
+        reject_broadcast_output("elementwise_binary", output_layout)?;
+        let rank = lhs_layout
+            .ndim()
+            .max(rhs_layout.ndim())
+            .max(output_layout.ndim());
+        match rank {
+            1 => self.dispatch_binary_rank::<T, 1>(
+                operation,
+                lhs,
+                lhs_layout,
+                rhs,
+                rhs_layout,
+                output,
+                output_layout,
+            ),
+            2 => self.dispatch_binary_rank::<T, 2>(
+                operation,
+                lhs,
+                lhs_layout,
+                rhs,
+                rhs_layout,
+                output,
+                output_layout,
+            ),
+            3 => self.dispatch_binary_rank::<T, 3>(
+                operation,
+                lhs,
+                lhs_layout,
+                rhs,
+                rhs_layout,
+                output,
+                output_layout,
+            ),
+            4 => self.dispatch_binary_rank::<T, 4>(
+                operation,
+                lhs,
+                lhs_layout,
+                rhs,
+                rhs_layout,
+                output,
+                output_layout,
+            ),
+            rank => Err(BackendError::UnsupportedRank {
+                operation: "elementwise_binary",
+                rank,
+                max_rank: 4,
+            }
+            .into()),
+        }
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "dispatch preserves the common elementwise backend contract"
+    )]
+    fn dispatch_binary_rank<T, const N: usize>(
+        &self,
+        operation: BinaryOp,
+        lhs: &HephaestusStorage<P, T>,
+        lhs_layout: &Layout,
+        rhs: &HephaestusStorage<P, T>,
+        rhs_layout: &Layout,
+        output: &mut HephaestusStorage<P, T>,
+        output_layout: &Layout,
+    ) -> Result<(), HephaestusBackendError>
+    where
+        P: ElementwiseProvider<T>,
+        T: Scalar + leto_ops::Scalar,
+    {
+        let lhs_layout = ranked::<N>("elementwise_binary", lhs_layout)?;
+        let rhs_layout = ranked::<N>("elementwise_binary", rhs_layout)?;
+        let output_layout = ranked::<N>("elementwise_binary", output_layout)?;
+        P::binary(
+            P::device(),
+            operation,
+            RankedOperand {
+                buffer: lhs.buffer(),
+                layout: &lhs_layout,
+            },
+            RankedOperand {
+                buffer: rhs.buffer(),
+                layout: &rhs_layout,
+            },
+            RankedOperand {
+                buffer: output.buffer(),
+                layout: &output_layout,
+            },
+        )
+        .map_err(|source| HephaestusBackendError::device("elementwise_binary", source))
+    }
+
+    fn dispatch_unary<T>(
+        &self,
+        operation: UnaryOp,
+        input: &HephaestusStorage<P, T>,
+        input_layout: &Layout,
+        output: &mut HephaestusStorage<P, T>,
+        output_layout: &Layout,
+    ) -> Result<(), HephaestusBackendError>
+    where
+        P: ElementwiseProvider<T>,
+        T: Scalar + leto_ops::Scalar,
+    {
+        reject_broadcast_output("elementwise_unary", output_layout)?;
+        let rank = input_layout.ndim().max(output_layout.ndim());
+        match rank {
+            1 => self.dispatch_unary_rank::<T, 1>(
+                operation,
+                input,
+                input_layout,
+                output,
+                output_layout,
+            ),
+            2 => self.dispatch_unary_rank::<T, 2>(
+                operation,
+                input,
+                input_layout,
+                output,
+                output_layout,
+            ),
+            3 => self.dispatch_unary_rank::<T, 3>(
+                operation,
+                input,
+                input_layout,
+                output,
+                output_layout,
+            ),
+            4 => self.dispatch_unary_rank::<T, 4>(
+                operation,
+                input,
+                input_layout,
+                output,
+                output_layout,
+            ),
+            rank => Err(BackendError::UnsupportedRank {
+                operation: "elementwise_unary",
+                rank,
+                max_rank: 4,
+            }
+            .into()),
+        }
+    }
+
+    fn dispatch_unary_rank<T, const N: usize>(
+        &self,
+        operation: UnaryOp,
+        input: &HephaestusStorage<P, T>,
+        input_layout: &Layout,
+        output: &mut HephaestusStorage<P, T>,
+        output_layout: &Layout,
+    ) -> Result<(), HephaestusBackendError>
+    where
+        P: ElementwiseProvider<T>,
+        T: Scalar + leto_ops::Scalar,
+    {
+        let input_layout = ranked::<N>("elementwise_unary", input_layout)?;
+        let output_layout = ranked::<N>("elementwise_unary", output_layout)?;
+        P::unary(
+            P::device(),
+            operation,
+            RankedOperand {
+                buffer: input.buffer(),
+                layout: &input_layout,
+            },
+            RankedOperand {
+                buffer: output.buffer(),
+                layout: &output_layout,
+            },
+        )
+        .map_err(|source| HephaestusBackendError::device("elementwise_unary", source))
+    }
+}
+
+impl<P, T> ElementwiseOps<T> for HephaestusBackend<P>
+where
+    P: ElementwiseProvider<T>,
+    T: Scalar + leto_ops::Scalar,
+{
+    fn elementwise_binary(
+        &self,
+        operation: BinaryOp,
+        lhs: &Self::DeviceBuffer<T>,
+        lhs_layout: &Layout,
+        rhs: &Self::DeviceBuffer<T>,
+        rhs_layout: &Layout,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.dispatch_binary(
+            operation,
+            lhs,
+            lhs_layout,
+            rhs,
+            rhs_layout,
+            output,
+            output_layout,
+        )
+    }
+
+    fn elementwise_unary(
+        &self,
+        operation: UnaryOp,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.dispatch_unary(operation, input, input_layout, output, output_layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reject_broadcast_output;
+    use coeus_core::Layout;
+
+    #[test]
+    fn output_broadcast_is_rejected_before_provider_dispatch() {
+        let layout = Layout::from_shape_strides(vec![2, 3].into(), vec![0, 1].into(), 0);
+        let error = reject_broadcast_output("elementwise_binary", &layout)
+            .expect_err("broadcast output must be rejected");
+        assert!(error.to_string().contains("output layout"));
+    }
+}

--- a/crates/coeus-hephaestus/src/elementwise.rs
+++ b/crates/coeus-hephaestus/src/elementwise.rs
@@ -283,8 +283,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::reject_broadcast_output;
-    use coeus_core::Layout;
+    use super::{ranked, reject_broadcast_output};
+    use coeus_core::{BackendError, Layout};
 
     #[test]
     fn output_broadcast_is_rejected_before_provider_dispatch() {
@@ -292,5 +292,22 @@ mod tests {
         let error = reject_broadcast_output("elementwise_binary", &layout)
             .expect_err("broadcast output must be rejected");
         assert!(error.to_string().contains("output layout"));
+    }
+
+    #[test]
+    fn rank_above_four_is_rejected_as_typed_backend_error() {
+        let layout = Layout::new([1, 1, 1, 1, 1].into());
+        let error = match ranked::<4>("elementwise_binary", &layout) {
+            Ok(_) => panic!("rank five must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error,
+            BackendError::UnsupportedRank {
+                operation: "elementwise_binary",
+                rank: 5,
+                max_rank: 4,
+            }
+        );
     }
 }

--- a/crates/coeus-hephaestus/src/layout.rs
+++ b/crates/coeus-hephaestus/src/layout.rs
@@ -1,37 +1,37 @@
 use coeus_core::{BackendError, Layout};
 use leto::Layout as LetoLayout;
 
-/// Convert a Coeus layout to the rank-2 layout consumed by the current
-/// Hephaestus reduction and scan kernels.
-pub(crate) fn rank_two(
+/// Convert a dynamic Coeus layout to a left-padded fixed-rank Leto layout.
+pub(crate) fn ranked<const N: usize>(
     operation: &'static str,
     layout: &Layout,
-) -> Result<LetoLayout<2>, BackendError> {
-    let [rows, columns] = layout.shape() else {
+) -> Result<LetoLayout<N>, BackendError> {
+    let rank = layout.ndim();
+    if rank > N {
         return Err(BackendError::UnsupportedRank {
             operation,
-            rank: layout.ndim(),
-            max_rank: 2,
+            rank,
+            max_rank: N,
         });
-    };
-    let [row_stride, column_stride] = layout.strides() else {
+    }
+    if layout.shape().len() != layout.strides().len() {
         return Err(BackendError::LayoutRankMismatch {
             operation,
             lhs: layout.shape().len(),
             rhs: layout.strides().len(),
         });
-    };
-    let row_stride = isize::try_from(*row_stride).map_err(|_| BackendError::Overflow {
-        operation,
-        reason: "row stride exceeds isize range",
-    })?;
-    let column_stride = isize::try_from(*column_stride).map_err(|_| BackendError::Overflow {
-        operation,
-        reason: "column stride exceeds isize range",
-    })?;
-    Ok(LetoLayout::new(
-        [*rows, *columns],
-        [row_stride, column_stride],
-        layout.offset(),
-    ))
+    }
+
+    let padding = N - rank;
+    let mut shape = [1_usize; N];
+    let mut strides = [0_isize; N];
+    for (index, (&extent, &stride)) in layout.shape().iter().zip(layout.strides()).enumerate() {
+        shape[padding + index] = extent;
+        strides[padding + index] = isize::try_from(stride).map_err(|_| BackendError::Overflow {
+            operation,
+            reason: "layout stride exceeds isize range",
+        })?;
+    }
+
+    Ok(LetoLayout::new(shape, strides, layout.offset()))
 }

--- a/crates/coeus-hephaestus/src/lib.rs
+++ b/crates/coeus-hephaestus/src/lib.rs
@@ -6,12 +6,14 @@
 //! they do not copy the consumer-side operation orchestration.
 #![deny(missing_docs)]
 
+mod elementwise;
 mod error;
 mod layout;
 mod reduction;
 mod storage;
 
+pub use elementwise::ElementwiseProvider;
 pub use error::HephaestusBackendError;
 pub use reduction::HephaestusBackend;
-pub use reduction::{HephaestusProvider, RankTwoOperand, ReductionProvider, ScanOperation};
+pub use reduction::{HephaestusProvider, RankedOperand, ReductionProvider, ScanOperation};
 pub use storage::HephaestusStorage;

--- a/crates/coeus-hephaestus/src/reduction.rs
+++ b/crates/coeus-hephaestus/src/reduction.rs
@@ -1,4 +1,4 @@
-use crate::{error::HephaestusBackendError, layout::rank_two, storage::HephaestusStorage};
+use crate::{error::HephaestusBackendError, layout::ranked, storage::HephaestusStorage};
 use coeus_core::{ComputeBackend, Layout, Scalar};
 use coeus_ops::ReductionOp;
 use hephaestus_core::{ComputeDevice, DeviceBuffer, ScanDirection};
@@ -33,13 +33,13 @@ pub enum ScanOperation {
     Product,
 }
 
-/// A rank-2 Hephaestus buffer paired with its logical Leto layout.
+/// A fixed-rank Hephaestus buffer paired with its logical Leto layout.
 #[derive(Clone, Copy)]
-pub struct RankTwoOperand<'a, B> {
+pub struct RankedOperand<'a, B, const N: usize> {
     /// Typed device buffer handle.
     pub buffer: &'a B,
     /// Logical shape, strides, and offset.
-    pub layout: &'a LetoLayout<2>,
+    pub layout: &'a LetoLayout<N>,
 }
 
 /// Provider implementation of scalar-specific rank-2 reduction and scan
@@ -52,19 +52,19 @@ where
     fn reduce(
         device: &Self::Device,
         op: ReductionOp,
-        input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+        input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, 2>,
         axis: usize,
-        output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+        output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, 2>,
     ) -> hephaestus_core::Result<()>;
 
     /// Execute an inclusive prefix or suffix scan over a rank-2 strided input.
     fn scan(
         device: &Self::Device,
-        input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+        input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, 2>,
         axis: usize,
         operation: ScanOperation,
         direction: ScanDirection,
-        output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>>,
+        output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<T>, 2>,
     ) -> hephaestus_core::Result<()>;
 }
 
@@ -166,17 +166,17 @@ where
         c: &mut Self::DeviceBuffer<T>,
         c_layout: &Layout,
     ) -> Result<(), Self::Error> {
-        let input_layout = rank_two("reduce", a_layout)?;
-        let output_layout = rank_two("reduce", c_layout)?;
+        let input_layout = ranked::<2>("reduce", a_layout)?;
+        let output_layout = ranked::<2>("reduce", c_layout)?;
         P::reduce(
             P::device(),
             op,
-            RankTwoOperand {
+            RankedOperand {
                 buffer: a.buffer(),
                 layout: &input_layout,
             },
             axis,
-            RankTwoOperand {
+            RankedOperand {
                 buffer: c.buffer(),
                 layout: &output_layout,
             },
@@ -274,18 +274,18 @@ where
         P: ReductionProvider<T>,
         T: Scalar + leto_ops::Scalar,
     {
-        let input_layout = rank_two(request.operation, request.input_layout)?;
-        let output_layout = rank_two(request.operation, request.output_layout)?;
+        let input_layout = ranked::<2>(request.operation, request.input_layout)?;
+        let output_layout = ranked::<2>(request.operation, request.output_layout)?;
         P::scan(
             P::device(),
-            RankTwoOperand {
+            RankedOperand {
                 buffer: request.input.buffer(),
                 layout: &input_layout,
             },
             request.axis,
             request.operation_kind,
             request.direction,
-            RankTwoOperand {
+            RankedOperand {
                 buffer: request.output.buffer(),
                 layout: &output_layout,
             },

--- a/crates/coeus-metal/src/backend.rs
+++ b/crates/coeus-metal/src/backend.rs
@@ -24,6 +24,22 @@ unsafe impl HephaestusProvider for MetalProvider {
     }
 }
 
+fn unsupported_binary_operation(operation: BinaryOp) -> HephaestusError {
+    HephaestusError::DispatchFailed {
+        message: format!(
+            "binary elementwise operation {operation:?} is not implemented by Metal provider"
+        ),
+    }
+}
+
+fn unsupported_unary_operation(operation: UnaryOp) -> HephaestusError {
+    HephaestusError::DispatchFailed {
+        message: format!(
+            "unary elementwise operation {operation:?} is not implemented by Metal provider"
+        ),
+    }
+}
+
 macro_rules! impl_reduction_provider {
     ($scalar:ty) => {
         impl ReductionProvider<$scalar> for MetalProvider {
@@ -195,11 +211,7 @@ macro_rules! impl_elementwise_provider {
                         output,
                         hephaestus_core::BlockWidth::DEFAULT,
                     ),
-                    _ => Err(HephaestusError::DispatchFailed {
-                        message:
-                            "binary elementwise operation is not implemented by Metal provider"
-                                .to_owned(),
-                    }),
+                    _ => Err(unsupported_binary_operation(operation)),
                 }
             }
 
@@ -274,10 +286,7 @@ macro_rules! impl_elementwise_provider {
                     >(
                         device, input, output, hephaestus_core::BlockWidth::DEFAULT
                     ),
-                    _ => Err(HephaestusError::DispatchFailed {
-                        message: "unary elementwise operation is not implemented by Metal provider"
-                            .to_owned(),
-                    }),
+                    _ => Err(unsupported_unary_operation(operation)),
                 }
             }
         }
@@ -431,5 +440,24 @@ where
     ) -> Result<(), Self::Error> {
         self.0
             .elementwise_unary(operation, input, input_layout, output, output_layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{unsupported_binary_operation, unsupported_unary_operation};
+    use coeus_ops::{BinaryOp, UnaryOp};
+    use hephaestus_core::HephaestusError;
+
+    #[test]
+    fn unsupported_operations_are_reported_as_typed_provider_errors() {
+        assert!(matches!(
+            unsupported_binary_operation(BinaryOp::Eq),
+            HephaestusError::DispatchFailed { .. }
+        ));
+        assert!(matches!(
+            unsupported_unary_operation(UnaryOp::Gelu),
+            HephaestusError::DispatchFailed { .. }
+        ));
     }
 }

--- a/crates/coeus-metal/src/backend.rs
+++ b/crates/coeus-metal/src/backend.rs
@@ -1,10 +1,10 @@
 use coeus_core::{ComputeBackend, Layout, Scalar};
 use coeus_hephaestus::{
-    HephaestusBackend, HephaestusBackendError, HephaestusProvider, HephaestusStorage,
-    RankTwoOperand, ReductionProvider, ScanOperation,
+    ElementwiseProvider, HephaestusBackend, HephaestusBackendError, HephaestusProvider,
+    HephaestusStorage, RankedOperand, ReductionProvider, ScanOperation,
 };
-use coeus_ops::{ReductionOp, ReductionOps};
-use hephaestus_core::{ComputeDevice, ScanDirection};
+use coeus_ops::{BinaryOp, ElementwiseOps, ReductionOp, ReductionOps, UnaryOp};
+use hephaestus_core::{ComputeDevice, HephaestusError, ScanDirection};
 use hephaestus_metal::{MetalDevice, StridedOperand};
 use std::sync::OnceLock;
 
@@ -30,9 +30,9 @@ macro_rules! impl_reduction_provider {
             fn reduce(
                 device: &Self::Device,
                 op: ReductionOp,
-                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
                 axis: usize,
-                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
             ) -> hephaestus_core::Result<()> {
                 let input = StridedOperand {
                     buffer: input.buffer,
@@ -83,11 +83,11 @@ macro_rules! impl_reduction_provider {
 
             fn scan(
                 device: &Self::Device,
-                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
                 axis: usize,
                 operation: ScanOperation,
                 direction: ScanDirection,
-                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
             ) -> hephaestus_core::Result<()> {
                 let input = StridedOperand {
                     buffer: input.buffer,
@@ -127,6 +127,166 @@ macro_rules! impl_reduction_provider {
 impl_reduction_provider!(f32);
 impl_reduction_provider!(u32);
 impl_reduction_provider!(i32);
+
+macro_rules! impl_elementwise_provider {
+    ($scalar:ty) => {
+        impl ElementwiseProvider<$scalar> for MetalProvider {
+            fn binary<const N: usize>(
+                device: &Self::Device,
+                operation: BinaryOp,
+                lhs: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+                rhs: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+            ) -> hephaestus_core::Result<()> {
+                let lhs = hephaestus_metal::StridedOperand {
+                    buffer: lhs.buffer,
+                    layout: lhs.layout,
+                };
+                let rhs = hephaestus_metal::StridedOperand {
+                    buffer: rhs.buffer,
+                    layout: rhs.layout,
+                };
+                let output = hephaestus_metal::StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match operation {
+                    BinaryOp::Add => hephaestus_metal::binary_elementwise_strided_into::<
+                        hephaestus_metal::AddOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    BinaryOp::Sub => hephaestus_metal::binary_elementwise_strided_into::<
+                        hephaestus_metal::SubOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    BinaryOp::Mul => hephaestus_metal::binary_elementwise_strided_into::<
+                        hephaestus_metal::MulOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    BinaryOp::Div => hephaestus_metal::binary_elementwise_strided_into::<
+                        hephaestus_metal::DivOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    _ => Err(HephaestusError::DispatchFailed {
+                        message:
+                            "binary elementwise operation is not implemented by Metal provider"
+                                .to_owned(),
+                    }),
+                }
+            }
+
+            fn unary<const N: usize>(
+                device: &Self::Device,
+                operation: UnaryOp,
+                input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+            ) -> hephaestus_core::Result<()> {
+                let input = hephaestus_metal::StridedOperand {
+                    buffer: input.buffer,
+                    layout: input.layout,
+                };
+                let output = hephaestus_metal::StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match operation {
+                    UnaryOp::Sin => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::SinOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Cos => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::CosOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Exp => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::ExpOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Log => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::LnOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Neg => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::NegOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Abs => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::AbsOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Sqrt => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::SqrtOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Recip => hephaestus_metal::unary_elementwise_strided_into::<
+                        hephaestus_metal::RecipOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    _ => Err(HephaestusError::DispatchFailed {
+                        message: "unary elementwise operation is not implemented by Metal provider"
+                            .to_owned(),
+                    }),
+                }
+            }
+        }
+    };
+}
+
+impl_elementwise_provider!(f32);
+impl_elementwise_provider!(u32);
+impl_elementwise_provider!(i32);
 
 /// Coeus Metal backend with native Hephaestus storage and rank-2 reductions.
 #[derive(Debug, Clone, Copy, Default)]
@@ -232,5 +392,44 @@ where
         c_layout: &Layout,
     ) -> Result<(), Self::Error> {
         self.0.suffix_prod(a, a_layout, axis, c, c_layout)
+    }
+}
+
+impl<T> ElementwiseOps<T> for MetalBackend
+where
+    T: Scalar + leto_ops::Scalar,
+    MetalProvider: ElementwiseProvider<T>,
+{
+    fn elementwise_binary(
+        &self,
+        operation: BinaryOp,
+        lhs: &Self::DeviceBuffer<T>,
+        lhs_layout: &Layout,
+        rhs: &Self::DeviceBuffer<T>,
+        rhs_layout: &Layout,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.elementwise_binary(
+            operation,
+            lhs,
+            lhs_layout,
+            rhs,
+            rhs_layout,
+            output,
+            output_layout,
+        )
+    }
+
+    fn elementwise_unary(
+        &self,
+        operation: UnaryOp,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0
+            .elementwise_unary(operation, input, input_layout, output, output_layout)
     }
 }

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -1,0 +1,160 @@
+use coeus_core::{BinaryOp, ComputeBackend, CpuUnaryOp, Layout};
+use coeus_metal::MetalBackend;
+use coeus_ops::ElementwiseOps;
+
+fn require_device() -> bool {
+    let available = hephaestus_metal::MetalDevice::try_default().is_ok();
+    if !available {
+        assert_ne!(
+            std::env::var("HEPHAESTUS_METAL_REQUIRE_DEVICE").as_deref(),
+            Ok("1"),
+            "Metal CI requires an acquired device"
+        );
+    }
+    available
+}
+
+fn assert_close(actual: &[f32], expected: &[f32], operation: &str) {
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        let tolerance = f32::EPSILON * 512.0 * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "Metal {operation} mismatch at {index}: actual {actual}, expected {expected}, tolerance {tolerance}"
+        );
+    }
+}
+
+#[test]
+fn native_elementwise_operations_match_leto_with_broadcasting() {
+    if !require_device() {
+        return;
+    }
+
+    let backend = MetalBackend::new();
+    assert_eq!(backend.name(), "metal");
+    let lhs_layout = Layout::new([2, 3].into());
+    let rhs_layout = Layout::new([1, 3].into());
+    let output_layout = Layout::new([2, 3].into());
+    let lhs = [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let rhs = [2.0_f32, 4.0, 6.0];
+    let mut device_lhs = backend.allocate::<f32>(lhs.len());
+    let mut device_rhs = backend.allocate::<f32>(rhs.len());
+    backend.copy_to_device(&lhs, &mut device_lhs);
+    backend.copy_to_device(&rhs, &mut device_rhs);
+
+    for operation in [BinaryOp::Add, BinaryOp::Sub, BinaryOp::Mul, BinaryOp::Div] {
+        let mut expected = [0.0_f32; 6];
+        coeus_leto::elementwise_binary_into(
+            operation,
+            &lhs_layout,
+            &lhs,
+            &rhs_layout,
+            &rhs,
+            &output_layout,
+            &mut expected,
+        )
+        .expect("Leto binary elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(lhs.len());
+        backend
+            .elementwise_binary(
+                operation,
+                &device_lhs,
+                &lhs_layout,
+                &device_rhs,
+                &rhs_layout,
+                &mut actual,
+                &output_layout,
+            )
+            .expect("Metal binary elementwise dispatch failed");
+        let mut actual_values = [0.0_f32; 6];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "binary");
+    }
+
+    for (shape, lhs, rhs) in [
+        (
+            vec![6],
+            vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![6.0_f32; 6],
+        ),
+        (
+            vec![2, 2, 2],
+            vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            vec![2.0_f32; 8],
+        ),
+        (
+            vec![1, 2, 2, 2],
+            vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            vec![2.0_f32; 8],
+        ),
+    ] {
+        let layout = Layout::new(shape.into());
+        let mut device_lhs = backend.allocate::<f32>(lhs.len());
+        let mut device_rhs = backend.allocate::<f32>(rhs.len());
+        backend.copy_to_device(&lhs, &mut device_lhs);
+        backend.copy_to_device(&rhs, &mut device_rhs);
+        let mut expected = vec![0.0_f32; lhs.len()];
+        coeus_leto::elementwise_binary_into(
+            BinaryOp::Add,
+            &layout,
+            &lhs,
+            &layout,
+            &rhs,
+            &layout,
+            &mut expected,
+        )
+        .expect("Leto ranked elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(lhs.len());
+        backend
+            .elementwise_binary(
+                BinaryOp::Add,
+                &device_lhs,
+                &layout,
+                &device_rhs,
+                &layout,
+                &mut actual,
+                &layout,
+            )
+            .expect("Metal ranked elementwise dispatch failed");
+        let mut actual_values = vec![0.0_f32; lhs.len()];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "ranked binary");
+    }
+
+    let unary_input = [0.25_f32, 0.5, 1.0, 2.0, 3.0, 4.0];
+    let mut device_unary_input = backend.allocate::<f32>(unary_input.len());
+    backend.copy_to_device(&unary_input, &mut device_unary_input);
+    for operation in [
+        CpuUnaryOp::Sin,
+        CpuUnaryOp::Cos,
+        CpuUnaryOp::Exp,
+        CpuUnaryOp::Log,
+        CpuUnaryOp::Neg,
+        CpuUnaryOp::Abs,
+        CpuUnaryOp::Sqrt,
+        CpuUnaryOp::Recip,
+    ] {
+        let mut expected = [0.0_f32; 6];
+        coeus_leto::elementwise_unary_into(
+            operation,
+            &lhs_layout,
+            &unary_input,
+            &output_layout,
+            &mut expected,
+        )
+        .expect("Leto unary elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(unary_input.len());
+        backend
+            .elementwise_unary(
+                operation,
+                &device_unary_input,
+                &lhs_layout,
+                &mut actual,
+                &output_layout,
+            )
+            .expect("Metal unary elementwise dispatch failed");
+        let mut actual_values = [0.0_f32; 6];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "unary");
+    }
+}

--- a/crates/coeus-rocm/src/backend.rs
+++ b/crates/coeus-rocm/src/backend.rs
@@ -24,6 +24,22 @@ unsafe impl HephaestusProvider for RocmProvider {
     }
 }
 
+fn unsupported_binary_operation(operation: BinaryOp) -> HephaestusError {
+    HephaestusError::DispatchFailed {
+        message: format!(
+            "binary elementwise operation {operation:?} is not implemented by ROCm provider"
+        ),
+    }
+}
+
+fn unsupported_unary_operation(operation: UnaryOp) -> HephaestusError {
+    HephaestusError::DispatchFailed {
+        message: format!(
+            "unary elementwise operation {operation:?} is not implemented by ROCm provider"
+        ),
+    }
+}
+
 macro_rules! impl_reduction_provider {
     ($scalar:ty) => {
         impl ReductionProvider<$scalar> for RocmProvider {
@@ -195,10 +211,7 @@ macro_rules! impl_elementwise_provider {
                         output,
                         hephaestus_core::BlockWidth::DEFAULT,
                     ),
-                    _ => Err(HephaestusError::DispatchFailed {
-                        message: "binary elementwise operation is not implemented by ROCm provider"
-                            .to_owned(),
-                    }),
+                    _ => Err(unsupported_binary_operation(operation)),
                 }
             }
 
@@ -273,10 +286,7 @@ macro_rules! impl_elementwise_provider {
                     >(
                         device, input, output, hephaestus_core::BlockWidth::DEFAULT
                     ),
-                    _ => Err(HephaestusError::DispatchFailed {
-                        message: "unary elementwise operation is not implemented by ROCm provider"
-                            .to_owned(),
-                    }),
+                    _ => Err(unsupported_unary_operation(operation)),
                 }
             }
         }
@@ -430,5 +440,24 @@ where
     ) -> Result<(), Self::Error> {
         self.0
             .elementwise_unary(operation, input, input_layout, output, output_layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{unsupported_binary_operation, unsupported_unary_operation};
+    use coeus_ops::{BinaryOp, UnaryOp};
+    use hephaestus_core::HephaestusError;
+
+    #[test]
+    fn unsupported_operations_are_reported_as_typed_provider_errors() {
+        assert!(matches!(
+            unsupported_binary_operation(BinaryOp::Eq),
+            HephaestusError::DispatchFailed { .. }
+        ));
+        assert!(matches!(
+            unsupported_unary_operation(UnaryOp::Gelu),
+            HephaestusError::DispatchFailed { .. }
+        ));
     }
 }

--- a/crates/coeus-rocm/src/backend.rs
+++ b/crates/coeus-rocm/src/backend.rs
@@ -1,10 +1,10 @@
 use coeus_core::{ComputeBackend, Layout, Scalar};
 use coeus_hephaestus::{
-    HephaestusBackend, HephaestusBackendError, HephaestusProvider, HephaestusStorage,
-    RankTwoOperand, ReductionProvider, ScanOperation,
+    ElementwiseProvider, HephaestusBackend, HephaestusBackendError, HephaestusProvider,
+    HephaestusStorage, RankedOperand, ReductionProvider, ScanOperation,
 };
-use coeus_ops::{ReductionOp, ReductionOps};
-use hephaestus_core::{ComputeDevice, ScanDirection};
+use coeus_ops::{BinaryOp, ElementwiseOps, ReductionOp, ReductionOps, UnaryOp};
+use hephaestus_core::{ComputeDevice, HephaestusError, ScanDirection};
 use hephaestus_rocm::{RocmDevice, StridedOperand};
 use std::sync::OnceLock;
 
@@ -30,9 +30,9 @@ macro_rules! impl_reduction_provider {
             fn reduce(
                 device: &Self::Device,
                 op: ReductionOp,
-                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
                 axis: usize,
-                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
             ) -> hephaestus_core::Result<()> {
                 let input = StridedOperand {
                     buffer: input.buffer,
@@ -83,11 +83,11 @@ macro_rules! impl_reduction_provider {
 
             fn scan(
                 device: &Self::Device,
-                input: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
                 axis: usize,
                 operation: ScanOperation,
                 direction: ScanDirection,
-                output: RankTwoOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, 2>,
             ) -> hephaestus_core::Result<()> {
                 let input = StridedOperand {
                     buffer: input.buffer,
@@ -127,6 +127,165 @@ macro_rules! impl_reduction_provider {
 impl_reduction_provider!(f32);
 impl_reduction_provider!(u32);
 impl_reduction_provider!(i32);
+
+macro_rules! impl_elementwise_provider {
+    ($scalar:ty) => {
+        impl ElementwiseProvider<$scalar> for RocmProvider {
+            fn binary<const N: usize>(
+                device: &Self::Device,
+                operation: BinaryOp,
+                lhs: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+                rhs: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+            ) -> hephaestus_core::Result<()> {
+                let lhs = hephaestus_rocm::StridedOperand {
+                    buffer: lhs.buffer,
+                    layout: lhs.layout,
+                };
+                let rhs = hephaestus_rocm::StridedOperand {
+                    buffer: rhs.buffer,
+                    layout: rhs.layout,
+                };
+                let output = hephaestus_rocm::StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match operation {
+                    BinaryOp::Add => hephaestus_rocm::binary_elementwise_strided_into::<
+                        hephaestus_rocm::AddOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    BinaryOp::Sub => hephaestus_rocm::binary_elementwise_strided_into::<
+                        hephaestus_rocm::SubOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    BinaryOp::Mul => hephaestus_rocm::binary_elementwise_strided_into::<
+                        hephaestus_rocm::MulOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    BinaryOp::Div => hephaestus_rocm::binary_elementwise_strided_into::<
+                        hephaestus_rocm::DivOp,
+                        $scalar,
+                        N,
+                    >(
+                        device,
+                        lhs,
+                        rhs,
+                        output,
+                        hephaestus_core::BlockWidth::DEFAULT,
+                    ),
+                    _ => Err(HephaestusError::DispatchFailed {
+                        message: "binary elementwise operation is not implemented by ROCm provider"
+                            .to_owned(),
+                    }),
+                }
+            }
+
+            fn unary<const N: usize>(
+                device: &Self::Device,
+                operation: UnaryOp,
+                input: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+                output: RankedOperand<'_, <Self::Device as ComputeDevice>::Buffer<$scalar>, N>,
+            ) -> hephaestus_core::Result<()> {
+                let input = hephaestus_rocm::StridedOperand {
+                    buffer: input.buffer,
+                    layout: input.layout,
+                };
+                let output = hephaestus_rocm::StridedOperand {
+                    buffer: output.buffer,
+                    layout: output.layout,
+                };
+                match operation {
+                    UnaryOp::Sin => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::SinOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Cos => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::CosOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Exp => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::ExpOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Log => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::LnOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Neg => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::NegOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Abs => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::AbsOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Sqrt => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::SqrtOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    UnaryOp::Recip => hephaestus_rocm::unary_elementwise_strided_into::<
+                        hephaestus_rocm::RecipOp,
+                        $scalar,
+                        N,
+                    >(
+                        device, input, output, hephaestus_core::BlockWidth::DEFAULT
+                    ),
+                    _ => Err(HephaestusError::DispatchFailed {
+                        message: "unary elementwise operation is not implemented by ROCm provider"
+                            .to_owned(),
+                    }),
+                }
+            }
+        }
+    };
+}
+
+impl_elementwise_provider!(f32);
+impl_elementwise_provider!(u32);
+impl_elementwise_provider!(i32);
 
 /// Coeus ROCm backend with native Hephaestus storage and rank-2 reductions.
 #[derive(Debug, Clone, Copy, Default)]
@@ -232,5 +391,44 @@ where
         c_layout: &Layout,
     ) -> Result<(), Self::Error> {
         self.0.suffix_prod(a, a_layout, axis, c, c_layout)
+    }
+}
+
+impl<T> ElementwiseOps<T> for RocmBackend
+where
+    T: Scalar + leto_ops::Scalar,
+    RocmProvider: ElementwiseProvider<T>,
+{
+    fn elementwise_binary(
+        &self,
+        operation: BinaryOp,
+        lhs: &Self::DeviceBuffer<T>,
+        lhs_layout: &Layout,
+        rhs: &Self::DeviceBuffer<T>,
+        rhs_layout: &Layout,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0.elementwise_binary(
+            operation,
+            lhs,
+            lhs_layout,
+            rhs,
+            rhs_layout,
+            output,
+            output_layout,
+        )
+    }
+
+    fn elementwise_unary(
+        &self,
+        operation: UnaryOp,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) -> Result<(), Self::Error> {
+        self.0
+            .elementwise_unary(operation, input, input_layout, output, output_layout)
     }
 }

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -1,0 +1,160 @@
+use coeus_core::{BinaryOp, ComputeBackend, CpuUnaryOp, Layout};
+use coeus_ops::ElementwiseOps;
+use coeus_rocm::RocmBackend;
+
+fn require_device() -> bool {
+    let available = hephaestus_rocm::RocmDevice::try_default().is_ok();
+    if !available {
+        assert_ne!(
+            std::env::var("HEPHAESTUS_ROCM_REQUIRE_DEVICE").as_deref(),
+            Ok("1"),
+            "ROCm CI requires an acquired device"
+        );
+    }
+    available
+}
+
+fn assert_close(actual: &[f32], expected: &[f32], operation: &str) {
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        let tolerance = f32::EPSILON * 512.0 * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "ROCm {operation} mismatch at {index}: actual {actual}, expected {expected}, tolerance {tolerance}"
+        );
+    }
+}
+
+#[test]
+fn native_elementwise_operations_match_leto_with_broadcasting() {
+    if !require_device() {
+        return;
+    }
+
+    let backend = RocmBackend::new();
+    assert_eq!(backend.name(), "rocm");
+    let lhs_layout = Layout::new([2, 3].into());
+    let rhs_layout = Layout::new([1, 3].into());
+    let output_layout = Layout::new([2, 3].into());
+    let lhs = [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let rhs = [2.0_f32, 4.0, 6.0];
+    let mut device_lhs = backend.allocate::<f32>(lhs.len());
+    let mut device_rhs = backend.allocate::<f32>(rhs.len());
+    backend.copy_to_device(&lhs, &mut device_lhs);
+    backend.copy_to_device(&rhs, &mut device_rhs);
+
+    for operation in [BinaryOp::Add, BinaryOp::Sub, BinaryOp::Mul, BinaryOp::Div] {
+        let mut expected = [0.0_f32; 6];
+        coeus_leto::elementwise_binary_into(
+            operation,
+            &lhs_layout,
+            &lhs,
+            &rhs_layout,
+            &rhs,
+            &output_layout,
+            &mut expected,
+        )
+        .expect("Leto binary elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(lhs.len());
+        backend
+            .elementwise_binary(
+                operation,
+                &device_lhs,
+                &lhs_layout,
+                &device_rhs,
+                &rhs_layout,
+                &mut actual,
+                &output_layout,
+            )
+            .expect("ROCm binary elementwise dispatch failed");
+        let mut actual_values = [0.0_f32; 6];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "binary");
+    }
+
+    for (shape, lhs, rhs) in [
+        (
+            vec![6],
+            vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![6.0_f32; 6],
+        ),
+        (
+            vec![2, 2, 2],
+            vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            vec![2.0_f32; 8],
+        ),
+        (
+            vec![1, 2, 2, 2],
+            vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            vec![2.0_f32; 8],
+        ),
+    ] {
+        let layout = Layout::new(shape.into());
+        let mut device_lhs = backend.allocate::<f32>(lhs.len());
+        let mut device_rhs = backend.allocate::<f32>(rhs.len());
+        backend.copy_to_device(&lhs, &mut device_lhs);
+        backend.copy_to_device(&rhs, &mut device_rhs);
+        let mut expected = vec![0.0_f32; lhs.len()];
+        coeus_leto::elementwise_binary_into(
+            BinaryOp::Add,
+            &layout,
+            &lhs,
+            &layout,
+            &rhs,
+            &layout,
+            &mut expected,
+        )
+        .expect("Leto ranked elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(lhs.len());
+        backend
+            .elementwise_binary(
+                BinaryOp::Add,
+                &device_lhs,
+                &layout,
+                &device_rhs,
+                &layout,
+                &mut actual,
+                &layout,
+            )
+            .expect("ROCm ranked elementwise dispatch failed");
+        let mut actual_values = vec![0.0_f32; lhs.len()];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "ranked binary");
+    }
+
+    let unary_input = [0.25_f32, 0.5, 1.0, 2.0, 3.0, 4.0];
+    let mut device_unary_input = backend.allocate::<f32>(unary_input.len());
+    backend.copy_to_device(&unary_input, &mut device_unary_input);
+    for operation in [
+        CpuUnaryOp::Sin,
+        CpuUnaryOp::Cos,
+        CpuUnaryOp::Exp,
+        CpuUnaryOp::Log,
+        CpuUnaryOp::Neg,
+        CpuUnaryOp::Abs,
+        CpuUnaryOp::Sqrt,
+        CpuUnaryOp::Recip,
+    ] {
+        let mut expected = [0.0_f32; 6];
+        coeus_leto::elementwise_unary_into(
+            operation,
+            &lhs_layout,
+            &unary_input,
+            &output_layout,
+            &mut expected,
+        )
+        .expect("Leto unary elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(unary_input.len());
+        backend
+            .elementwise_unary(
+                operation,
+                &device_unary_input,
+                &lhs_layout,
+                &mut actual,
+                &output_layout,
+            )
+            .expect("ROCm unary elementwise dispatch failed");
+        let mut actual_values = [0.0_f32; 6];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "unary");
+    }
+}

--- a/docs/adr/0023-coeus-hephaestus-elementwise-providers.md
+++ b/docs/adr/0023-coeus-hephaestus-elementwise-providers.md
@@ -1,0 +1,42 @@
+# ADR-0023: Add ranked Coeus Hephaestus elementwise providers
+
+## Status
+
+Accepted; implemented in the native ROCm and Metal elementwise increment.
+
+## Decision
+
+Extend the existing `coeus-hephaestus` integration layer with one fixed-rank,
+const-generic elementwise provider seam. The consumer dispatches ranks 1
+through 4 and converts dynamic Coeus layouts into left-padded Leto layouts.
+ROCm and Metal implement the seam by mapping Coeus operation tags to the
+native Hephaestus strided kernels. The supported operation set is Add, Sub,
+Mul, Div, Sin, Cos, Exp, Log, Neg, Abs, Sqrt, and Recip.
+
+Broadcasting remains an input-layout concern owned by the Hephaestus strided
+kernel. Output zero-stride aliasing is rejected at the Coeus boundary, and
+unsupported ranks or provider operations return typed errors. The provider
+does not copy computation through the host and does not duplicate the
+elementwise algorithm per vendor.
+
+`RankTwoOperand` is replaced by the rank-generic `RankedOperand`; all in-repo
+callers are migrated in this change. This is a public-name migration for the
+integration crate and is intentionally not bridged by a compatibility alias.
+
+## Alternatives rejected
+
+Separate ROCm and Metal operation trees were rejected because they duplicate
+dispatch and allow backend semantics to drift. Retaining a `RankTwoOperand`
+alias was rejected because it would preserve a second public mental model for
+the rank-generic operand and violate the repository's compatibility-shim
+policy.
+
+## Verification
+
+The ROCm and Metal tests compare the native binary and unary operations with
+the Leto CPU oracle over contiguous and broadcast inputs at ranks 1 through 4.
+The backend-parity workflow runs the existing WGPU and CUDA elementwise
+contracts together with the new ROCm and Metal contracts. Exact-head run
+`30223618665` passed WGPU `89850168729`, CUDA `89850168726`, ROCm
+`89850168739`, and Metal `89850168706`; the required-device ROCm lane
+`89850168954` was skipped because the workflow was not manually dispatched.

--- a/docs/adr/0023-coeus-hephaestus-elementwise-providers.md
+++ b/docs/adr/0023-coeus-hephaestus-elementwise-providers.md
@@ -37,6 +37,6 @@ The ROCm and Metal tests compare the native binary and unary operations with
 the Leto CPU oracle over contiguous and broadcast inputs at ranks 1 through 4.
 The backend-parity workflow runs the existing WGPU and CUDA elementwise
 contracts together with the new ROCm and Metal contracts. Exact-head run
-`30223618665` passed WGPU `89850168729`, CUDA `89850168726`, ROCm
-`89850168739`, and Metal `89850168706`; the required-device ROCm lane
-`89850168954` was skipped because the workflow was not manually dispatched.
+`30224422963` passed WGPU `89852207720`, CUDA `89852207699`, ROCm
+`89852207677`, and Metal `89852207739`; the required-device ROCm lane
+`89852208025` was skipped because the workflow was not manually dispatched.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,10 +16,15 @@
   passes.
 - Risk/change class: `[arch]` provider-boundary extension with additive
   consumer capability.
-- Status: in-progress; claimed files are the shared Hephaestus adapter,
-  provider crates, focused tests, and synchronized CI/docs.
+- Status: complete. The shared adapter, provider crates, focused tests, CI,
+  and ADR are delivered in `a3e586c3`. Exact-head run `30223618665` passed
+  WGPU `89850168729`, CUDA `89850168726`, ROCm `89850168739`, and Metal
+  `89850168706`; the required-device ROCm lane `89850168954` was skipped
+  because the workflow was not manually dispatched.
 - Decision: extend the existing generic provider layer with a ranked
   elementwise seam; vendor crates map operation tags to Hephaestus kernels.
+  ADR-0023 records the boundary and the intentional `RankTwoOperand` to
+  `RankedOperand` public-name migration.
 
 ## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers [arch]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,9 +17,9 @@
 - Risk/change class: `[arch]` provider-boundary extension with additive
   consumer capability.
 - Status: complete. The shared adapter, provider crates, focused tests, CI,
-  and ADR are delivered in `a3e586c3`. Exact-head run `30223618665` passed
-  WGPU `89850168729`, CUDA `89850168726`, ROCm `89850168739`, and Metal
-  `89850168706`; the required-device ROCm lane `89850168954` was skipped
+  and ADR are delivered in `df78aba2`. Exact-head run `30224422963` passed
+  WGPU `89852207720`, CUDA `89852207699`, ROCm `89852207677`, and Metal
+  `89852207739`; the required-device ROCm lane `89852208025` was skipped
   because the workflow was not manually dispatched.
 - Decision: extend the existing generic provider layer with a ranked
   elementwise seam; vendor crates map operation tags to Hephaestus kernels.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,26 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers [arch]
+
+- Owner: Codex; scope: `coeus-hephaestus`, `coeus-rocm`, `coeus-metal`, their
+  Leto differential tests, and backend-parity CI.
+- Outcome: route the common binary arithmetic and unary math elementwise
+  contract through Hephaestus for ROCm and Metal using one rank-generic
+  provider layer.
+- Non-goals: comparisons, parameterized activations, higher-rank-than-four
+  layouts, and unrelated matmul/convolution families remain separate slices.
+- Acceptance: Add/Sub/Mul/Div and Sin/Cos/Exp/Log/Neg/Abs/Sqrt/Recip match the
+  Leto CPU oracle on contiguous and broadcast rank-1 through rank-4 inputs for
+  ROCm and Metal; unsupported operations and ranks return typed errors; no CPU
+  fallback or vendor algorithm clone is added; the full provider CI matrix
+  passes.
+- Risk/change class: `[arch]` provider-boundary extension with additive
+  consumer capability.
+- Status: in-progress; claimed files are the shared Hephaestus adapter,
+  provider crates, focused tests, and synchronized CI/docs.
+- Decision: extend the existing generic provider layer with a ranked
+  elementwise seam; vendor crates map operation tags to Hephaestus kernels.
+
 ## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers [arch]
 
 - Owner: Codex; scope: `coeus-hephaestus`, `coeus-rocm`, `coeus-metal`, their

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -9,9 +9,9 @@
 - [x] Compare provider results with Leto for contiguous and broadcast inputs;
       cover unsupported operation/rank errors.
 - [x] Run exact-head ROCm, Metal, WGPU, and CUDA backend-parity CI and record
-      the terminal run and job IDs: `30223618665` passed WGPU
-      `89850168729`, CUDA `89850168726`, ROCm `89850168739`, and Metal
-      `89850168706`; required-device ROCm `89850168954` was skipped because
+      the terminal run and job IDs: `30224422963` passed WGPU
+      `89852207720`, CUDA `89852207699`, ROCm `89852207677`, and Metal
+      `89852207739`; required-device ROCm `89852208025` was skipped because
       the workflow was not manually dispatched.
 
 ## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,14 +2,17 @@
 
 ## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers
 
-- [ ] Add the generic ranked Hephaestus elementwise provider seam for
+- [x] Add the generic ranked Hephaestus elementwise provider seam for
       contiguous and broadcast rank-1 through rank-4 layouts.
-- [ ] Add native ROCm and Metal implementations for the common arithmetic and
+- [x] Add native ROCm and Metal implementations for the common arithmetic and
       unary math operation set.
-- [ ] Compare provider results with Leto for contiguous and broadcast inputs;
+- [x] Compare provider results with Leto for contiguous and broadcast inputs;
       cover unsupported operation/rank errors.
-- [ ] Run exact-head ROCm, Metal, WGPU, and CUDA backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Run exact-head ROCm, Metal, WGPU, and CUDA backend-parity CI and record
+      the terminal run and job IDs: `30223618665` passed WGPU
+      `89850168729`, CUDA `89850168726`, ROCm `89850168739`, and Metal
+      `89850168706`; required-device ROCm `89850168954` was skipped because
+      the workflow was not manually dispatched.
 
 ## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,16 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers
+
+- [ ] Add the generic ranked Hephaestus elementwise provider seam for
+      contiguous and broadcast rank-1 through rank-4 layouts.
+- [ ] Add native ROCm and Metal implementations for the common arithmetic and
+      unary math operation set.
+- [ ] Compare provider results with Leto for contiguous and broadcast inputs;
+      cover unsupported operation/rank errors.
+- [ ] Run exact-head ROCm, Metal, WGPU, and CUDA backend-parity CI and record
+      the terminal run and job IDs.
+
 ## ATLAS-COEUS-HEPHAESTUS-001 — Native ROCm and Metal reduction providers
 
 - [x] Add one generic `coeus-hephaestus` storage and reduction/scan dispatch


### PR DESCRIPTION
## Summary\n- add one rank-generic Hephaestus elementwise seam for Coeus\n- map Add/Sub/Mul/Div and Sin/Cos/Exp/Log/Neg/Abs/Sqrt/Recip to native ROCm and Metal kernels\n- compare ranks 1 through 4, contiguous and broadcast inputs, with Leto\n- extend WGPU, CUDA, ROCm, Metal, and required-device ROCm CI filters\n\n## Verification\n- cargo clippy --locked --package coeus-hephaestus --package coeus-rocm --package coeus-metal --all-targets --no-deps -- -D warnings\n- cargo nextest run --locked --package coeus-hephaestus --package coeus-rocm --package coeus-metal --status-level fail --final-status-level fail\n- cargo test --locked --package coeus-hephaestus --package coeus-rocm --package coeus-metal --doc\n\nRefs: docs/backlog.md#atlas-coeus-hephaestus-002

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds native ROCm and Metal elementwise operation support through a new rank-generic Hephaestus provider layer. It introduces an `ElementwiseProvider` trait supporting binary operations (Add, Sub, Mul, Div) and unary operations (Sin, Cos, Exp, Log, Neg, Abs, Sqrt, Recip) for ranks 1-4 with broadcasting capability. The implementation refactors the existing layout conversion logic from rank-2 specific to rank-generic, extends both ROCm and Metal backends with elementwise implementations, and adds comprehensive differential tests comparing results against the Leto CPU reference. CI workflows are updated to include the new elementwise test filters for WGPU, CUDA, ROCm, and Metal pipelines.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/backlog.md` |
| 2 | `docs/checklist.md` |
| 3 | `crates/coeus-hephaestus/src/elementwise.rs` |
| 4 | `crates/coeus-hephaestus/src/lib.rs` |
| 5 | `crates/coeus-hephaestus/src/layout.rs` |
| 6 | `crates/coeus-hephaestus/src/reduction.rs` |
| 7 | `crates/coeus-rocm/src/backend.rs` |
| 8 | `crates/coeus-metal/src/backend.rs` |
| 9 | `crates/coeus-rocm/tests/elementwise.rs` |
| 10 | `crates/coeus-metal/tests/elementwise.rs` |
| 11 | `.github/workflows/backend-parity.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native elementwise arithmetic and math operations for ROCm and Metal backends, including broadcasting across ranks 1–4.
  * Added support for common binary operations such as add, subtract, multiply, and divide.
  * Added unary operations including trigonometric, exponential, logarithmic, sign, absolute value, square root, and reciprocal functions.

* **Bug Fixes**
  * Improved layout validation and rejected unsupported broadcasted output layouts.

* **Tests**
  * Added backend integration coverage and expanded parity checks for ROCm, Metal, WGPU, and CUDA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->