### PR TITLE
Add native unary math providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - [arch] Routes the 19 unparameterized unary math operations already defined by
   Coeus/Leto through native Hephaestus ROCm and Metal strided providers for
   f32, with valid-domain Leto differential coverage and explicit integer
-  capability rejection.
+  capability rejection. Exact-head provider CI passed WGPU, CUDA, ROCm, and
+  Metal; the required-device ROCm lane was skipped without a registered AMD
+  runner.
 
 - [arch] Routes Coeus equality, inequality, and ordering binary operations
   through typed Hephaestus ROCm and Metal providers for f32, i32, and u32;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- [arch] Routes the 19 unparameterized unary math operations already defined by
+  Coeus/Leto through native Hephaestus ROCm and Metal strided providers for
+  f32, with valid-domain Leto differential coverage and explicit integer
+  capability rejection.
+
 - [arch] Routes Coeus equality, inequality, and ordering binary operations
   through typed Hephaestus ROCm and Metal providers for f32, i32, and u32;
   Leto differential coverage now exercises all six comparisons.

--- a/crates/coeus-metal/src/backend/elementwise.rs
+++ b/crates/coeus-metal/src/backend/elementwise.rs
@@ -74,6 +74,101 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Tan => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::TanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asin => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AsinOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acos => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AcosOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atan => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AtanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sinh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Cosh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::CoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log2 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Log2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log10 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Log10Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Exp2 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Exp2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atanh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AtanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asinh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AsinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acosh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AcoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Expm1 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Expm1Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log1p => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Log1pOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sign => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SignOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Floor => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::FloorOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Ceil => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::CeilOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Round => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::RoundOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Trunc => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::TruncOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -224,6 +224,70 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         assert_close(&actual_values, &expected, "unary");
     }
 
+    macro_rules! assert_unary_math {
+        ($operation:expr, $input:expr, $label:expr) => {{
+            let math_input: &[f32] = $input;
+            let math_layout = Layout::new([math_input.len()].into());
+            let mut device_math_input = backend.allocate::<f32>(math_input.len());
+            backend.copy_to_device(math_input, &mut device_math_input);
+            let mut expected = vec![0.0_f32; math_input.len()];
+            coeus_leto::elementwise_unary_into(
+                $operation,
+                &math_layout,
+                math_input,
+                &math_layout,
+                &mut expected,
+            )
+            .expect("Leto unary math elementwise oracle failed");
+            let mut actual = backend.allocate::<f32>(math_input.len());
+            backend
+                .elementwise_unary(
+                    $operation,
+                    &device_math_input,
+                    &math_layout,
+                    &mut actual,
+                    &math_layout,
+                )
+                .expect("Metal unary math elementwise dispatch failed");
+            let mut actual_values = vec![0.0_f32; math_input.len()];
+            backend.copy_to_host(&actual, &mut actual_values);
+            assert_close(&actual_values, &expected, $label);
+        }};
+    }
+
+    let bounded_math_input = [-0.75_f32, -0.25, 0.0, 0.25, 0.75];
+    for operation in [
+        CpuUnaryOp::Tan,
+        CpuUnaryOp::Asin,
+        CpuUnaryOp::Acos,
+        CpuUnaryOp::Atan,
+        CpuUnaryOp::Sinh,
+        CpuUnaryOp::Atanh,
+        CpuUnaryOp::Asinh,
+        CpuUnaryOp::Expm1,
+        CpuUnaryOp::Log1p,
+        CpuUnaryOp::Sign,
+        CpuUnaryOp::Floor,
+        CpuUnaryOp::Ceil,
+        CpuUnaryOp::Round,
+        CpuUnaryOp::Trunc,
+    ] {
+        assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
+    }
+
+    let positive_math_input = [0.25_f32, 0.5, 1.0, 2.0, 4.0];
+    for operation in [
+        CpuUnaryOp::Cosh,
+        CpuUnaryOp::Log2,
+        CpuUnaryOp::Log10,
+        CpuUnaryOp::Exp2,
+    ] {
+        assert_unary_math!(operation, &positive_math_input, "positive unary math");
+    }
+
+    let acosh_input = [1.0_f32, 1.25, 2.0, 4.0, 8.0];
+    assert_unary_math!(CpuUnaryOp::Acosh, &acosh_input, "acosh");
+
     let activation_input = [-3.0_f32, -1.0, 0.0, 0.25, 1.0, 3.0];
     let activation_layout = Layout::new([6].into());
     let mut device_activation_input = backend.allocate::<f32>(activation_input.len());

--- a/crates/coeus-rocm/src/backend/elementwise.rs
+++ b/crates/coeus-rocm/src/backend/elementwise.rs
@@ -74,6 +74,101 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Tan => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::TanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asin => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AsinOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acos => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AcosOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atan => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AtanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sinh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Cosh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::CoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log2 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Log2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log10 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Log10Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Exp2 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Exp2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atanh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AtanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asinh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AsinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acosh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AcoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Expm1 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Expm1Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log1p => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Log1pOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sign => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SignOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Floor => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::FloorOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Ceil => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::CeilOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Round => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::RoundOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Trunc => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::TruncOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -224,6 +224,70 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         assert_close(&actual_values, &expected, "unary");
     }
 
+    macro_rules! assert_unary_math {
+        ($operation:expr, $input:expr, $label:expr) => {{
+            let math_input: &[f32] = $input;
+            let math_layout = Layout::new([math_input.len()].into());
+            let mut device_math_input = backend.allocate::<f32>(math_input.len());
+            backend.copy_to_device(math_input, &mut device_math_input);
+            let mut expected = vec![0.0_f32; math_input.len()];
+            coeus_leto::elementwise_unary_into(
+                $operation,
+                &math_layout,
+                math_input,
+                &math_layout,
+                &mut expected,
+            )
+            .expect("Leto unary math elementwise oracle failed");
+            let mut actual = backend.allocate::<f32>(math_input.len());
+            backend
+                .elementwise_unary(
+                    $operation,
+                    &device_math_input,
+                    &math_layout,
+                    &mut actual,
+                    &math_layout,
+                )
+                .expect("ROCm unary math elementwise dispatch failed");
+            let mut actual_values = vec![0.0_f32; math_input.len()];
+            backend.copy_to_host(&actual, &mut actual_values);
+            assert_close(&actual_values, &expected, $label);
+        }};
+    }
+
+    let bounded_math_input = [-0.75_f32, -0.25, 0.0, 0.25, 0.75];
+    for operation in [
+        CpuUnaryOp::Tan,
+        CpuUnaryOp::Asin,
+        CpuUnaryOp::Acos,
+        CpuUnaryOp::Atan,
+        CpuUnaryOp::Sinh,
+        CpuUnaryOp::Atanh,
+        CpuUnaryOp::Asinh,
+        CpuUnaryOp::Expm1,
+        CpuUnaryOp::Log1p,
+        CpuUnaryOp::Sign,
+        CpuUnaryOp::Floor,
+        CpuUnaryOp::Ceil,
+        CpuUnaryOp::Round,
+        CpuUnaryOp::Trunc,
+    ] {
+        assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
+    }
+
+    let positive_math_input = [0.25_f32, 0.5, 1.0, 2.0, 4.0];
+    for operation in [
+        CpuUnaryOp::Cosh,
+        CpuUnaryOp::Log2,
+        CpuUnaryOp::Log10,
+        CpuUnaryOp::Exp2,
+    ] {
+        assert_unary_math!(operation, &positive_math_input, "positive unary math");
+    }
+
+    let acosh_input = [1.0_f32, 1.25, 2.0, 4.0, 8.0];
+    assert_unary_math!(CpuUnaryOp::Acosh, &acosh_input, "acosh");
+
     let activation_input = [-3.0_f32, -1.0, 0.0, 0.25, 1.0, 3.0];
     let activation_layout = Layout::new([6].into());
     let mut device_activation_input = backend.allocate::<f32>(activation_input.len());

--- a/docs/adr/0026-coeus-hephaestus-unary-math-providers.md
+++ b/docs/adr/0026-coeus-hephaestus-unary-math-providers.md
@@ -1,0 +1,51 @@
+# ADR-0026: Add native unary math providers
+
+## Status
+
+Accepted; implementation is in progress pending the exact-head backend matrix.
+
+## Decision
+
+Route the 19 unparameterized unary math operations already defined by Coeus
+and Leto through native Hephaestus strided kernels in the ROCm and Metal
+providers:
+
+`Tan`, `Asin`, `Acos`, `Atan`, `Sinh`, `Cosh`, `Log2`, `Log10`, `Exp2`,
+`Atanh`, `Asinh`, `Acosh`, `Expm1`, `Log1p`, `Sign`, `Floor`, `Ceil`, `Round`,
+and `Trunc`.
+
+The provider dispatch is restricted to f32, using the existing activation-
+capable branch. u32 and i32 implementations retain the arithmetic-only
+capability boundary and return the typed unsupported-operation error for these
+float operations. The operation expressions remain owned by Hephaestus, with
+Metal delegating through its WGPU-backed implementation.
+
+Tests use valid input domains per operation and compare native output with the
+Leto CPU oracle. The test inputs keep inverse hyperbolic and inverse
+trigonometric operations inside their mathematical domains, use positive
+values for logarithms, and use values at least one for `acosh`.
+
+## Alternatives rejected
+
+- Keep ROCm and Metal unsupported: rejected because the Coeus/Leto operation
+  vocabulary and WGPU/CUDA capability already define the required behavior.
+- Copy expressions into the Coeus provider matches: rejected because
+  Hephaestus owns dialect syntax and kernel traversal.
+- Add a CPU fallback: rejected because it would hide a missing native provider
+  capability and break device-resident output semantics.
+- Add `erf`, `erfc`, or `lgamma` here: rejected because they do not yet have a
+  common native Hephaestus expression across WGPU, CUDA, ROCm, and Metal.
+
+## Verification
+
+The provider unit boundary compiles each new marker through ROCm and Metal.
+Integration tests compare every operation with `coeus_leto` across bounded
+valid-domain f32 inputs. Exact-head WGPU, CUDA, ROCm, and Metal CI is required
+for closure; adapterless provider compilation and physical-device execution
+are reported as separate evidence tiers.
+
+## Revisit trigger
+
+Revisit when Coeus requires f64, reduced-precision, vector, `erf`/`erfc`, or
+`lgamma` accelerator contracts, or when the Hephaestus unary seam becomes
+scalar-parameterized.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,8 +17,10 @@
   CUDA, ROCm, and Metal CI passes.
 - Risk/change class: `[arch]` additive shared operation vocabulary and native
   provider integration; ADR 0026 records the boundary and residuals.
-- Status: Hephaestus API dependency is merged upstream; Coeus dispatch and
-  differential tests are in progress.
+- Status: complete. Hephaestus PR #112 merged as `e6ba1c14`; Coeus PR #226
+  exact-head run `30273987046` passed WGPU `90003264732`, CUDA `90003264777`,
+  ROCm `90003265014`, and Metal `90003264805`. Required-device ROCm
+  `90003265412` was skipped because no registered AMD runner was available.
 
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers [arch]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,25 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-HEPHAESTUS-005 — Native unary math providers [arch]
+
+- Owner: Codex on `codex/coeus-unary-math-parity`; scope: shared Hephaestus
+  unary math markers, `coeus-rocm`, `coeus-metal`, Leto differential tests,
+  and backend-parity CI.
+- Outcome: route the 19 unparameterized unary math operations already present
+  in Coeus/Leto through native ROCm and Metal Hephaestus strided kernels:
+  tangent, inverse and hyperbolic functions, logarithm/exponential bases,
+  `expm1`, `log1p`, sign, and rounding.
+- Non-goals: `erf`, `erfc`, `lgamma`, parameterized activations, f64/vector
+  contracts, higher ranks, and unrelated operation families.
+- Acceptance: every operation matches the Leto f32 oracle on valid input
+  domains; integer requests remain typed unsupported operations; no CPU
+  fallback or provider-local shader expressions are added; exact-head WGPU,
+  CUDA, ROCm, and Metal CI passes.
+- Risk/change class: `[arch]` additive shared operation vocabulary and native
+  provider integration; ADR 0026 records the boundary and residuals.
+- Status: Hephaestus API dependency is merged upstream; Coeus dispatch and
+  differential tests are in progress.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers [arch]
 
 - Owner: Codex; scope: typed Hephaestus comparison expressions,
@@ -15,13 +35,10 @@
   provider-boundary extension.
 - Topology: each vendor backend is a manifest over dedicated provider,
   reduction, elementwise, and runtime leaves; public re-exports are unchanged.
-- Status: implementation and the exact post-commit ROCm/Metal library check
-  pass. Full verification remains open because the active local `coeus-leto`
-  migration imports comparison markers that are absent from the checked-out
-  Leto branch; the markers exist in merged Leto comparison-parity commit
-  `d94e3ba`/`df14311`. The earlier Mnemosyne page-tree blocker is now
-  coherent; the Leto provider co-evolution is the remaining local gate
-  blocker.
+- Status: merged in Coeus PR #224 at `84b5bcc`; exact-head run `30268824209`
+  passed WGPU `89986119972`, CUDA `89986119939`, ROCm `89986120026`, and Metal
+  `89986119988`. Required-device ROCm remained skipped because no hosted AMD
+  runner was available.
 - Decision: ADR-0025 selects the shared typed Hephaestus expression seam over
   provider-local kernels or CPU fallback.
 
@@ -41,9 +58,9 @@
   CUDA, ROCm, and Metal CI passes.
 - Risk/change class: `[arch]` shared accelerator operation-vocabulary
   extension with additive Coeus provider capability.
-- Status: implementation complete; code-head CI passed in run `30226854005`
-  (ROCm `89858362239`, Metal `89858362247`, CUDA `89858362266`, WGPU
-  `89858362274`); documentation-head rerun remains required before merge.
+- Status: merged in Coeus PR #223 at `4b807ddd`; code-head run `30226854005`
+  passed ROCm `89858362239`, Metal `89858362247`, CUDA `89858362266`, and WGPU
+  `89858362274`. Required-device ROCm remained skipped without hardware.
 - Decision: use one `UnaryExpr` marker per activation operation with
   dialect-specific WGSL/CUDA/HIP expressions; ADR-0024 records the boundary.
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -7,8 +7,11 @@
 - [x] Route all 19 f32 operations through native ROCm and Metal strided
       providers; keep integer capability boundaries typed and explicit.
 - [x] Compare valid-domain ROCm and Metal outputs with the Leto CPU oracle.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs. Run `30273987046` passed WGPU
+      `90003264732`, CUDA `90003264777`, ROCm `90003265014`, and Metal
+      `90003264805`; required-device ROCm `90003265412` was skipped because no
+      registered AMD runner was available.
 
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,15 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-HEPHAESTUS-005 — Native unary math providers
+
+- [x] Add the shared 19-operation Hephaestus unary math vocabulary and export
+      it through WGPU, CUDA, ROCm, and Metal.
+- [x] Route all 19 f32 operations through native ROCm and Metal strided
+      providers; keep integer capability boundaries typed and explicit.
+- [x] Compare valid-domain ROCm and Metal outputs with the Leto CPU oracle.
+- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers
 
 - [x] Add scalar-aware Hephaestus comparison markers and contiguous/strided
@@ -10,10 +20,12 @@
       oracle, including f32 broadcast inputs.
 - [x] Split vendor backend identity, operation families, and runtime integration
       into vertical leaves while preserving the public backend surface.
-- [ ] Complete the local provider co-evolution: make the active Leto path
-      expose the six comparison markers before running Coeus native gates.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Complete the local provider co-evolution: Leto comparison markers land in
+      merged provider commit `d94e3ba`.
+- [x] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs: run `30268824209` passed WGPU `89986119972`,
+      CUDA `89986119939`, ROCm `89986120026`, and Metal `89986119988`; required
+      AMD hardware remained skipped.
 
 ## ATLAS-COEUS-HEPHAESTUS-003 — Native activation providers
 
@@ -27,8 +39,8 @@
       signed inputs and test unsupported integer requests.
 - [x] Run exact code-head WGPU, CUDA, ROCm, and Metal backend-parity CI:
       run `30226854005`, WGPU `89858362274`, CUDA `89858362266`, ROCm
-      `89858362239`, and Metal `89858362247` passed; the documentation-head
-      rerun remains required before merge.
+      `89858362239`, and Metal `89858362247` passed; Coeus PR #223 merged at
+      `4b807ddd`.
 
 ## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,23 @@
 # Coeus Gap Audit
 
+## ATLAS-COEUS-HEPHAESTUS-005: Unary math provider parity
+
+**Location**: `crates/coeus-rocm/src/backend/elementwise.rs`,
+`crates/coeus-metal/src/backend/elementwise.rs`, and their elementwise
+contracts.
+**Gap**: Coeus/Leto defined 19 unparameterized f32 unary math operations that
+were available to the WGPU/CUDA shader paths but were rejected by the native
+ROCm and Metal provider matches.
+**Resolution**: route each operation through the shared Hephaestus marker and
+strided kernel, with valid-domain Leto differential coverage. Keep integer
+providers on their typed arithmetic-only rejection path.
+**Residual**: `erf`, `erfc`, `lgamma`, parameterized activations, and f64/vector
+contracts remain separate capability slices.
+**Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal CI; hardware lanes
+are reported independently from adapterless provider compilation.
+**Status**: implementation in progress; native dispatch and tests are present,
+with hosted verification pending.
+
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 
 **Location**: `crates/coeus-hephaestus/src/reduction.rs` and the ROCm/Metal

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -15,8 +15,10 @@ providers on their typed arithmetic-only rejection path.
 contracts remain separate capability slices.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal CI; hardware lanes
 are reported independently from adapterless provider compilation.
-**Status**: implementation in progress; native dispatch and tests are present,
-with hosted verification pending.
+**Status**: complete for the 19-operation f32 scope. Hephaestus PR #112 merged
+as `e6ba1c14`. Coeus exact-head run `30273987046` passed WGPU `90003264732`,
+CUDA `90003264777`, ROCm `90003265014`, and Metal `90003264805`; required-device
+ROCm `90003265412` was skipped because no registered AMD runner was available.
 
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 


### PR DESCRIPTION
## Summary

- add native ROCm and Metal dispatch for the Hephaestus unary math marker set
- cover 19 f32 unary operations with differential tests against leto CPU results
- preserve integer arithmetic-only rejection and document the provider contract

## Validation

- local rustfmt and diff checks passed
- local coeus-rocm and coeus-metal test compilation passed against the merged Hephaestus unary API and Leto comparison markers
- hosted provider CI must validate the exact PR head across WGPU, CUDA, ROCm, and Metal

Depends on merged Hephaestus PR #112 and Leto comparison marker parity.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds native ROCm and Metal hardware acceleration for 19 unparameterized floating-point unary math operations (including trigonometric functions like `Tan`, `Asin`, `Acos`, logarithmic functions like `Log2`, `Log10`, hyperbolic functions like `Sinh`, `Cosh`, and rounding operations like `Floor`, `Ceil`, `Round`) by routing them through Hephaestus strided kernels. The implementation is restricted to `f32` types, preserves explicit rejection for integer types, and includes differential testing against Leto CPU reference outputs using valid input domains for each mathematical operation.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0026-coeus-hephaestus-unary-math-providers.md` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/checklist.md` |
| 5 | `CHANGELOG.md` |
| 6 | `crates/coeus-rocm/src/backend/elementwise.rs` |
| 7 | `crates/coeus-metal/src/backend/elementwise.rs` |
| 8 | `crates/coeus-rocm/tests/elementwise.rs` |
| 9 | `crates/coeus-metal/tests/elementwise.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->