### PR TITLE
feat(coeus): Add activation providers

### DIFF
--- a/crates/coeus-metal/src/backend.rs
+++ b/crates/coeus-metal/src/backend.rs
@@ -144,8 +144,79 @@ impl_reduction_provider!(f32);
 impl_reduction_provider!(u32);
 impl_reduction_provider!(i32);
 
+macro_rules! activation_unary_dispatch {
+    (activations, $operation:expr, $device:expr, $input:expr, $output:expr) => {
+        match $operation {
+            UnaryOp::Relu => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::ReluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::ReluGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::ReluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sigmoid => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SigmoidOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::SigmoidGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SigmoidGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Tanh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::TanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::TanhGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::TanhGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::GeluTanh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::GeluTanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::GeluTanhGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::GeluTanhGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Silu => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SiluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::SiluGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SiluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Softplus => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SoftplusOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::SoftplusGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SoftplusGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            _ => Err(unsupported_unary_operation($operation)),
+        }
+    };
+    (arithmetic_only, $operation:expr, $device:expr, $input:expr, $output:expr) => {
+        Err(unsupported_unary_operation($operation))
+    };
+}
+
 macro_rules! impl_elementwise_provider {
-    ($scalar:ty) => {
+    ($scalar:ty, $activation_mode:ident) => {
         impl ElementwiseProvider<$scalar> for MetalProvider {
             fn binary<const N: usize>(
                 device: &Self::Device,
@@ -286,16 +357,22 @@ macro_rules! impl_elementwise_provider {
                     >(
                         device, input, output, hephaestus_core::BlockWidth::DEFAULT
                     ),
-                    _ => Err(unsupported_unary_operation(operation)),
+                    _ => activation_unary_dispatch!(
+                        $activation_mode,
+                        operation,
+                        device,
+                        input,
+                        output
+                    ),
                 }
             }
         }
     };
 }
 
-impl_elementwise_provider!(f32);
-impl_elementwise_provider!(u32);
-impl_elementwise_provider!(i32);
+impl_elementwise_provider!(f32, activations);
+impl_elementwise_provider!(u32, arithmetic_only);
+impl_elementwise_provider!(i32, arithmetic_only);
 
 /// Coeus Metal backend with native Hephaestus storage and rank-2 reductions.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -157,4 +157,46 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         backend.copy_to_host(&actual, &mut actual_values);
         assert_close(&actual_values, &expected, "unary");
     }
+
+    let activation_input = [-3.0_f32, -1.0, 0.0, 0.25, 1.0, 3.0];
+    let activation_layout = Layout::new([6].into());
+    let mut device_activation_input = backend.allocate::<f32>(activation_input.len());
+    backend.copy_to_device(&activation_input, &mut device_activation_input);
+    for operation in [
+        CpuUnaryOp::Relu,
+        CpuUnaryOp::Sigmoid,
+        CpuUnaryOp::Tanh,
+        CpuUnaryOp::GeluTanh,
+        CpuUnaryOp::Silu,
+        CpuUnaryOp::Softplus,
+        CpuUnaryOp::ReluGrad,
+        CpuUnaryOp::SigmoidGrad,
+        CpuUnaryOp::TanhGrad,
+        CpuUnaryOp::GeluTanhGrad,
+        CpuUnaryOp::SiluGrad,
+        CpuUnaryOp::SoftplusGrad,
+    ] {
+        let mut expected = [0.0_f32; 6];
+        coeus_leto::elementwise_unary_into(
+            operation,
+            &activation_layout,
+            &activation_input,
+            &activation_layout,
+            &mut expected,
+        )
+        .expect("Leto activation elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(activation_input.len());
+        backend
+            .elementwise_unary(
+                operation,
+                &device_activation_input,
+                &activation_layout,
+                &mut actual,
+                &activation_layout,
+            )
+            .expect("Metal activation elementwise dispatch failed");
+        let mut actual_values = [0.0_f32; 6];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "activation");
+    }
 }

--- a/crates/coeus-rocm/src/backend.rs
+++ b/crates/coeus-rocm/src/backend.rs
@@ -144,8 +144,79 @@ impl_reduction_provider!(f32);
 impl_reduction_provider!(u32);
 impl_reduction_provider!(i32);
 
+macro_rules! activation_unary_dispatch {
+    (activations, $operation:expr, $device:expr, $input:expr, $output:expr) => {
+        match $operation {
+            UnaryOp::Relu => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::ReluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::ReluGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::ReluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sigmoid => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SigmoidOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::SigmoidGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SigmoidGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Tanh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::TanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::TanhGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::TanhGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::GeluTanh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::GeluTanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::GeluTanhGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::GeluTanhGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Silu => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SiluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::SiluGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SiluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Softplus => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SoftplusOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::SoftplusGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SoftplusGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            _ => Err(unsupported_unary_operation($operation)),
+        }
+    };
+    (arithmetic_only, $operation:expr, $device:expr, $input:expr, $output:expr) => {
+        Err(unsupported_unary_operation($operation))
+    };
+}
+
 macro_rules! impl_elementwise_provider {
-    ($scalar:ty) => {
+    ($scalar:ty, $activation_mode:ident) => {
         impl ElementwiseProvider<$scalar> for RocmProvider {
             fn binary<const N: usize>(
                 device: &Self::Device,
@@ -286,16 +357,22 @@ macro_rules! impl_elementwise_provider {
                     >(
                         device, input, output, hephaestus_core::BlockWidth::DEFAULT
                     ),
-                    _ => Err(unsupported_unary_operation(operation)),
+                    _ => activation_unary_dispatch!(
+                        $activation_mode,
+                        operation,
+                        device,
+                        input,
+                        output
+                    ),
                 }
             }
         }
     };
 }
 
-impl_elementwise_provider!(f32);
-impl_elementwise_provider!(u32);
-impl_elementwise_provider!(i32);
+impl_elementwise_provider!(f32, activations);
+impl_elementwise_provider!(u32, arithmetic_only);
+impl_elementwise_provider!(i32, arithmetic_only);
 
 /// Coeus ROCm backend with native Hephaestus storage and rank-2 reductions.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -157,4 +157,46 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         backend.copy_to_host(&actual, &mut actual_values);
         assert_close(&actual_values, &expected, "unary");
     }
+
+    let activation_input = [-3.0_f32, -1.0, 0.0, 0.25, 1.0, 3.0];
+    let activation_layout = Layout::new([6].into());
+    let mut device_activation_input = backend.allocate::<f32>(activation_input.len());
+    backend.copy_to_device(&activation_input, &mut device_activation_input);
+    for operation in [
+        CpuUnaryOp::Relu,
+        CpuUnaryOp::Sigmoid,
+        CpuUnaryOp::Tanh,
+        CpuUnaryOp::GeluTanh,
+        CpuUnaryOp::Silu,
+        CpuUnaryOp::Softplus,
+        CpuUnaryOp::ReluGrad,
+        CpuUnaryOp::SigmoidGrad,
+        CpuUnaryOp::TanhGrad,
+        CpuUnaryOp::GeluTanhGrad,
+        CpuUnaryOp::SiluGrad,
+        CpuUnaryOp::SoftplusGrad,
+    ] {
+        let mut expected = [0.0_f32; 6];
+        coeus_leto::elementwise_unary_into(
+            operation,
+            &activation_layout,
+            &activation_input,
+            &activation_layout,
+            &mut expected,
+        )
+        .expect("Leto activation elementwise oracle failed");
+        let mut actual = backend.allocate::<f32>(activation_input.len());
+        backend
+            .elementwise_unary(
+                operation,
+                &device_activation_input,
+                &activation_layout,
+                &mut actual,
+                &activation_layout,
+            )
+            .expect("ROCm activation elementwise dispatch failed");
+        let mut actual_values = [0.0_f32; 6];
+        backend.copy_to_host(&actual, &mut actual_values);
+        assert_close(&actual_values, &expected, "activation");
+    }
 }

--- a/docs/adr/0024-coeus-hephaestus-activation-providers.md
+++ b/docs/adr/0024-coeus-hephaestus-activation-providers.md
@@ -1,0 +1,40 @@
+# ADR-0024: Add common Hephaestus activation providers
+
+## Status
+
+Accepted; implementation is in progress across Hephaestus and Coeus.
+
+## Decision
+
+Extend the Hephaestus operation vocabulary with the common activation forward
+and gradient expressions already supported by the Coeus WGPU and CUDA
+providers: ReLU, sigmoid, tanh, tanh-approximated GELU, SiLU, and softplus.
+ROCm and Metal dispatch these expressions through their native Hephaestus
+strided elementwise kernels. The provider implementations are restricted to
+`f32`; integer storage keeps the existing typed unsupported-operation result
+instead of compiling floating-point formulas for integer shaders.
+
+The expressions remain dialect-specific constants on the existing
+`UnaryExpr<L>` seam. This keeps one operation vocabulary while preserving the
+WGSL, CUDA C++, and HIP C++ syntax required by each compiler. The operation
+formulas match the existing Coeus CPU/Leto contracts, including the tanh GELU
+approximation and its derivative.
+
+## Alternatives rejected
+
+- Copying activation kernels into Coeus ROCm and Metal would fork the shared
+  shader-expression and strided traversal logic.
+- Routing ROCm or Metal activations through CPU evaluation would hide provider
+  capability gaps and violate the device-resident output contract.
+- Generalizing the activation formulas to integer scalars would create
+  invalid floating-point shader programs; the supported type boundary is
+  explicit instead.
+
+## Verification
+
+Hephaestus core expression tests pin representative dialect expressions.
+Coeus ROCm and Metal tests compare the native forward and gradient activation
+results against the Leto CPU oracle on signed `f32` inputs. The backend-parity
+workflow keeps the existing WGPU and CUDA activation contracts in the same
+matrix and adds the native ROCm/Metal activation cases to their focused test
+filters.

--- a/docs/adr/0024-coeus-hephaestus-activation-providers.md
+++ b/docs/adr/0024-coeus-hephaestus-activation-providers.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted; implementation is in progress across Hephaestus and Coeus.
+Accepted; implementation is complete locally and code-head CI passed. The
+documentation-only head requires one final matrix rerun before merge.
 
 ## Decision
 
@@ -13,6 +14,9 @@ ROCm and Metal dispatch these expressions through their native Hephaestus
 strided elementwise kernels. The provider implementations are restricted to
 `f32`; integer storage keeps the existing typed unsupported-operation result
 instead of compiling floating-point formulas for integer shaders.
+
+Hephaestus provides the shared vocabulary at merged master commit `7ac5359`;
+Coeus consumes it in commit `28c3cbf`.
 
 The expressions remain dialect-specific constants on the existing
 `UnaryExpr<L>` seam. This keeps one operation vocabulary while preserving the
@@ -37,4 +41,6 @@ Coeus ROCm and Metal tests compare the native forward and gradient activation
 results against the Leto CPU oracle on signed `f32` inputs. The backend-parity
 workflow keeps the existing WGPU and CUDA activation contracts in the same
 matrix and adds the native ROCm/Metal activation cases to their focused test
-filters.
+filters. Code-head run `30226854005` passed WGPU job `89858362274`, CUDA job
+`89858362266`, ROCm job `89858362239`, and Metal job `89858362247`; the
+required-device ROCm job `89858362563` skipped without hardware.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,7 +16,9 @@
   CUDA, ROCm, and Metal CI passes.
 - Risk/change class: `[arch]` shared accelerator operation-vocabulary
   extension with additive Coeus provider capability.
-- Status: in progress.
+- Status: implementation complete; code-head CI passed in run `30226854005`
+  (ROCm `89858362239`, Metal `89858362247`, CUDA `89858362266`, WGPU
+  `89858362274`); documentation-head rerun remains required before merge.
 - Decision: use one `UnaryExpr` marker per activation operation with
   dialect-specific WGSL/CUDA/HIP expressions; ADR-0024 records the boundary.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,25 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-HEPHAESTUS-003 — Native activation providers [arch]
+
+- Owner: Codex; scope: Hephaestus activation expressions and exports,
+  `coeus-hephaestus`, `coeus-rocm`, `coeus-metal`, Leto differential tests,
+  and backend-parity CI.
+- Outcome: route the common activation forward and gradient operation set
+  through native Hephaestus strided kernels for ROCm and Metal while keeping
+  WGPU and CUDA in the same tested capability matrix.
+- Non-goals: parameterized activations, exact-erf GELU, comparisons, higher
+  ranks, and unrelated matrix or convolution families remain separate slices.
+- Acceptance: ReLU, sigmoid, tanh, tanh-GELU, SiLU, and softplus forward and
+  gradient operations match Leto for signed `f32` inputs on ROCm and Metal;
+  integer requests remain typed unsupported operations; exact-head WGPU,
+  CUDA, ROCm, and Metal CI passes.
+- Risk/change class: `[arch]` shared accelerator operation-vocabulary
+  extension with additive Coeus provider capability.
+- Status: in progress.
+- Decision: use one `UnaryExpr` marker per activation operation with
+  dialect-specific WGSL/CUDA/HIP expressions; ADR-0024 records the boundary.
+
 ## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers [arch]
 
 - Owner: Codex; scope: `coeus-hephaestus`, `coeus-rocm`, `coeus-metal`, their

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,16 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-HEPHAESTUS-003 — Native activation providers
+
+- [ ] Add dialect-specific Hephaestus activation and gradient expression
+      markers and export them through the backend crates.
+- [ ] Dispatch the common activation set through native ROCm and Metal
+      strided providers with an explicit `f32` capability boundary.
+- [ ] Compare ROCm and Metal forward/gradient activation results with Leto on
+      signed inputs and test unsupported integer requests.
+- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs.
+
 ## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers
 
 - [x] Add the generic ranked Hephaestus elementwise provider seam for

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -2,14 +2,16 @@
 
 ## ATLAS-COEUS-HEPHAESTUS-003 — Native activation providers
 
-- [ ] Add dialect-specific Hephaestus activation and gradient expression
+- [x] Add dialect-specific Hephaestus activation and gradient expression
       markers and export them through the backend crates.
-- [ ] Dispatch the common activation set through native ROCm and Metal
+- [x] Dispatch the common activation set through native ROCm and Metal
       strided providers with an explicit `f32` capability boundary.
-- [ ] Compare ROCm and Metal forward/gradient activation results with Leto on
+- [x] Compare ROCm and Metal forward/gradient activation results with Leto on
       signed inputs and test unsupported integer requests.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Run exact code-head WGPU, CUDA, ROCm, and Metal backend-parity CI:
+      run `30226854005`, WGPU `89858362274`, CUDA `89858362266`, ROCm
+      `89858362239`, and Metal `89858362247` passed; the documentation-head
+      rerun remains required before merge.
 
 ## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers
 


### PR DESCRIPTION
## Summary\n- route ReLU, sigmoid, tanh, tanh-GELU, SiLU, and softplus forward/gradient operations through native Hephaestus ROCm and Metal strided kernels\n- keep the activation capability boundary at f32 and return typed unsupported-operation errors for integer providers\n- compare signed activation results against Leto and record the shared provider decision in ADR-0024\n\n## Dependency\n- Hephaestus activation vocabulary is merged on master at 7ac5359 (PR #110).\n\n## Verification\n- rustfmt --edition 2024 on changed Rust files\n- cargo clippy --locked -p coeus-rocm -p coeus-metal --all-targets --no-deps -- -D warnings\n- cargo nextest run --locked -p coeus-rocm -p coeus-metal --status-level fail --final-status-level fail\n- cargo test --locked -p coeus-rocm -p coeus-metal --doc\n- exact-head WGPU, CUDA, ROCm, and Metal backend CI

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds activation function support (ReLU, sigmoid, tanh, tanh-GELU, SiLU, and softplus) along with their gradient operations to the Coeus ROCm and Metal backends by routing them through native Hephaestus strided kernels. The implementation restricts activation operations to `f32` only, returning typed unsupported-operation errors for integer types. Results are validated against the Leto CPU oracle and the architectural decision is documented in ADR-0024.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0024-coeus-hephaestus-activation-providers.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/checklist.md` |
| 4 | `crates/coeus-rocm/src/backend.rs` |
| 5 | `crates/coeus-metal/src/backend.rs` |
| 6 | `crates/coeus-rocm/tests/elementwise.rs` |
| 7 | `crates/coeus-metal/tests/elementwise.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->