### PR TITLE
Gate unsupported reduction dispatch

### DIFF
--- a/crates/coeus-autograd/src/ops/reduction/topk.rs
+++ b/crates/coeus-autograd/src/ops/reduction/topk.rs
@@ -88,7 +88,7 @@ pub fn topk<T: Scalar + leto_ops::Scalar, B>(
     largest: bool,
 ) -> (Var<T, B>, Var<T, B>)
 where
-    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + Default,
+    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<T>:
         coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
     B::DeviceBuffer<i64>:

--- a/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
+++ b/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
@@ -1,4 +1,5 @@
-use coeus_core::{ComputeBackend, Layout, Scalar};
+use crate::backend_ops::CpuBackend;
+use coeus_core::{Layout, Scalar};
 
 /// Default: copy to host, run `coeus_leto::argmax_into`, copy back.
 pub fn argmax<T, B>(
@@ -10,7 +11,7 @@ pub fn argmax<T, B>(
     c_layout: &Layout,
 ) where
     T: Scalar + leto_ops::Scalar,
-    B: ComputeBackend,
+    B: CpuBackend,
 {
     let mut host_a = vec![T::zero(); a_layout.shape().iter().product()];
     backend.copy_to_host(a, &mut host_a);
@@ -32,7 +33,7 @@ pub fn argmin<T, B>(
     c_layout: &Layout,
 ) where
     T: Scalar + leto_ops::Scalar,
-    B: ComputeBackend,
+    B: CpuBackend,
 {
     let mut host_a = vec![T::zero(); a_layout.shape().iter().product()];
     backend.copy_to_host(a, &mut host_a);
@@ -59,7 +60,7 @@ pub fn topk<T, B>(
     indices_layout: &Layout,
 ) where
     T: Scalar + leto_ops::Scalar,
-    B: ComputeBackend,
+    B: CpuBackend,
 {
     let mut host_a = vec![T::zero(); a_layout.shape().iter().product()];
     backend.copy_to_host(a, &mut host_a);

--- a/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
+++ b/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
@@ -1,5 +1,5 @@
 use crate::backend_ops::CpuBackend;
-use coeus_core::{Layout, Scalar};
+use coeus_core::{ComputeBackend, Layout, Scalar};
 
 /// Default: copy to host, run `coeus_leto::argmax_into`, copy back.
 pub fn argmax<T, B>(

--- a/crates/coeus-ops/src/backend_ops/traits/reduction.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/reduction.rs
@@ -2,13 +2,15 @@
 //!
 //! [`ReductionOps`] is the interface-segregated sub-trait for all reduction
 //! kernel dispatch (reduce, argmax, argmin, topk, cumsum, suffix_sum, cumprod,
-//! suffix_prod). The default implementations for argmax/argmin/topk and host
-//! scans use only [`ComputeBackend`] copy methods.
+//! suffix_prod). The argmax/argmin/topk defaults are CPU-only and route to
+//! Leto through [`super::super::CpuBackend`]. Accelerator implementations must
+//! provide a native operation before those methods are exposed.
 
 use coeus_core::{ComputeBackend, Layout, Scalar};
 
 use super::super::defaults;
 use super::super::ops::ReductionOp;
+use super::super::CpuBackend;
 
 /// Reduction operations along an axis.
 ///
@@ -44,6 +46,7 @@ pub trait ReductionOps<T: Scalar>: ComputeBackend {
         c_layout: &Layout,
     ) where
         T: leto_ops::Scalar,
+        Self: CpuBackend,
     {
         defaults::reductions::argmax(self, a, a_layout, axis, c, c_layout)
     }
@@ -58,6 +61,7 @@ pub trait ReductionOps<T: Scalar>: ComputeBackend {
         c_layout: &Layout,
     ) where
         T: leto_ops::Scalar,
+        Self: CpuBackend,
     {
         defaults::reductions::argmin(self, a, a_layout, axis, c, c_layout)
     }
@@ -77,6 +81,7 @@ pub trait ReductionOps<T: Scalar>: ComputeBackend {
         indices_layout: &Layout,
     ) where
         T: leto_ops::Scalar,
+        Self: CpuBackend,
     {
         defaults::reductions::topk(
             self,

--- a/crates/coeus-ops/src/backend_ops/traits/reduction.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/reduction.rs
@@ -8,9 +8,9 @@
 
 use coeus_core::{ComputeBackend, Layout, Scalar};
 
+use super::super::CpuBackend;
 use super::super::defaults;
 use super::super::ops::ReductionOp;
-use super::super::CpuBackend;
 
 /// Reduction operations along an axis.
 ///

--- a/crates/coeus-ops/src/reduction/topk.rs
+++ b/crates/coeus-ops/src/reduction/topk.rs
@@ -1,7 +1,7 @@
 // ── TopK and ArgMax/ArgMin ──
 // Returns the k largest (or smallest) values and their indices along a dimension.
 
-use crate::BackendOps;
+use crate::{BackendOps, CpuBackend};
 use coeus_core::{Layout, Scalar};
 use coeus_tensor::Tensor;
 
@@ -115,7 +115,10 @@ pub fn topk_impl<T: Scalar>(
 /// - If `k == 0` or `k > x.shape()[dim]`.
 /// - If `dim` is out of range.
 #[inline]
-pub fn topk<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + Default>(
+pub fn topk<
+    T: Scalar + leto_ops::Scalar,
+    B: BackendOps<T> + BackendOps<i64> + CpuBackend + Default,
+>(
     x: &Tensor<T, B>,
     k: usize,
     dim: usize,
@@ -160,7 +163,10 @@ pub fn topk<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + D
 
 /// Argmax along `dim`: returns indices of maximum values, shape `x.shape()[dim] = 1`.
 #[inline]
-pub fn argmax<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + Default>(
+pub fn argmax<
+    T: Scalar + leto_ops::Scalar,
+    B: BackendOps<T> + BackendOps<i64> + CpuBackend + Default,
+>(
     x: &Tensor<T, B>,
     dim: usize,
 ) -> Tensor<i64, B> {
@@ -178,7 +184,10 @@ pub fn argmax<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> +
 
 /// Argmin along `dim`: returns indices of minimum values, shape `x.shape()[dim] = 1`.
 #[inline]
-pub fn argmin<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + Default>(
+pub fn argmin<
+    T: Scalar + leto_ops::Scalar,
+    B: BackendOps<T> + BackendOps<i64> + CpuBackend + Default,
+>(
     x: &Tensor<T, B>,
     dim: usize,
 ) -> Tensor<i64, B> {

--- a/crates/coeus-ops/tests/ops/activations/activation_ext_diff.rs
+++ b/crates/coeus-ops/tests/ops/activations/activation_ext_diff.rs
@@ -148,7 +148,7 @@ fn moirai_causal_softmax_matches_reference() {
 
 fn check_topk<B>(backend: &B)
 where
-    B: coeus_ops::BackendOps<f32> + coeus_ops::BackendOps<i64> + Default,
+    B: coeus_ops::BackendOps<f32> + coeus_ops::BackendOps<i64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<f32>: CpuAddressableStorage<f32> + CpuAddressableStorageMut<f32>,
     B::DeviceBuffer<i64>: CpuAddressableStorage<i64> + CpuAddressableStorageMut<i64>,
 {

--- a/crates/coeus-ops/tests/ops/reductions/arg_reduction_leto_diff.rs
+++ b/crates/coeus-ops/tests/ops/reductions/arg_reduction_leto_diff.rs
@@ -25,7 +25,7 @@ fn assert_indices(got: &[i64], expected: &[i64], context: &str) {
 fn check_backend<T, B>(backend: &B)
 where
     T: Scalar + leto_ops::Scalar,
-    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + Default,
+    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<T>: coeus_core::CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
     B::DeviceBuffer<i64>: CpuAddressableStorageMut<i64>,
 {

--- a/docs/adr/0026-coeus-backend-dispatch-boundaries.md
+++ b/docs/adr/0026-coeus-backend-dispatch-boundaries.md
@@ -1,0 +1,55 @@
+# ADR-0026: Make unsupported reduction dispatch statically unavailable
+
+- Status: accepted
+- Date: 2026-07-27
+- Scope: `coeus-ops` reduction traits and their Coeus/autograd callers
+
+## Context
+
+`ReductionOps` supplied default implementations for `argmax`, `argmin`, and
+`topk`. Those defaults copied accelerator storage to host memory, executed a
+Coeus/Leto CPU algorithm, and copied the result back. This made an operation
+appear available on ROCm, Metal, WGPU, CUDA, and generic Hephaestus backends
+without a native provider implementation. It violated backend ownership,
+zero-copy expectations, and the provider-first dispatch contract.
+
+CPU backends already implement these operations directly through Leto and
+`CpuBackend` exposes the required addressable output seam. The accelerator
+providers do not currently expose native selection kernels.
+
+## Decision
+
+The default selection methods are constrained by `Self: CpuBackend`. The public
+`coeus_ops::{topk,argmax,argmin}` and autograd `topk` entry points carry the
+same bound. CPU calls therefore monomorphize directly to the existing Leto
+implementation. Accelerator calls cannot select a host-copy default; they
+remain unavailable until their owning provider exposes a native operation.
+
+Native reduction and scan methods remain unchanged. ROCm and Metal continue to
+dispatch through Hephaestus, while WGPU and CUDA continue to dispatch through
+their native provider paths.
+
+## Rejected alternatives
+
+- Copying accelerator buffers to CPU: preserves the false capability and adds
+  allocation, transfer, and synchronization cost.
+- Runtime backend-name branching: duplicates capability policy in call sites
+  and defers an invariant that the type system can enforce.
+- `dyn` operation providers: adds vtable dispatch and erases the existing
+  monomorphized backend seam.
+- Local accelerator selection kernels: violates upstream provider ownership and
+  creates duplicated operation vocabularies.
+
+## Verification
+
+- CPU/Leto selection tests continue to exercise value-semantic results.
+- Trait bounds are checked for all workspace backends; non-CPU backends cannot
+  satisfy the selection entry points through the default implementation.
+- Provider reduction and scan dispatch remains covered by the existing backend
+  matrix.
+
+## Follow-up
+
+Native arg-reduction and top-k kernels belong in the owning Hephaestus/provider
+operation families. That work is a separate vertical slice and must add
+provider conformance and differential tests before widening the bound.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,22 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks [arch]
+
+- Owner: Codex; scope: `coeus-ops` reduction dispatch and its direct Coeus and
+  autograd callers.
+- Outcome: prevent unsupported accelerator argmax/argmin/topk calls from
+  silently copying through host memory and Leto.
+- Non-goals: native accelerator selection kernels, the fallible
+  `ComputeBackend` migration, and unrelated matmul/convolution defaults.
+- Acceptance: the selection defaults require `CpuBackend`; CPU calls retain
+  direct Leto dispatch; accelerator provider reduction/scan dispatch remains
+  available; focused checks and tests pass.
+- Risk/change class: `[arch]` breaking generic capability boundary.
+- Decision: ADR-0026 makes selection defaults statically CPU-only until the
+  owning Hephaestus/provider operation families provide native kernels.
+- Status: implementation complete; local compile and Nextest remain blocked by
+  the peer-owned Leto path missing the merged comparison marker unit.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers [arch]
 
 - Owner: Codex; scope: typed Hephaestus comparison expressions,

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,15 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks
+
+- [x] Record the CPU/provider capability boundary in ADR-0026.
+- [x] Constrain `ReductionOps` selection defaults to `CpuBackend`.
+- [x] Migrate Coeus and autograd selection entry points to the bound.
+- [ ] Run formatting, metadata, focused checks, nextest, doctests, and the
+      applicable provider dispatch checks.
+- [ ] Commit and publish the verified increment; record residual provider
+      coverage and the local Leto co-evolution blocker.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers
 
 - [x] Add scalar-aware Hephaestus comparison markers and contiguous/strided

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,25 @@
 # Coeus Gap Audit
 
+## ATLAS-COEUS-DISPATCH-001: Unsupported reduction selection fallback
+
+**Location**: `crates/coeus-ops/src/backend_ops/traits/reduction.rs`,
+`crates/coeus-ops/src/backend_ops/defaults/reductions.rs`, and the public
+selection callers under `crates/coeus-ops/src/reduction`.
+**Gap**: generic `argmax`, `argmin`, and `topk` defaults copied device buffers
+to host memory and executed the Leto CPU path when an accelerator did not
+provide a native operation. This made unsupported ROCm, Metal, WGPU, CUDA,
+and generic Hephaestus calls look available while violating provider ownership
+and zero-copy dispatch.
+**Resolution**: the defaults and public/autograd selection entry points now
+require `CpuBackend`. CPU backends retain direct Leto dispatch; accelerator
+reduction and scan methods remain provider-owned. Native selection kernels are
+not added downstream and remain a separate Hephaestus/provider item.
+**Evidence target**: package compile, CPU/Leto value-semantic selection tests,
+and the provider matrix. The local gate is currently blocked before Coeus
+compilation because the peer-owned Leto path lacks `EqOp`/`GeOp`/`GtOp`/`LeOp`/
+`LtOp`/`NeOp`; merged provider CI is the authoritative clean-graph evidence.
+**Status**: implementation complete; hosted verification pending.
+
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 
 **Location**: `crates/coeus-hephaestus/src/reduction.rs` and the ROCm/Metal


### PR DESCRIPTION
## Summary
- require CpuBackend for argmax, argmin, and topk defaults
- preserve direct CPU/Leto selection and native accelerator reduction/scan dispatch
- document the breaking capability boundary in ADR-0026 and PM artifacts

## Verification
- cargo fmt --package coeus-ops --package coeus-autograd -- --check: pass
- cargo metadata --locked --offline --no-deps: pass
- cargo check / cargo nextest: blocked by the peer-owned local Leto path missing merged comparison markers EqOp, GeOp, GtOp, LeOp, LtOp, and NeOp
- hosted backend-parity CI on the merged provider unit previously passed WGPU, CUDA, ROCm, and Metal

The local Leto path is not changed in this PR.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enforces a compile-time boundary preventing unsupported reduction operations (`argmax`, `argmin`, `topk`) from silently falling back to expensive host-copy paths on accelerator backends. The default implementations and public entry points now require `CpuBackend`, ensuring CPU backends continue to use direct Leto dispatch while accelerator backends (ROCm, Metal, WGPU, CUDA) cannot access these operations until native kernels are provided by their owning providers. This preserves zero-copy expectations and the provider-first dispatch contract, with the architectural decision and rationale documented in ADR-0026.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0026-coeus-backend-dispatch-boundaries.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-ops/src/backend_ops/traits/reduction.rs` |
| 6 | `crates/coeus-ops/src/backend_ops/defaults/reductions.rs` |
| 7 | `crates/coeus-ops/src/reduction/topk.rs` |
| 8 | `crates/coeus-autograd/src/ops/reduction/topk.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->