### PR TITLE
Add Coeus error-function providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### Changed
 
 - [arch] Routes Coeus `erf` and `erfc` through the Hephaestus ROCm and Metal
-  f32 providers with Leto CPU differential coverage. Exact-head provider CI is
-  pending for this consumer increment; hardware-device execution is not claimed
-  when the required-device lane skips.
+  f32 providers with Leto CPU differential coverage. Exact-head WGPU, CUDA,
+  ROCm, and Metal provider CI passed; hardware-device execution is not claimed
+  because the required-device ROCm lane skipped.
 
 - [arch] Routes the 19 unparameterized unary math operations already defined by
   Coeus/Leto through native Hephaestus ROCm and Metal strided providers for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- [arch] Routes Coeus `erf` and `erfc` through the Hephaestus ROCm and Metal
+  f32 providers with Leto CPU differential coverage. Exact-head provider CI is
+  pending for this consumer increment; hardware-device execution is not claimed
+  when the required-device lane skips.
+
 - [arch] Routes the 19 unparameterized unary math operations already defined by
   Coeus/Leto through native Hephaestus ROCm and Metal strided providers for
   f32, with valid-domain Leto differential coverage and explicit integer

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,21 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
+
+- [x] Route `UnaryOp::Erf` and `UnaryOp::Erfc` through the provider-owned
+      Hephaestus ROCm and Metal f32 dispatch arms.
+- [x] Extend both backend elementwise suites with Leto CPU differential cases
+      over the existing bounded real-valued input domain.
+- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+      Hephaestus expression seam and the Coeus consumer head.
+
+Evidence: local Coeus test-target compilation and `cargo nextest run -p
+coeus-rocm -p coeus-metal` pass 6/6 with the Hephaestus error-function branch
+and the merged Leto comparison-marker revision temporarily overlaid. The
+temporary manifest and lock overlays are restored; the remaining acceptance
+item is hosted exact-head CI. Hardware-device execution remains a separate
+evidence tier and is not claimed when the required-device lane skips.
+
 ## ATLAS-COEUS-BUILD-001 Locked provider source graph [patch]
 
 - [x] Verify the current manifest graph and active peer provider declarations.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -6,15 +6,17 @@
       Hephaestus ROCm and Metal f32 dispatch arms.
 - [x] Extend both backend elementwise suites with Leto CPU differential cases
       over the existing bounded real-valued input domain.
-- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
       Hephaestus expression seam and the Coeus consumer head.
 
 Evidence: local Coeus test-target compilation and `cargo nextest run -p
 coeus-rocm -p coeus-metal` pass 6/6 with the Hephaestus error-function branch
 and the merged Leto comparison-marker revision temporarily overlaid. The
-temporary manifest and lock overlays are restored; the remaining acceptance
-item is hosted exact-head CI. Hardware-device execution remains a separate
-evidence tier and is not claimed when the required-device lane skips.
+temporary manifest and lock overlays are restored. Coeus run `30282267102`
+passed CUDA job `90031346303`, Metal job `90031346354`, ROCm job `90031346411`,
+and WGPU job `90031346421`; required-device ROCm job `90031346992` skipped.
+Hardware-device execution remains a separate evidence tier and is not claimed
+when the required-device lane skips.
 
 ## ATLAS-COEUS-BUILD-001 Locked provider source graph [patch]
 

--- a/crates/coeus-metal/src/backend/elementwise.rs
+++ b/crates/coeus-metal/src/backend/elementwise.rs
@@ -169,6 +169,16 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erf => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::ErfOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erfc => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::ErfcOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -271,6 +271,8 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::Ceil,
         CpuUnaryOp::Round,
         CpuUnaryOp::Trunc,
+        CpuUnaryOp::Erf,
+        CpuUnaryOp::Erfc,
     ] {
         assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
     }

--- a/crates/coeus-rocm/src/backend/elementwise.rs
+++ b/crates/coeus-rocm/src/backend/elementwise.rs
@@ -169,6 +169,16 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erf => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::ErfOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erfc => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::ErfcOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -271,6 +271,8 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::Ceil,
         CpuUnaryOp::Round,
         CpuUnaryOp::Trunc,
+        CpuUnaryOp::Erf,
+        CpuUnaryOp::Erfc,
     ] {
         assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
     }

--- a/docs/adr/0027-coeus-hephaestus-error-function-providers.md
+++ b/docs/adr/0027-coeus-hephaestus-error-function-providers.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted; implementation is in progress pending exact-head provider CI.
+Accepted; implementation and exact-head provider CI are complete.
 
 ## Context
 
@@ -37,9 +37,10 @@ success.
 
 Local compilation and nextest pass for the ROCm and Metal packages with the
 Hephaestus error-function branch and merged Leto comparison-marker revision
-overlaid temporarily. Exact-head WGPU, CUDA, ROCm, and Metal CI is required
-before closure; physical-device execution is reported separately from
-adapterless/provider compilation.
+overlaid temporarily. Coeus run `30282267102` passed CUDA job `90031346303`,
+Metal job `90031346354`, ROCm job `90031346411`, and WGPU job `90031346421`.
+Required-device ROCm job `90031346992` skipped; physical-device execution is
+reported separately from adapterless/provider compilation.
 
 ## Residual scope
 

--- a/docs/adr/0027-coeus-hephaestus-error-function-providers.md
+++ b/docs/adr/0027-coeus-hephaestus-error-function-providers.md
@@ -1,0 +1,48 @@
+# ADR-0027: Add Hephaestus error-function providers
+
+## Status
+
+Accepted; implementation is in progress pending exact-head provider CI.
+
+## Context
+
+Coeus and Leto expose f32 `erf` and `erfc` operations. The shared Hephaestus
+expression seam now owns WGPU, CUDA, ROCm, and Metal forms, but Coeus ROCm and
+Metal dispatch still rejected both operations. That left the consumer backend
+capability below the existing WGPU/CUDA and CPU vocabulary.
+
+## Decision
+
+Add `UnaryOp::Erf` and `UnaryOp::Erfc` to the existing ROCm and Metal f32
+activation-capable dispatch table. ROCm consumes the Hephaestus HIP expressions
+and Metal consumes the Hephaestus WGPU-backed expressions through the existing
+provider API. Keep integer backends on their arithmetic-only capability
+boundary and preserve the typed unsupported-operation error for those types.
+
+Extend both backend integration suites with the existing Leto CPU oracle over
+the bounded real-valued input set. The test uses the established f32 tolerance;
+it covers native device output semantics rather than merely checking dispatch
+success.
+
+## Alternatives rejected
+
+- Keep `erf` and `erfc` unsupported: rejected because the shared Hephaestus
+  expressions and CPU contract already exist.
+- Reimplement the approximation in Coeus: rejected because dialect syntax and
+  kernel ownership belong to Hephaestus.
+- Fall back to CPU execution: rejected because it would hide a missing device
+  capability and change output placement semantics.
+
+## Verification
+
+Local compilation and nextest pass for the ROCm and Metal packages with the
+Hephaestus error-function branch and merged Leto comparison-marker revision
+overlaid temporarily. Exact-head WGPU, CUDA, ROCm, and Metal CI is required
+before closure; physical-device execution is reported separately from
+adapterless/provider compilation.
+
+## Residual scope
+
+Exact GELU, additional activations, parameterized activations, `lgamma`,
+tail-stable `erfc`, and f64/reduced/vector contracts remain separate parity
+items. This decision does not claim complete Coeus CPU/backend parity.


### PR DESCRIPTION
## Scope
- route Coeus UnaryOp::Erf and UnaryOp::Erfc through Hephaestus ROCm and Metal f32 providers
- extend both backend elementwise suites with Leto CPU differential checks
- record the provider decision, evidence tiers, and remaining parity scope

## Verification
- cargo check -p coeus-rocm -p coeus-metal --tests with the merged Hephaestus marker source overlaid locally
- cargo nextest run -p coeus-rocm -p coeus-metal: 6 passed, 0 skipped
- exact-head WGPU, CUDA, ROCm, and Metal Coeus provider CI required before merge

## Residual scope
Exact GELU and additional activations, parameterized activations, lgamma, tail-stable erfc, and f64/reduced/vector contracts remain separate. Physical-device execution is reported independently when hardware jobs skip.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds support for the error function (`erf`) and complementary error function (`erfc`) to the Coeus ROCm and Metal backends by routing them through the Hephaestus provider layer. The implementation extends both backends' f32 dispatch tables with the new operations and adds Leto CPU differential test coverage to verify correctness against bounded real-valued inputs. The changes are documented through an architectural decision record, changelog entry, and roadmap checklist item, with final exact-head provider CI verification pending before merge.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0027-coeus-hephaestus-error-function-providers.md` |
| 2 | `CHECKLIST.md` |
| 3 | `CHANGELOG.md` |
| 4 | `crates/coeus-rocm/src/backend/elementwise.rs` |
| 5 | `crates/coeus-metal/src/backend/elementwise.rs` |
| 6 | `crates/coeus-rocm/tests/elementwise.rs` |
| 7 | `crates/coeus-metal/tests/elementwise.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->