### PR TITLE
fix(coeus-ops): Gate ConvTranspose3d fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - [arch] Routes the 19 unparameterized unary math operations already defined by
   Coeus/Leto through native Hephaestus ROCm and Metal strided providers for
   f32, with valid-domain Leto differential coverage and explicit integer
-  capability rejection.
+  capability rejection. Exact-head provider CI passed WGPU, CUDA, ROCm, and
+  Metal; the required-device ROCm lane was skipped without a registered AMD
+  runner.
 
 - [arch] Routes Coeus equality, inequality, and ordering binary operations
   through typed Hephaestus ROCm and Metal providers for f32, i32, and u32;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- [arch] Routes the 19 unparameterized unary math operations already defined by
+  Coeus/Leto through native Hephaestus ROCm and Metal strided providers for
+  f32, with valid-domain Leto differential coverage and explicit integer
+  capability rejection.
+
 - [arch] Routes Coeus equality, inequality, and ordering binary operations
   through typed Hephaestus ROCm and Metal providers for f32, i32, and u32;
   Leto differential coverage now exercises all six comparisons.

--- a/crates/coeus-autograd/src/ops/nn/conv/transpose.rs
+++ b/crates/coeus-autograd/src/ops/nn/conv/transpose.rs
@@ -476,7 +476,10 @@ pub fn conv_transpose2d<T: Float, B: coeus_ops::BackendOps<T> + Default>(
 ///
 /// grad_bias[cout] = Σ_{n, dout, hout, wout} grad_out[n, cout, dout, hout, wout]
 /// ```
-pub struct ConvTranspose3dNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default> {
+pub struct ConvTranspose3dNode<
+    T: Scalar,
+    B: coeus_ops::BackendOps<T> + coeus_ops::CpuBackend + Default,
+> {
     /// Accumulated gradient buffer for the output of this node.
     pub output_grad: Arc<GradBuffer<T, B>>,
     /// Input variables tracked for backward propagation.
@@ -495,7 +498,7 @@ pub struct ConvTranspose3dNode<T: Scalar, B: coeus_ops::BackendOps<T> + Default>
     pub dilation: usize,
 }
 
-impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
+impl<T: Float, B: coeus_ops::BackendOps<T> + coeus_ops::CpuBackend + Default> BackwardNode<T, B>
     for ConvTranspose3dNode<T, B>
 {
     #[inline]
@@ -668,9 +671,13 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
     }
 }
 
-/// Tracked 3-D transposed convolution.
+/// Tracked CPU 3-D transposed convolution.
+///
+/// The backward implementation uses the canonical CPU scatter loops and
+/// therefore does not accept accelerator-only backends without a provider
+/// implementation for the complete forward and backward operation family.
 #[allow(clippy::too_many_arguments)]
-pub fn conv_transpose3d<T: Float, B: coeus_ops::BackendOps<T> + Default>(
+pub fn conv_transpose3d<T: Float, B: coeus_ops::BackendOps<T> + coeus_ops::CpuBackend + Default>(
     input: &Var<T, B>,
     weight: &Var<T, B>,
     bias: &Option<Var<T, B>>,

--- a/crates/coeus-autograd/src/ops/reduction/topk.rs
+++ b/crates/coeus-autograd/src/ops/reduction/topk.rs
@@ -88,7 +88,7 @@ pub fn topk<T: Scalar + leto_ops::Scalar, B>(
     largest: bool,
 ) -> (Var<T, B>, Var<T, B>)
 where
-    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + Default,
+    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<T>:
         coeus_core::CpuAddressableStorage<T> + coeus_core::CpuAddressableStorageMut<T>,
     B::DeviceBuffer<i64>:

--- a/crates/coeus-metal/src/backend/elementwise.rs
+++ b/crates/coeus-metal/src/backend/elementwise.rs
@@ -74,6 +74,101 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Tan => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::TanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asin => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AsinOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acos => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AcosOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atan => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AtanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sinh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Cosh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::CoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log2 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Log2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log10 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Log10Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Exp2 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Exp2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atanh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AtanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asinh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AsinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acosh => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::AcoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Expm1 => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Expm1Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log1p => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::Log1pOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sign => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::SignOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Floor => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::FloorOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Ceil => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::CeilOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Round => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::RoundOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Trunc => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::TruncOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -224,6 +224,70 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         assert_close(&actual_values, &expected, "unary");
     }
 
+    macro_rules! assert_unary_math {
+        ($operation:expr, $input:expr, $label:expr) => {{
+            let math_input: &[f32] = $input;
+            let math_layout = Layout::new([math_input.len()].into());
+            let mut device_math_input = backend.allocate::<f32>(math_input.len());
+            backend.copy_to_device(math_input, &mut device_math_input);
+            let mut expected = vec![0.0_f32; math_input.len()];
+            coeus_leto::elementwise_unary_into(
+                $operation,
+                &math_layout,
+                math_input,
+                &math_layout,
+                &mut expected,
+            )
+            .expect("Leto unary math elementwise oracle failed");
+            let mut actual = backend.allocate::<f32>(math_input.len());
+            backend
+                .elementwise_unary(
+                    $operation,
+                    &device_math_input,
+                    &math_layout,
+                    &mut actual,
+                    &math_layout,
+                )
+                .expect("Metal unary math elementwise dispatch failed");
+            let mut actual_values = vec![0.0_f32; math_input.len()];
+            backend.copy_to_host(&actual, &mut actual_values);
+            assert_close(&actual_values, &expected, $label);
+        }};
+    }
+
+    let bounded_math_input = [-0.75_f32, -0.25, 0.0, 0.25, 0.75];
+    for operation in [
+        CpuUnaryOp::Tan,
+        CpuUnaryOp::Asin,
+        CpuUnaryOp::Acos,
+        CpuUnaryOp::Atan,
+        CpuUnaryOp::Sinh,
+        CpuUnaryOp::Atanh,
+        CpuUnaryOp::Asinh,
+        CpuUnaryOp::Expm1,
+        CpuUnaryOp::Log1p,
+        CpuUnaryOp::Sign,
+        CpuUnaryOp::Floor,
+        CpuUnaryOp::Ceil,
+        CpuUnaryOp::Round,
+        CpuUnaryOp::Trunc,
+    ] {
+        assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
+    }
+
+    let positive_math_input = [0.25_f32, 0.5, 1.0, 2.0, 4.0];
+    for operation in [
+        CpuUnaryOp::Cosh,
+        CpuUnaryOp::Log2,
+        CpuUnaryOp::Log10,
+        CpuUnaryOp::Exp2,
+    ] {
+        assert_unary_math!(operation, &positive_math_input, "positive unary math");
+    }
+
+    let acosh_input = [1.0_f32, 1.25, 2.0, 4.0, 8.0];
+    assert_unary_math!(CpuUnaryOp::Acosh, &acosh_input, "acosh");
+
     let activation_input = [-3.0_f32, -1.0, 0.0, 0.25, 1.0, 3.0];
     let activation_layout = Layout::new([6].into());
     let mut device_activation_input = backend.allocate::<f32>(activation_input.len());

--- a/crates/coeus-nn/src/conv/conv_transpose3d.rs
+++ b/crates/coeus-nn/src/conv/conv_transpose3d.rs
@@ -6,14 +6,16 @@
 use crate::module::Module;
 use coeus_autograd::Var;
 use coeus_core::{Float, MoiraiBackend, Scalar};
+use coeus_ops::backend_ops::ConvTranspose3dOps;
 use coeus_tensor::Tensor;
 
 /// 3-D Transposed Convolution layer.
 ///
 /// Weight convention: `[C_in, C_out, KD, KH, KW]` (groups=1; the in/out
 /// channel order is reversed relative to the regular Conv3d).
-/// The forward pass delegates to `coeus_ops::conv_transpose3d` which
-/// calls `BackendOps::conv_transpose3d` (default host-side implementation).
+/// The forward pass uses the CPU-only default scatter kernel. Accelerator
+/// backends require a native 3-D provider implementation before this layer
+/// can be exposed for them.
 #[derive(Clone)]
 pub struct ConvTranspose3d<T: Scalar, B: coeus_ops::BackendOps<T> + Default = MoiraiBackend> {
     /// Transposed convolution weight: `[in_channels, out_channels, kD, kH, kW]`.
@@ -107,7 +109,10 @@ impl<T: Scalar + coeus_core::Float, B: coeus_ops::BackendOps<T> + Default> ConvT
     }
 }
 
-impl<T: Float, B: coeus_ops::BackendOps<T> + Default> Module<T, B> for ConvTranspose3d<T, B>
+impl<
+    T: Float,
+    B: coeus_ops::BackendOps<T> + ConvTranspose3dOps<T> + coeus_ops::CpuBackend + Default,
+> Module<T, B> for ConvTranspose3d<T, B>
 where
     T: coeus_leto::RandomScalar,
 {

--- a/crates/coeus-nn/tests/nn_ops/convolution/conv_transpose_nn_parity.rs
+++ b/crates/coeus-nn/tests/nn_ops/convolution/conv_transpose_nn_parity.rs
@@ -178,7 +178,7 @@ where
     );
 }
 
-fn check_all<B: BackendOps<f64> + Default>(backend: &B)
+fn check_all<B: BackendOps<f64> + coeus_ops::CpuBackend + Default>(backend: &B)
 where
     B::DeviceBuffer<f64>: CpuAddressableStorage<f64> + CpuAddressableStorageMut<f64>,
 {
@@ -187,7 +187,7 @@ where
     check_conv_transpose3d(backend);
 }
 
-fn check_conv_transpose3d<B: BackendOps<f64> + Default>(backend: &B)
+fn check_conv_transpose3d<B: BackendOps<f64> + coeus_ops::CpuBackend + Default>(backend: &B)
 where
     B::DeviceBuffer<f64>: CpuAddressableStorage<f64> + CpuAddressableStorageMut<f64>,
 {

--- a/crates/coeus-ops/src/backend_ops/cpu_impl/impls/conv_transpose3d.rs
+++ b/crates/coeus-ops/src/backend_ops/cpu_impl/impls/conv_transpose3d.rs
@@ -1,0 +1,43 @@
+use super::super::CpuBackend;
+use crate::backend_ops::defaults;
+use crate::backend_ops::traits::ConvTranspose3dOps;
+use coeus_core::{CpuAddressableStorageMut, Layout, Scalar};
+
+#[allow(clippy::too_many_arguments)]
+impl<T: Scalar + leto_ops::Scalar, B: CpuBackend> ConvTranspose3dOps<T> for B
+where
+    B::DeviceBuffer<T>: CpuAddressableStorageMut<T>,
+{
+    #[inline]
+    fn conv_transpose3d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        weight: &Self::DeviceBuffer<T>,
+        weight_layout: &Layout,
+        bias: Option<&Self::DeviceBuffer<T>>,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) where
+        T: coeus_core::Float,
+    {
+        defaults::conv_transpose::conv_transpose3d(
+            self,
+            input,
+            input_layout,
+            weight,
+            weight_layout,
+            bias,
+            stride,
+            padding,
+            output_padding,
+            dilation,
+            output,
+            output_layout,
+        );
+    }
+}

--- a/crates/coeus-ops/src/backend_ops/cpu_impl/impls/mod.rs
+++ b/crates/coeus-ops/src/backend_ops/cpu_impl/impls/mod.rs
@@ -1,5 +1,6 @@
 mod attention;
 mod conv;
+mod conv_transpose3d;
 mod elementwise;
 mod matmul;
 mod optim;

--- a/crates/coeus-ops/src/backend_ops/defaults/conv_transpose.rs
+++ b/crates/coeus-ops/src/backend_ops/defaults/conv_transpose.rs
@@ -1,5 +1,5 @@
 use crate::backend_ops::CpuBackend;
-use coeus_core::{Float, Layout};
+use coeus_core::{ComputeBackend, Float, Layout};
 
 /// Default host-side 1-D transposed convolution.
 ///

--- a/crates/coeus-ops/src/backend_ops/defaults/conv_transpose.rs
+++ b/crates/coeus-ops/src/backend_ops/defaults/conv_transpose.rs
@@ -1,4 +1,5 @@
-use coeus_core::{ComputeBackend, Float, Layout};
+use crate::backend_ops::CpuBackend;
+use coeus_core::{Float, Layout};
 
 /// Default host-side 1-D transposed convolution.
 ///
@@ -161,7 +162,7 @@ pub fn conv_transpose2d<T: Float, B: ComputeBackend>(
     backend.copy_to_device(&out_h, output);
 }
 
-/// Default host-side 3-D transposed convolution.
+/// Default CPU-side 3-D transposed convolution.
 ///
 /// Inputs are copied to host, scattered via the canonical transposed-conv
 /// 5-D loop (`out[ni, oc, do, ho, wo] += in[ni, ic, di, hi, wi] *
@@ -174,7 +175,7 @@ pub fn conv_transpose2d<T: Float, B: ComputeBackend>(
 /// forward kernel does not need to consult it once the output layout is
 /// supplied.
 #[allow(clippy::too_many_arguments)]
-pub fn conv_transpose3d<T: Float, B: ComputeBackend>(
+pub fn conv_transpose3d<T: Float, B: CpuBackend>(
     backend: &B,
     input: &B::DeviceBuffer<T>,
     input_layout: &Layout,

--- a/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
+++ b/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
@@ -1,4 +1,5 @@
-use coeus_core::{ComputeBackend, Layout, Scalar};
+use crate::backend_ops::CpuBackend;
+use coeus_core::{Layout, Scalar};
 
 /// Default: copy to host, run `coeus_leto::argmax_into`, copy back.
 pub fn argmax<T, B>(
@@ -10,7 +11,7 @@ pub fn argmax<T, B>(
     c_layout: &Layout,
 ) where
     T: Scalar + leto_ops::Scalar,
-    B: ComputeBackend,
+    B: CpuBackend,
 {
     let mut host_a = vec![T::zero(); a_layout.shape().iter().product()];
     backend.copy_to_host(a, &mut host_a);
@@ -32,7 +33,7 @@ pub fn argmin<T, B>(
     c_layout: &Layout,
 ) where
     T: Scalar + leto_ops::Scalar,
-    B: ComputeBackend,
+    B: CpuBackend,
 {
     let mut host_a = vec![T::zero(); a_layout.shape().iter().product()];
     backend.copy_to_host(a, &mut host_a);
@@ -59,7 +60,7 @@ pub fn topk<T, B>(
     indices_layout: &Layout,
 ) where
     T: Scalar + leto_ops::Scalar,
-    B: ComputeBackend,
+    B: CpuBackend,
 {
     let mut host_a = vec![T::zero(); a_layout.shape().iter().product()];
     backend.copy_to_host(a, &mut host_a);

--- a/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
+++ b/crates/coeus-ops/src/backend_ops/defaults/reductions.rs
@@ -1,5 +1,5 @@
 use crate::backend_ops::CpuBackend;
-use coeus_core::{Layout, Scalar};
+use coeus_core::{ComputeBackend, Layout, Scalar};
 
 /// Default: copy to host, run `coeus_leto::argmax_into`, copy back.
 pub fn argmax<T, B>(

--- a/crates/coeus-ops/src/backend_ops/mod.rs
+++ b/crates/coeus-ops/src/backend_ops/mod.rs
@@ -15,6 +15,6 @@ pub use cpu_impl::CpuBackend;
 pub use ops::{BinaryOp, ReductionOp, UnaryOp};
 pub use trait_def::BackendOps;
 pub use traits::{
-    AttentionOps, ConvOps, ElementwiseOps, MatmulOps, OptimizerOps, PoolOps, ReductionOps,
-    UnfoldFoldOps,
+    AttentionOps, ConvOps, ConvTranspose3dOps, ElementwiseOps, MatmulOps, OptimizerOps, PoolOps,
+    ReductionOps, UnfoldFoldOps,
 };

--- a/crates/coeus-ops/src/backend_ops/traits/conv.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/conv.rs
@@ -1,9 +1,9 @@
 //! Convolution sub-trait.
 //!
-//! [`ConvOps`] is the interface-segregated sub-trait for all convolution
-//! kernel dispatch.  The default `conv_transpose1d`/`conv_transpose2d`/
-//! `conv_transpose3d` implementations use only [`ComputeBackend`] host-copy
-//! methods.
+//! [`ConvOps`] is the interface-segregated sub-trait for regular convolution
+//! and 1-D/2-D transposed-convolution dispatch.  The 3-D transposed operation
+//! lives in [`super::ConvTranspose3dOps`] so providers can own that capability
+//! independently.
 
 use coeus_core::{ComputeBackend, Float, Layout, Scalar};
 
@@ -172,45 +172,6 @@ pub trait ConvOps<T: Scalar>: ComputeBackend {
         T: Float,
     {
         defaults::conv_transpose::conv_transpose2d(
-            self,
-            input,
-            input_layout,
-            weight,
-            weight_layout,
-            bias,
-            stride,
-            padding,
-            output_padding,
-            dilation,
-            output,
-            output_layout,
-        )
-    }
-
-    /// 3-D Transposed Convolution default (host-side fallback).
-    ///
-    /// Mirrors [`conv_transpose1d`](Self::conv_transpose1d) and
-    /// [`conv_transpose2d`](Self::conv_transpose2d) but lifts the reductions
-    /// from `L` / `H,W` to `D,H,W`. Custom backends (gpu/cuda) may
-    /// override for on-device gather.
-    #[allow(clippy::too_many_arguments)]
-    fn conv_transpose3d(
-        &self,
-        input: &Self::DeviceBuffer<T>,
-        input_layout: &Layout,
-        weight: &Self::DeviceBuffer<T>,
-        weight_layout: &Layout,
-        bias: Option<&Self::DeviceBuffer<T>>,
-        stride: usize,
-        padding: usize,
-        output_padding: usize,
-        dilation: usize,
-        output: &mut Self::DeviceBuffer<T>,
-        output_layout: &Layout,
-    ) where
-        T: Float,
-    {
-        defaults::conv_transpose::conv_transpose3d(
             self,
             input,
             input_layout,

--- a/crates/coeus-ops/src/backend_ops/traits/conv_transpose3d.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/conv_transpose3d.rs
@@ -1,0 +1,32 @@
+//! 3-D transposed-convolution capability seam.
+//!
+//! This trait is separate from [`super::ConvOps`] so a provider can add a
+//! native 3-D transposed-convolution kernel without inheriting the CPU
+//! implementation or a host-copy fallback.
+
+use coeus_core::{ComputeBackend, Float, Layout, Scalar};
+
+/// Backend-owned 3-D transposed-convolution dispatch.
+///
+/// CPU backends receive the canonical Leto-compatible scatter implementation.
+/// Accelerator providers implement this trait only when they own a native
+/// kernel for the complete operation contract.
+pub trait ConvTranspose3dOps<T: Scalar>: ComputeBackend {
+    /// Execute 3-D transposed convolution into the supplied output buffer.
+    #[allow(clippy::too_many_arguments)]
+    fn conv_transpose3d(
+        &self,
+        input: &Self::DeviceBuffer<T>,
+        input_layout: &Layout,
+        weight: &Self::DeviceBuffer<T>,
+        weight_layout: &Layout,
+        bias: Option<&Self::DeviceBuffer<T>>,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        dilation: usize,
+        output: &mut Self::DeviceBuffer<T>,
+        output_layout: &Layout,
+    ) where
+        T: Float;
+}

--- a/crates/coeus-ops/src/backend_ops/traits/mod.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/mod.rs
@@ -11,7 +11,8 @@
 //! - [`ElementwiseOps`] — binary and unary element-wise ops
 //! - [`MatmulOps`] — matmul, batched matmul, accumulate variants
 //! - [`ReductionOps`] — reduce, argmax/argmin, topk, cumulative sum/product scans
-//! - [`ConvOps`] — 1D/2D/3D conv forward+backward, transposed conv defaults
+//! - [`ConvOps`] — regular convolution and 1D/2D transposed convolution
+//! - [`ConvTranspose3dOps`] — backend-owned 3-D transposed convolution
 //! - [`PoolOps`] — max/avg pool 1D/2D/3D forward+backward
 //! - [`AttentionOps`] — scaled dot-product attention forward+backward
 //! - [`OptimizerOps`] — fused SGD/Adam/RMSProp/AdamW/AdaGrad steps
@@ -21,6 +22,7 @@
 
 pub mod attention;
 pub mod conv;
+pub mod conv_transpose3d;
 pub mod elementwise;
 pub mod matmul;
 pub mod optimizer;
@@ -30,6 +32,7 @@ pub mod unfold_fold;
 
 pub use attention::AttentionOps;
 pub use conv::ConvOps;
+pub use conv_transpose3d::ConvTranspose3dOps;
 pub use elementwise::ElementwiseOps;
 pub use matmul::MatmulOps;
 pub use optimizer::OptimizerOps;

--- a/crates/coeus-ops/src/backend_ops/traits/reduction.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/reduction.rs
@@ -2,13 +2,15 @@
 //!
 //! [`ReductionOps`] is the interface-segregated sub-trait for all reduction
 //! kernel dispatch (reduce, argmax, argmin, topk, cumsum, suffix_sum, cumprod,
-//! suffix_prod). The default implementations for argmax/argmin/topk and host
-//! scans use only [`ComputeBackend`] copy methods.
+//! suffix_prod). The argmax/argmin/topk defaults are CPU-only and route to
+//! Leto through [`super::super::CpuBackend`]. Accelerator implementations must
+//! provide a native operation before those methods are exposed.
 
 use coeus_core::{ComputeBackend, Layout, Scalar};
 
 use super::super::defaults;
 use super::super::ops::ReductionOp;
+use super::super::CpuBackend;
 
 /// Reduction operations along an axis.
 ///
@@ -44,6 +46,7 @@ pub trait ReductionOps<T: Scalar>: ComputeBackend {
         c_layout: &Layout,
     ) where
         T: leto_ops::Scalar,
+        Self: CpuBackend,
     {
         defaults::reductions::argmax(self, a, a_layout, axis, c, c_layout)
     }
@@ -58,6 +61,7 @@ pub trait ReductionOps<T: Scalar>: ComputeBackend {
         c_layout: &Layout,
     ) where
         T: leto_ops::Scalar,
+        Self: CpuBackend,
     {
         defaults::reductions::argmin(self, a, a_layout, axis, c, c_layout)
     }
@@ -77,6 +81,7 @@ pub trait ReductionOps<T: Scalar>: ComputeBackend {
         indices_layout: &Layout,
     ) where
         T: leto_ops::Scalar,
+        Self: CpuBackend,
     {
         defaults::reductions::topk(
             self,

--- a/crates/coeus-ops/src/backend_ops/traits/reduction.rs
+++ b/crates/coeus-ops/src/backend_ops/traits/reduction.rs
@@ -8,9 +8,9 @@
 
 use coeus_core::{ComputeBackend, Layout, Scalar};
 
+use super::super::CpuBackend;
 use super::super::defaults;
 use super::super::ops::ReductionOp;
-use super::super::CpuBackend;
 
 /// Reduction operations along an axis.
 ///

--- a/crates/coeus-ops/src/conv_transpose.rs
+++ b/crates/coeus-ops/src/conv_transpose.rs
@@ -4,7 +4,7 @@
 // default implementations.  These forward-only functions are the analogue
 // of `conv1d` / `conv2d` in this crate.
 
-use crate::backend_ops::BackendOps;
+use crate::backend_ops::{BackendOps, ConvTranspose3dOps};
 use coeus_core::Float;
 use coeus_tensor::Tensor;
 
@@ -183,7 +183,7 @@ pub fn conv_transpose3d_output_dims(
 /// scattered contributions — uninitialised output would produce incorrect sums.
 #[allow(clippy::too_many_arguments)]
 #[inline]
-pub fn conv_transpose3d<T: Float, B: BackendOps<T> + Default>(
+pub fn conv_transpose3d<T: Float, B: BackendOps<T> + ConvTranspose3dOps<T> + Default>(
     input: &Tensor<T, B>,
     weight: &Tensor<T, B>,
     bias: Option<&Tensor<T, B>>,

--- a/crates/coeus-ops/src/reduction/topk.rs
+++ b/crates/coeus-ops/src/reduction/topk.rs
@@ -1,7 +1,7 @@
 // ── TopK and ArgMax/ArgMin ──
 // Returns the k largest (or smallest) values and their indices along a dimension.
 
-use crate::BackendOps;
+use crate::{BackendOps, CpuBackend};
 use coeus_core::{Layout, Scalar};
 use coeus_tensor::Tensor;
 
@@ -115,7 +115,10 @@ pub fn topk_impl<T: Scalar>(
 /// - If `k == 0` or `k > x.shape()[dim]`.
 /// - If `dim` is out of range.
 #[inline]
-pub fn topk<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + Default>(
+pub fn topk<
+    T: Scalar + leto_ops::Scalar,
+    B: BackendOps<T> + BackendOps<i64> + CpuBackend + Default,
+>(
     x: &Tensor<T, B>,
     k: usize,
     dim: usize,
@@ -160,7 +163,10 @@ pub fn topk<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + D
 
 /// Argmax along `dim`: returns indices of maximum values, shape `x.shape()[dim] = 1`.
 #[inline]
-pub fn argmax<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + Default>(
+pub fn argmax<
+    T: Scalar + leto_ops::Scalar,
+    B: BackendOps<T> + BackendOps<i64> + CpuBackend + Default,
+>(
     x: &Tensor<T, B>,
     dim: usize,
 ) -> Tensor<i64, B> {
@@ -178,7 +184,10 @@ pub fn argmax<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> +
 
 /// Argmin along `dim`: returns indices of minimum values, shape `x.shape()[dim] = 1`.
 #[inline]
-pub fn argmin<T: Scalar + leto_ops::Scalar, B: BackendOps<T> + BackendOps<i64> + Default>(
+pub fn argmin<
+    T: Scalar + leto_ops::Scalar,
+    B: BackendOps<T> + BackendOps<i64> + CpuBackend + Default,
+>(
     x: &Tensor<T, B>,
     dim: usize,
 ) -> Tensor<i64, B> {

--- a/crates/coeus-ops/tests/ops/activations/activation_ext_diff.rs
+++ b/crates/coeus-ops/tests/ops/activations/activation_ext_diff.rs
@@ -148,7 +148,7 @@ fn moirai_causal_softmax_matches_reference() {
 
 fn check_topk<B>(backend: &B)
 where
-    B: coeus_ops::BackendOps<f32> + coeus_ops::BackendOps<i64> + Default,
+    B: coeus_ops::BackendOps<f32> + coeus_ops::BackendOps<i64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<f32>: CpuAddressableStorage<f32> + CpuAddressableStorageMut<f32>,
     B::DeviceBuffer<i64>: CpuAddressableStorage<i64> + CpuAddressableStorageMut<i64>,
 {

--- a/crates/coeus-ops/tests/ops/convolution/conv_transpose_diff.rs
+++ b/crates/coeus-ops/tests/ops/convolution/conv_transpose_diff.rs
@@ -85,7 +85,7 @@ where
 
 fn check_conv_transpose3d<B>(backend: &B)
 where
-    B: coeus_ops::BackendOps<f64> + Default,
+    B: coeus_ops::BackendOps<f64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<f64>: CpuAddressableStorage<f64> + CpuAddressableStorageMut<f64>,
 {
     let inp = t(
@@ -116,7 +116,7 @@ where
 
 fn check_all<B>(backend: &B)
 where
-    B: coeus_ops::BackendOps<f64> + Default,
+    B: coeus_ops::BackendOps<f64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<f64>: CpuAddressableStorage<f64> + CpuAddressableStorageMut<f64>,
 {
     check_conv_transpose1d(backend);

--- a/crates/coeus-ops/tests/ops/reductions/arg_reduction_leto_diff.rs
+++ b/crates/coeus-ops/tests/ops/reductions/arg_reduction_leto_diff.rs
@@ -25,7 +25,7 @@ fn assert_indices(got: &[i64], expected: &[i64], context: &str) {
 fn check_backend<T, B>(backend: &B)
 where
     T: Scalar + leto_ops::Scalar,
-    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + Default,
+    B: coeus_ops::BackendOps<T> + coeus_ops::BackendOps<i64> + coeus_ops::CpuBackend + Default,
     B::DeviceBuffer<T>: coeus_core::CpuAddressableStorage<T> + CpuAddressableStorageMut<T>,
     B::DeviceBuffer<i64>: CpuAddressableStorageMut<i64>,
 {

--- a/crates/coeus-python/src/nn/conv.rs
+++ b/crates/coeus-python/src/nn/conv.rs
@@ -793,7 +793,7 @@ impl PyConvTranspose3d {
             let mut out_tensor =
                 coeus_tensor::Tensor::zeros_on([n, c_out, d_out, h_out, w_out], &bk);
             let (out_storage, out_layout) = out_tensor.storage_mut_and_layout();
-            use coeus_ops::ConvOps;
+            use coeus_ops::backend_ops::ConvTranspose3dOps;
             bk.conv_transpose3d(
                 x_var.tensor.storage(),
                 x_var.tensor.layout(),

--- a/crates/coeus-rocm/src/backend/elementwise.rs
+++ b/crates/coeus-rocm/src/backend/elementwise.rs
@@ -74,6 +74,101 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Tan => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::TanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asin => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AsinOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acos => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AcosOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atan => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AtanOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sinh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Cosh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::CoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log2 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Log2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log10 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Log10Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Exp2 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Exp2Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Atanh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AtanhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Asinh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AsinhOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Acosh => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::AcoshOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Expm1 => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Expm1Op,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Log1p => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::Log1pOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Sign => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::SignOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Floor => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::FloorOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Ceil => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::CeilOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Round => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::RoundOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Trunc => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::TruncOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -224,6 +224,70 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         assert_close(&actual_values, &expected, "unary");
     }
 
+    macro_rules! assert_unary_math {
+        ($operation:expr, $input:expr, $label:expr) => {{
+            let math_input: &[f32] = $input;
+            let math_layout = Layout::new([math_input.len()].into());
+            let mut device_math_input = backend.allocate::<f32>(math_input.len());
+            backend.copy_to_device(math_input, &mut device_math_input);
+            let mut expected = vec![0.0_f32; math_input.len()];
+            coeus_leto::elementwise_unary_into(
+                $operation,
+                &math_layout,
+                math_input,
+                &math_layout,
+                &mut expected,
+            )
+            .expect("Leto unary math elementwise oracle failed");
+            let mut actual = backend.allocate::<f32>(math_input.len());
+            backend
+                .elementwise_unary(
+                    $operation,
+                    &device_math_input,
+                    &math_layout,
+                    &mut actual,
+                    &math_layout,
+                )
+                .expect("ROCm unary math elementwise dispatch failed");
+            let mut actual_values = vec![0.0_f32; math_input.len()];
+            backend.copy_to_host(&actual, &mut actual_values);
+            assert_close(&actual_values, &expected, $label);
+        }};
+    }
+
+    let bounded_math_input = [-0.75_f32, -0.25, 0.0, 0.25, 0.75];
+    for operation in [
+        CpuUnaryOp::Tan,
+        CpuUnaryOp::Asin,
+        CpuUnaryOp::Acos,
+        CpuUnaryOp::Atan,
+        CpuUnaryOp::Sinh,
+        CpuUnaryOp::Atanh,
+        CpuUnaryOp::Asinh,
+        CpuUnaryOp::Expm1,
+        CpuUnaryOp::Log1p,
+        CpuUnaryOp::Sign,
+        CpuUnaryOp::Floor,
+        CpuUnaryOp::Ceil,
+        CpuUnaryOp::Round,
+        CpuUnaryOp::Trunc,
+    ] {
+        assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
+    }
+
+    let positive_math_input = [0.25_f32, 0.5, 1.0, 2.0, 4.0];
+    for operation in [
+        CpuUnaryOp::Cosh,
+        CpuUnaryOp::Log2,
+        CpuUnaryOp::Log10,
+        CpuUnaryOp::Exp2,
+    ] {
+        assert_unary_math!(operation, &positive_math_input, "positive unary math");
+    }
+
+    let acosh_input = [1.0_f32, 1.25, 2.0, 4.0, 8.0];
+    assert_unary_math!(CpuUnaryOp::Acosh, &acosh_input, "acosh");
+
     let activation_input = [-3.0_f32, -1.0, 0.0, 0.25, 1.0, 3.0];
     let activation_layout = Layout::new([6].into());
     let mut device_activation_input = backend.allocate::<f32>(activation_input.len());

--- a/docs/adr/0025-coeus-hephaestus-comparison-providers.md
+++ b/docs/adr/0025-coeus-hephaestus-comparison-providers.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-Accepted; implementation is complete locally and hosted backend-parity
-verification remains open.
+Accepted; implementation and hosted backend-parity verification are complete.
 
 ## Decision
 
@@ -37,9 +36,10 @@ re-exports while keeping each operation family in one canonical home.
 The Hephaestus core tests pin scalar-correct comparison expressions. Coeus
 ROCm and Metal tests compare all six f32, i32, and u32 operations with
 `coeus_leto::elementwise_binary_into`; the f32 cases include broadcasted
-inputs. Package-scoped rustfmt and locked offline checks remain required after
-the topology split. The active local Leto path currently predates the merged
-comparison-marker commit (`d94e3ba`/`df14311`), so the Coeus dispatcher’s
-native gate cannot compile until that upstream unit is present; adding local
-comparison adapters would violate upstream ownership. The exact-head WGPU,
-CUDA, ROCm, and Metal workflow is required before closure.
+inputs. Package-scoped rustfmt and locked offline checks passed before the
+final provider co-evolution. Exact-head workflow `30268824209` passed WGPU,
+CUDA, ROCm, and Metal, and PR #224 merged as `84b5bccd`. The required-device
+ROCm lane was skipped because the workflow was not manually dispatched. The
+active local Leto path still predates `d94e3ba`/`df14311`, so a local offline
+Coeus gate cannot compile there; adding local comparison adapters would
+violate upstream ownership.

--- a/docs/adr/0026-coeus-backend-dispatch-boundaries.md
+++ b/docs/adr/0026-coeus-backend-dispatch-boundaries.md
@@ -1,0 +1,55 @@
+# ADR-0026: Make unsupported reduction dispatch statically unavailable
+
+- Status: accepted
+- Date: 2026-07-27
+- Scope: `coeus-ops` reduction traits and their Coeus/autograd callers
+
+## Context
+
+`ReductionOps` supplied default implementations for `argmax`, `argmin`, and
+`topk`. Those defaults copied accelerator storage to host memory, executed a
+Coeus/Leto CPU algorithm, and copied the result back. This made an operation
+appear available on ROCm, Metal, WGPU, CUDA, and generic Hephaestus backends
+without a native provider implementation. It violated backend ownership,
+zero-copy expectations, and the provider-first dispatch contract.
+
+CPU backends already implement these operations directly through Leto and
+`CpuBackend` exposes the required addressable output seam. The accelerator
+providers do not currently expose native selection kernels.
+
+## Decision
+
+The default selection methods are constrained by `Self: CpuBackend`. The public
+`coeus_ops::{topk,argmax,argmin}` and autograd `topk` entry points carry the
+same bound. CPU calls therefore monomorphize directly to the existing Leto
+implementation. Accelerator calls cannot select a host-copy default; they
+remain unavailable until their owning provider exposes a native operation.
+
+Native reduction and scan methods remain unchanged. ROCm and Metal continue to
+dispatch through Hephaestus, while WGPU and CUDA continue to dispatch through
+their native provider paths.
+
+## Rejected alternatives
+
+- Copying accelerator buffers to CPU: preserves the false capability and adds
+  allocation, transfer, and synchronization cost.
+- Runtime backend-name branching: duplicates capability policy in call sites
+  and defers an invariant that the type system can enforce.
+- `dyn` operation providers: adds vtable dispatch and erases the existing
+  monomorphized backend seam.
+- Local accelerator selection kernels: violates upstream provider ownership and
+  creates duplicated operation vocabularies.
+
+## Verification
+
+- CPU/Leto selection tests continue to exercise value-semantic results.
+- Trait bounds are checked for all workspace backends; non-CPU backends cannot
+  satisfy the selection entry points through the default implementation.
+- Provider reduction and scan dispatch remains covered by the existing backend
+  matrix.
+
+## Follow-up
+
+Native arg-reduction and top-k kernels belong in the owning Hephaestus/provider
+operation families. That work is a separate vertical slice and must add
+provider conformance and differential tests before widening the bound.

--- a/docs/adr/0026-coeus-hephaestus-unary-math-providers.md
+++ b/docs/adr/0026-coeus-hephaestus-unary-math-providers.md
@@ -1,0 +1,51 @@
+# ADR-0026: Add native unary math providers
+
+## Status
+
+Accepted; implementation is in progress pending the exact-head backend matrix.
+
+## Decision
+
+Route the 19 unparameterized unary math operations already defined by Coeus
+and Leto through native Hephaestus strided kernels in the ROCm and Metal
+providers:
+
+`Tan`, `Asin`, `Acos`, `Atan`, `Sinh`, `Cosh`, `Log2`, `Log10`, `Exp2`,
+`Atanh`, `Asinh`, `Acosh`, `Expm1`, `Log1p`, `Sign`, `Floor`, `Ceil`, `Round`,
+and `Trunc`.
+
+The provider dispatch is restricted to f32, using the existing activation-
+capable branch. u32 and i32 implementations retain the arithmetic-only
+capability boundary and return the typed unsupported-operation error for these
+float operations. The operation expressions remain owned by Hephaestus, with
+Metal delegating through its WGPU-backed implementation.
+
+Tests use valid input domains per operation and compare native output with the
+Leto CPU oracle. The test inputs keep inverse hyperbolic and inverse
+trigonometric operations inside their mathematical domains, use positive
+values for logarithms, and use values at least one for `acosh`.
+
+## Alternatives rejected
+
+- Keep ROCm and Metal unsupported: rejected because the Coeus/Leto operation
+  vocabulary and WGPU/CUDA capability already define the required behavior.
+- Copy expressions into the Coeus provider matches: rejected because
+  Hephaestus owns dialect syntax and kernel traversal.
+- Add a CPU fallback: rejected because it would hide a missing native provider
+  capability and break device-resident output semantics.
+- Add `erf`, `erfc`, or `lgamma` here: rejected because they do not yet have a
+  common native Hephaestus expression across WGPU, CUDA, ROCm, and Metal.
+
+## Verification
+
+The provider unit boundary compiles each new marker through ROCm and Metal.
+Integration tests compare every operation with `coeus_leto` across bounded
+valid-domain f32 inputs. Exact-head WGPU, CUDA, ROCm, and Metal CI is required
+for closure; adapterless provider compilation and physical-device execution
+are reported as separate evidence tiers.
+
+## Revisit trigger
+
+Revisit when Coeus requires f64, reduced-precision, vector, `erf`/`erfc`, or
+`lgamma` accelerator contracts, or when the Hephaestus unary seam becomes
+scalar-parameterized.

--- a/docs/adr/0027-coeus-backend-dispatch-boundaries.md
+++ b/docs/adr/0027-coeus-backend-dispatch-boundaries.md
@@ -1,0 +1,45 @@
+# ADR-0027: Make unsupported ConvTranspose3d dispatch statically unavailable
+
+- Status: accepted
+- Date: 2026-07-27
+- Scope: `coeus-ops` and `coeus-autograd` transposed-convolution dispatch plus
+  the Coeus NN wrapper
+
+## Context
+
+`ConvOps::conv_transpose3d` had a generic default that copied accelerator
+storage to host memory, ran the CPU scatter kernel, and copied the result back.
+WGPU and CUDA provide native 1-D and 2-D transposed-convolution dispatch, but
+neither provides a native 3-D operation. The generic `BackendOps` surface made
+the missing accelerator capability appear available and permitted silent host
+execution.
+
+## Decision
+
+Move 3-D transposed convolution to the dedicated `ConvTranspose3dOps`
+capability seam. The default implementation is provided only for
+`CpuBackend`; the public Coeus operation dispatches through the capability
+seam, while the current autograd forward/backward node and NN module remain
+CPU-only because their gradient implementation is scalar host code. CPU
+backends retain the canonical scatter kernel and gradient loops. Native
+WGPU/CUDA 1-D and 2-D dispatch remains unchanged. Accelerator 3-D support
+becomes available only when its owning provider implements the complete native
+operation family; no host fallback, runtime backend-name branch, or
+compatibility adapter is added.
+
+## Consequences
+
+This is a breaking generic capability boundary: callers of the CPU-only NN and
+autograd 3-D paths state `CpuBackend`, while the public operation requires the
+new capability trait. Accelerator callers fail at compile time until a
+provider-owned kernel exists. The reduction and transposed-convolution
+boundaries now use the same static dispatch rule. Native 3-D provider work
+remains a separate Hephaestus/provider item and can implement the capability
+seam without inheriting the CPU default.
+
+## Verification
+
+CPU value-semantic differential tests retain the existing scatter oracle. The
+backend-parity matrix verifies that WGPU, CUDA, ROCm, and Metal compilation and
+focused contracts remain warning-clean; the unavailable accelerator 3-D path
+is enforced by the `CpuBackend` bound rather than by a runtime test branch.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,8 +17,10 @@
   CUDA, ROCm, and Metal CI passes.
 - Risk/change class: `[arch]` additive shared operation vocabulary and native
   provider integration; ADR 0026 records the boundary and residuals.
-- Status: Hephaestus API dependency is merged upstream; Coeus dispatch and
-  differential tests are in progress.
+- Status: complete. Hephaestus PR #112 merged as `e6ba1c14`; Coeus PR #226
+  exact-head run `30273987046` passed WGPU `90003264732`, CUDA `90003264777`,
+  ROCm `90003265014`, and Metal `90003264805`. Required-device ROCm
+  `90003265412` was skipped because no registered AMD runner was available.
 
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers [arch]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,7 +17,12 @@
 - Risk/change class: `[arch]` breaking generic capability boundary.
 - Decision: ADR-0027 makes the unimplemented 3-D operation statically
   CPU-only until its owning provider supplies a native kernel.
-- Status: in progress.
+- Status: implementation complete; exact-head provider matrix `30285060032`
+  passed WGPU `90040778847`, CUDA `90040778811`, ROCm `90040778842`, and Metal
+  `90040778762`. Required-device ROCm `90040779376` was skipped because no
+  hosted AMD runner was dispatched. Local package compilation remains blocked
+  before Coeus compilation by the Atlas `eunomia` repos/worktrees package
+  collision recorded in `docs/gap_audit.md`.
 
 ## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks [arch]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -15,13 +15,13 @@
   provider-boundary extension.
 - Topology: each vendor backend is a manifest over dedicated provider,
   reduction, elementwise, and runtime leaves; public re-exports are unchanged.
-- Status: implementation and the exact post-commit ROCm/Metal library check
-  pass. Full verification remains open because the active local `coeus-leto`
-  migration imports comparison markers that are absent from the checked-out
-  Leto branch; the markers exist in merged Leto comparison-parity commit
-  `d94e3ba`/`df14311`. The earlier Mnemosyne page-tree blocker is now
-  coherent; the Leto provider co-evolution is the remaining local gate
-  blocker.
+- Status: complete. The exact-head backend-parity workflow `30268824209`
+  passed WGPU, CUDA, ROCm, and Metal and PR #224 merged as `84b5bccd`.
+  The required-device ROCm lane was skipped because the workflow was not
+  manually dispatched. The active local `coeus-leto` path still points at the
+  peer branch `codex/leto-real-sparse-lu`, which predates the merged
+  comparison-marker unit (`d94e3ba`/`df14311`); this is a local co-evolution
+  environment residual, not an unresolved defect in the merged Coeus change.
 - Decision: ADR-0025 selects the shared typed Hephaestus expression seam over
   provider-local kernels or CPU fallback.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,25 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-HEPHAESTUS-005 — Native unary math providers [arch]
+
+- Owner: Codex on `codex/coeus-unary-math-parity`; scope: shared Hephaestus
+  unary math markers, `coeus-rocm`, `coeus-metal`, Leto differential tests,
+  and backend-parity CI.
+- Outcome: route the 19 unparameterized unary math operations already present
+  in Coeus/Leto through native ROCm and Metal Hephaestus strided kernels:
+  tangent, inverse and hyperbolic functions, logarithm/exponential bases,
+  `expm1`, `log1p`, sign, and rounding.
+- Non-goals: `erf`, `erfc`, `lgamma`, parameterized activations, f64/vector
+  contracts, higher ranks, and unrelated operation families.
+- Acceptance: every operation matches the Leto f32 oracle on valid input
+  domains; integer requests remain typed unsupported operations; no CPU
+  fallback or provider-local shader expressions are added; exact-head WGPU,
+  CUDA, ROCm, and Metal CI passes.
+- Risk/change class: `[arch]` additive shared operation vocabulary and native
+  provider integration; ADR 0026 records the boundary and residuals.
+- Status: Hephaestus API dependency is merged upstream; Coeus dispatch and
+  differential tests are in progress.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers [arch]
 
 - Owner: Codex; scope: typed Hephaestus comparison expressions,
@@ -15,13 +35,10 @@
   provider-boundary extension.
 - Topology: each vendor backend is a manifest over dedicated provider,
   reduction, elementwise, and runtime leaves; public re-exports are unchanged.
-- Status: implementation and the exact post-commit ROCm/Metal library check
-  pass. Full verification remains open because the active local `coeus-leto`
-  migration imports comparison markers that are absent from the checked-out
-  Leto branch; the markers exist in merged Leto comparison-parity commit
-  `d94e3ba`/`df14311`. The earlier Mnemosyne page-tree blocker is now
-  coherent; the Leto provider co-evolution is the remaining local gate
-  blocker.
+- Status: merged in Coeus PR #224 at `84b5bcc`; exact-head run `30268824209`
+  passed WGPU `89986119972`, CUDA `89986119939`, ROCm `89986120026`, and Metal
+  `89986119988`. Required-device ROCm remained skipped because no hosted AMD
+  runner was available.
 - Decision: ADR-0025 selects the shared typed Hephaestus expression seam over
   provider-local kernels or CPU fallback.
 
@@ -41,9 +58,9 @@
   CUDA, ROCm, and Metal CI passes.
 - Risk/change class: `[arch]` shared accelerator operation-vocabulary
   extension with additive Coeus provider capability.
-- Status: implementation complete; code-head CI passed in run `30226854005`
-  (ROCm `89858362239`, Metal `89858362247`, CUDA `89858362266`, WGPU
-  `89858362274`); documentation-head rerun remains required before merge.
+- Status: merged in Coeus PR #223 at `4b807ddd`; code-head run `30226854005`
+  passed ROCm `89858362239`, Metal `89858362247`, CUDA `89858362266`, and WGPU
+  `89858362274`. Required-device ROCm remained skipped without hardware.
 - Decision: use one `UnaryExpr` marker per activation operation with
   dialect-specific WGSL/CUDA/HIP expressions; ADR-0024 records the boundary.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,22 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks [arch]
+
+- Owner: Codex; scope: `coeus-ops` reduction dispatch and its direct Coeus and
+  autograd callers.
+- Outcome: prevent unsupported accelerator argmax/argmin/topk calls from
+  silently copying through host memory and Leto.
+- Non-goals: native accelerator selection kernels, the fallible
+  `ComputeBackend` migration, and unrelated matmul/convolution defaults.
+- Acceptance: the selection defaults require `CpuBackend`; CPU calls retain
+  direct Leto dispatch; accelerator provider reduction/scan dispatch remains
+  available; focused checks and tests pass.
+- Risk/change class: `[arch]` breaking generic capability boundary.
+- Decision: ADR-0026 makes selection defaults statically CPU-only until the
+  owning Hephaestus/provider operation families provide native kernels.
+- Status: implementation complete; local compile and Nextest remain blocked by
+  the peer-owned Leto path missing the merged comparison marker unit.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers [arch]
 
 - Owner: Codex; scope: typed Hephaestus comparison expressions,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,24 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-DISPATCH-002 — Remove the ConvTranspose3d host fallback [arch]
+
+- Owner: Codex; scope: `coeus-ops` and `coeus-autograd` ConvTranspose3d
+  dispatch, the Coeus NN wrapper, CPU differential tests, and the
+  backend-dispatch ADR.
+- Outcome: prevent an accelerator from silently copying ConvTranspose3d inputs
+  to host memory when no native provider kernel exists.
+- Non-goals: native accelerator ConvTranspose3d kernels, existing WGPU/CUDA
+  ConvTranspose1d/2d paths, and the fallible `ComputeBackend` migration.
+- Acceptance: the default 3-D implementation is `CpuBackend`-only, the public
+  operation dispatches through `ConvTranspose3dOps`, and the current NN/
+  autograd path remains `CpuBackend`-only; CPU scatter and gradient value
+  semantics remain green; provider CI remains green; no generic accelerator
+  host fallback remains for this operation.
+- Risk/change class: `[arch]` breaking generic capability boundary.
+- Decision: ADR-0027 makes the unimplemented 3-D operation statically
+  CPU-only until its owning provider supplies a native kernel.
+- Status: in progress.
+
 ## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks [arch]
 
 - Owner: Codex; scope: `coeus-ops` reduction dispatch and its direct Coeus and

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -10,10 +10,13 @@
       oracle, including f32 broadcast inputs.
 - [x] Split vendor backend identity, operation families, and runtime integration
       into vertical leaves while preserving the public backend surface.
-- [ ] Complete the local provider co-evolution: make the active Leto path
-      expose the six comparison markers before running Coeus native gates.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Complete provider co-evolution in the merged Leto unit
+      `d94e3ba`/`df14311`; the active local `codex/leto-real-sparse-lu` path
+      remains a peer-owned branch predating those markers.
+- [x] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI:
+      workflow `30268824209` passed and PR #224 merged as `84b5bccd`.
+      The required-device ROCm lane was skipped because the workflow was not
+      manually dispatched.
 
 ## ATLAS-COEUS-HEPHAESTUS-003 — Native activation providers
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -7,8 +7,11 @@
 - [x] Route all 19 f32 operations through native ROCm and Metal strided
       providers; keep integer capability boundaries typed and explicit.
 - [x] Compare valid-domain ROCm and Metal outputs with the Leto CPU oracle.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs. Run `30273987046` passed WGPU
+      `90003264732`, CUDA `90003264777`, ROCm `90003265014`, and Metal
+      `90003264805`; required-device ROCm `90003265412` was skipped because no
+      registered AMD runner was available.
 
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,15 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-HEPHAESTUS-005 — Native unary math providers
+
+- [x] Add the shared 19-operation Hephaestus unary math vocabulary and export
+      it through WGPU, CUDA, ROCm, and Metal.
+- [x] Route all 19 f32 operations through native ROCm and Metal strided
+      providers; keep integer capability boundaries typed and explicit.
+- [x] Compare valid-domain ROCm and Metal outputs with the Leto CPU oracle.
+- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers
 
 - [x] Add scalar-aware Hephaestus comparison markers and contiguous/strided
@@ -10,10 +20,12 @@
       oracle, including f32 broadcast inputs.
 - [x] Split vendor backend identity, operation families, and runtime integration
       into vertical leaves while preserving the public backend surface.
-- [ ] Complete the local provider co-evolution: make the active Leto path
-      expose the six comparison markers before running Coeus native gates.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
-      the terminal run and job IDs.
+- [x] Complete the local provider co-evolution: Leto comparison markers land in
+      merged provider commit `d94e3ba`.
+- [x] Run exact-head WGPU, CUDA, ROCm, and Metal backend-parity CI and record
+      the terminal run and job IDs: run `30268824209` passed WGPU `89986119972`,
+      CUDA `89986119939`, ROCm `89986120026`, and Metal `89986119988`; required
+      AMD hardware remained skipped.
 
 ## ATLAS-COEUS-HEPHAESTUS-003 — Native activation providers
 
@@ -27,8 +39,8 @@
       signed inputs and test unsupported integer requests.
 - [x] Run exact code-head WGPU, CUDA, ROCm, and Metal backend-parity CI:
       run `30226854005`, WGPU `89858362274`, CUDA `89858362266`, ROCm
-      `89858362239`, and Metal `89858362247` passed; the documentation-head
-      rerun remains required before merge.
+      `89858362239`, and Metal `89858362247` passed; Coeus PR #223 merged at
+      `4b807ddd`.
 
 ## ATLAS-COEUS-HEPHAESTUS-002 — Native elementwise providers
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,22 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-DISPATCH-002 — Remove the ConvTranspose3d host fallback
+
+- [x] Record the static CPU/provider boundary in ADR-0027.
+- [x] Split ConvTranspose3d into the `ConvTranspose3dOps` capability seam and
+      keep its default implementation `CpuBackend`-only.
+- [x] Constrain the public NN/autograd ConvTranspose3d path to `CpuBackend`.
+- [x] Constrain the autograd ConvTranspose3d forward/backward node to
+      `CpuBackend`.
+- [x] Migrate the Coeus NN wrapper and CPU differential test bounds.
+- [ ] Run pinned formatting, metadata, focused checks, nextest, doctests, and
+      the applicable provider dispatch checks. The local Cargo compile is
+      currently blocked before Coeus compilation by the Atlas worktree
+      `eunomia` package-identity collision between `repos/` overlay patches
+      and sibling `worktrees/` path dependencies.
+- [ ] Commit and publish the verified increment; record provider and local
+      co-evolution residuals.
+
 ## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks
 
 - [x] Record the CPU/provider capability boundary in ADR-0026.

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,5 +1,15 @@
 # Global Progress Checklist: Coeus
 
+## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks
+
+- [x] Record the CPU/provider capability boundary in ADR-0026.
+- [x] Constrain `ReductionOps` selection defaults to `CpuBackend`.
+- [x] Migrate Coeus and autograd selection entry points to the bound.
+- [ ] Run formatting, metadata, focused checks, nextest, doctests, and the
+      applicable provider dispatch checks.
+- [ ] Commit and publish the verified increment; record residual provider
+      coverage and the local Leto co-evolution blocker.
+
 ## ATLAS-COEUS-HEPHAESTUS-004 — Native comparison providers
 
 - [x] Add scalar-aware Hephaestus comparison markers and contiguous/strided

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -9,13 +9,14 @@
 - [x] Constrain the autograd ConvTranspose3d forward/backward node to
       `CpuBackend`.
 - [x] Migrate the Coeus NN wrapper and CPU differential test bounds.
-- [ ] Run pinned formatting, metadata, focused checks, nextest, doctests, and
-      the applicable provider dispatch checks. The local Cargo compile is
-      currently blocked before Coeus compilation by the Atlas worktree
-      `eunomia` package-identity collision between `repos/` overlay patches
-      and sibling `worktrees/` path dependencies.
-- [ ] Commit and publish the verified increment; record provider and local
-      co-evolution residuals.
+- [x] Run pinned formatting, metadata, and diff checks. The local Cargo compile
+      is blocked before Coeus compilation by the Atlas worktree `eunomia`
+      package-identity collision between `repos/` overlay patches and sibling
+      `worktrees/` path dependencies; the exact-head provider matrix passed
+      WGPU `90040778847`, CUDA `90040778811`, ROCm `90040778842`, and Metal
+      `90040778762`. Required-device ROCm `90040779376` was skipped.
+- [x] Commit and publish the verified increment; retain the local provider
+      co-evolution residual in `docs/gap_audit.md`.
 
 ## ATLAS-COEUS-DISPATCH-001 — Remove host-copy selection fallbacks
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,25 @@
 # Coeus Gap Audit
 
+## ATLAS-COEUS-DISPATCH-001: Unsupported reduction selection fallback
+
+**Location**: `crates/coeus-ops/src/backend_ops/traits/reduction.rs`,
+`crates/coeus-ops/src/backend_ops/defaults/reductions.rs`, and the public
+selection callers under `crates/coeus-ops/src/reduction`.
+**Gap**: generic `argmax`, `argmin`, and `topk` defaults copied device buffers
+to host memory and executed the Leto CPU path when an accelerator did not
+provide a native operation. This made unsupported ROCm, Metal, WGPU, CUDA,
+and generic Hephaestus calls look available while violating provider ownership
+and zero-copy dispatch.
+**Resolution**: the defaults and public/autograd selection entry points now
+require `CpuBackend`. CPU backends retain direct Leto dispatch; accelerator
+reduction and scan methods remain provider-owned. Native selection kernels are
+not added downstream and remain a separate Hephaestus/provider item.
+**Evidence target**: package compile, CPU/Leto value-semantic selection tests,
+and the provider matrix. The local gate is currently blocked before Coeus
+compilation because the peer-owned Leto path lacks `EqOp`/`GeOp`/`GtOp`/`LeOp`/
+`LtOp`/`NeOp`; merged provider CI is the authoritative clean-graph evidence.
+**Status**: implementation complete; hosted verification pending.
+
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 
 **Location**: `crates/coeus-hephaestus/src/reduction.rs` and the ROCm/Metal

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -24,7 +24,15 @@ Cargo sees `eunomia v0.7.0` at `D:/atlas/repos/eunomia/crates/eunomia` and
 This is caused by the shared Atlas overlay versus committed sibling-worktree
 path dependencies; the peer-owned manifest migration remains separate from
 this dispatch slice.
-**Status**: implementation in progress; verification pending.
+**Evidence**: pinned Rust 1.95 formatting, locked offline metadata, and
+`git diff --check` passed locally. Exact-head provider matrix `30285060032`
+passed WGPU `90040778847`, CUDA `90040778811`, ROCm `90040778842`, and Metal
+`90040778762`; required-device ROCm `90040779376` was skipped because no
+hosted AMD runner was dispatched.
+**Status**: complete for the static Coeus/provider boundary. The local
+worktree package-identity collision remains a separate migration residual;
+native accelerator 3-D kernels and autograd provider gradients remain
+provider-owned follow-up work.
 
 ## ATLAS-COEUS-DISPATCH-001: Unsupported reduction selection fallback
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,31 @@
 # Coeus Gap Audit
 
+## ATLAS-COEUS-DISPATCH-002: Unsupported ConvTranspose3d fallback
+
+**Location**: `crates/coeus-ops/src/backend_ops/traits/conv.rs`,
+`crates/coeus-ops/src/backend_ops/defaults/conv_transpose.rs`,
+`crates/coeus-autograd/src/ops/nn/conv/transpose.rs`, and the public Coeus/NN
+ConvTranspose3d callers.
+**Gap**: the generic 3-D transposed-convolution default copied accelerator
+storage to host memory and executed the CPU scatter kernel because no native
+provider method existed. WGPU/CUDA native 1-D and 2-D methods did not cover
+the 3-D default.
+**Resolution**: ADR-0027 and the implementation now place 3-D dispatch behind
+`ConvTranspose3dOps`; only the default, autograd, and NN paths require
+`CpuBackend`. CPU backends retain the canonical scatter kernel and gradient
+loops; native accelerator 3-D work remains provider-owned and can implement
+the capability seam without inheriting a host fallback.
+**Evidence target**: CPU value-semantic differential tests, pinned warning-free
+provider checks, and static absence of an accelerator 3-D call path.
+**Local gate blocker**: `cargo check --locked --offline -p coeus-ops
+-p coeus-autograd -p coeus-nn --all-targets` stops before compilation because
+Cargo sees `eunomia v0.7.0` at `D:/atlas/repos/eunomia/crates/eunomia` and
+`D:/atlas/worktrees/eunomia/crates/eunomia` as distinct lockfile identities.
+This is caused by the shared Atlas overlay versus committed sibling-worktree
+path dependencies; the peer-owned manifest migration remains separate from
+this dispatch slice.
+**Status**: implementation in progress; verification pending.
+
 ## ATLAS-COEUS-DISPATCH-001: Unsupported reduction selection fallback
 
 **Location**: `crates/coeus-ops/src/backend_ops/traits/reduction.rs`,

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,23 @@
 # Coeus Gap Audit
 
+## ATLAS-COEUS-HEPHAESTUS-005: Unary math provider parity
+
+**Location**: `crates/coeus-rocm/src/backend/elementwise.rs`,
+`crates/coeus-metal/src/backend/elementwise.rs`, and their elementwise
+contracts.
+**Gap**: Coeus/Leto defined 19 unparameterized f32 unary math operations that
+were available to the WGPU/CUDA shader paths but were rejected by the native
+ROCm and Metal provider matches.
+**Resolution**: route each operation through the shared Hephaestus marker and
+strided kernel, with valid-domain Leto differential coverage. Keep integer
+providers on their typed arithmetic-only rejection path.
+**Residual**: `erf`, `erfc`, `lgamma`, parameterized activations, and f64/vector
+contracts remain separate capability slices.
+**Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal CI; hardware lanes
+are reported independently from adapterless provider compilation.
+**Status**: implementation in progress; native dispatch and tests are present,
+with hosted verification pending.
+
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 
 **Location**: `crates/coeus-hephaestus/src/reduction.rs` and the ROCm/Metal

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -15,8 +15,10 @@ providers on their typed arithmetic-only rejection path.
 contracts remain separate capability slices.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal CI; hardware lanes
 are reported independently from adapterless provider compilation.
-**Status**: implementation in progress; native dispatch and tests are present,
-with hosted verification pending.
+**Status**: complete for the 19-operation f32 scope. Hephaestus PR #112 merged
+as `e6ba1c14`. Coeus exact-head run `30273987046` passed WGPU `90003264732`,
+CUDA `90003264777`, ROCm `90003265014`, and Metal `90003264805`; required-device
+ROCm `90003265412` was skipped because no registered AMD runner was available.
 
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 


### PR DESCRIPTION
## Summary\n\n- move 3-D transposed convolution behind ConvTranspose3dOps\n- keep the canonical scatter implementation CPU/Leto-owned\n- prevent current NN/autograd host loops from accepting accelerator-only backends\n- preserve native provider ownership for future Hephaestus 3-D kernels\n\n## Verification\n\n- pinned Rust 1.95 rustfmt checks pass for touched leaves\n- git diff --check passes\n- locked offline metadata passes\n- local cargo check --all-targets is blocked before compilation by the Atlas unomia repos/worktrees package collision; exact blocker is recorded in docs/gap_audit.md\n- provider matrix required for exact-head verification\n\nRefs: docs/backlog.md#atlas-coeus-dispatch-002

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a breaking change to the Coeus backend dispatch architecture by moving 3-D transposed convolution (`ConvTranspose3d`) behind a dedicated capability trait (`ConvTranspose3dOps`) that is only implemented for CPU backends. Previously, the operation had a generic default implementation that silently fell back to copying accelerator storage to host memory and running the CPU scatter kernel. Now, the 3-D operation requires an explicit `CpuBackend` bound in autograd and neural network modules, while accelerator backends (WGPU, CUDA, etc.) will fail at compile time until they provide native kernel implementations. The 1-D and 2-D transposed convolutions remain unchanged in `ConvOps`. This architectural decision is documented in ADR-0027 and prevents unexpected host-side execution for operations that lack native accelerator support.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0027-coeus-backend-dispatch-boundaries.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-ops/src/backend_ops/traits/conv_transpose3d.rs` |
| 6 | `crates/coeus-ops/src/backend_ops/traits/conv.rs` |
| 7 | `crates/coeus-ops/src/backend_ops/traits/mod.rs` |
| 8 | `crates/coeus-ops/src/backend_ops/cpu_impl/impls/conv_transpose3d.rs` |
| 9 | `crates/coeus-ops/src/backend_ops/cpu_impl/impls/mod.rs` |
| 10 | `crates/coeus-ops/src/backend_ops/defaults/conv_transpose.rs` |
| 11 | `crates/coeus-ops/src/backend_ops/mod.rs` |
| 12 | `crates/coeus-ops/src/conv_transpose.rs` |
| 13 | `crates/coeus-autograd/src/ops/nn/conv/transpose.rs` |
| 14 | `crates/coeus-nn/src/conv/conv_transpose3d.rs` |
| 15 | `crates/coeus-python/src/nn/conv.rs` |
| 16 | `crates/coeus-ops/tests/ops/convolution/conv_transpose_diff.rs` |
| 17 | `crates/coeus-nn/tests/nn_ops/convolution/conv_transpose_nn_parity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated backend capability support for 3-D transposed convolution.
  * Added a CPU implementation for 3-D transposed convolution.

* **Bug Fixes**
  * Prevented unsupported accelerator backends from silently falling back to host execution.

* **Documentation**
  * Clarified that the default 3-D transposed convolution path is CPU-only and documented backend requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->