### PR TITLE
feat(backends): Add exact GELU providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Changed
 
+- [arch] Routes Coeus exact `Gelu` and `GeluGrad` through the Hephaestus ROCm
+  and Metal f32 providers with Leto CPU differential coverage. Exact-head
+  provider and consumer CI remains open for this increment.
+
+- [arch] Routes Coeus `erf` and `erfc` through the Hephaestus ROCm and Metal
+  f32 providers with Leto CPU differential coverage. Exact-head WGPU, CUDA,
+  ROCm, and Metal provider CI passed; hardware-device execution is not claimed
+  because the required-device ROCm lane skipped.
+
 - [arch] Routes the 19 unparameterized unary math operations already defined by
   Coeus/Leto through native Hephaestus ROCm and Metal strided providers for
   f32, with valid-domain Leto differential coverage and explicit integer

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,35 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-COEUS-HEPHAESTUS-GELU-PARITY-001 [arch]
+
+- [x] Route `UnaryOp::Gelu` and `UnaryOp::GeluGrad` through the shared
+      Hephaestus ROCm and Metal f32 dispatch arms.
+- [x] Extend both backend elementwise suites with Leto CPU differential cases
+      over the existing activation input domain.
+- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+      Hephaestus expression seam and the Coeus consumer head.
+
+Status: provider and consumer source changes are complete; exact-head CI and
+merge remain open. ADR 0028 owns the exact GELU contract.
+
+## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
+
+- [x] Route `UnaryOp::Erf` and `UnaryOp::Erfc` through the provider-owned
+      Hephaestus ROCm and Metal f32 dispatch arms.
+- [x] Extend both backend elementwise suites with Leto CPU differential cases
+      over the existing bounded real-valued input domain.
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+      Hephaestus expression seam and the Coeus consumer head.
+
+Evidence: local Coeus test-target compilation and `cargo nextest run -p
+coeus-rocm -p coeus-metal` pass 6/6 with the Hephaestus error-function branch
+and the merged Leto comparison-marker revision temporarily overlaid. The
+temporary manifest and lock overlays are restored. Coeus run `30282267102`
+passed CUDA job `90031346303`, Metal job `90031346354`, ROCm job `90031346411`,
+and WGPU job `90031346421`; required-device ROCm job `90031346992` skipped.
+Hardware-device execution remains a separate evidence tier and is not claimed
+when the required-device lane skips.
+
 ## ATLAS-COEUS-BUILD-001 Locked provider source graph [patch]
 
 - [x] Verify the current manifest graph and active peer provider declarations.

--- a/crates/coeus-metal/src/backend/elementwise.rs
+++ b/crates/coeus-metal/src/backend/elementwise.rs
@@ -44,6 +44,16 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Gelu => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::GeluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::GeluGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::GeluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             UnaryOp::GeluTanh => hephaestus_metal::unary_elementwise_strided_into::<
             hephaestus_metal::GeluTanhOp,
             f32,
@@ -166,6 +176,16 @@ macro_rules! activation_unary_dispatch {
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             UnaryOp::Trunc => hephaestus_metal::unary_elementwise_strided_into::<
             hephaestus_metal::TruncOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erf => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::ErfOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erfc => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::ErfcOp,
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -271,6 +271,8 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::Ceil,
         CpuUnaryOp::Round,
         CpuUnaryOp::Trunc,
+        CpuUnaryOp::Erf,
+        CpuUnaryOp::Erfc,
     ] {
         assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
     }
@@ -296,6 +298,8 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::Relu,
         CpuUnaryOp::Sigmoid,
         CpuUnaryOp::Tanh,
+        CpuUnaryOp::Gelu,
+        CpuUnaryOp::GeluGrad,
         CpuUnaryOp::GeluTanh,
         CpuUnaryOp::Silu,
         CpuUnaryOp::Softplus,

--- a/crates/coeus-rocm/src/backend/elementwise.rs
+++ b/crates/coeus-rocm/src/backend/elementwise.rs
@@ -44,6 +44,16 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Gelu => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::GeluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::GeluGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::GeluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             UnaryOp::GeluTanh => hephaestus_rocm::unary_elementwise_strided_into::<
             hephaestus_rocm::GeluTanhOp,
             f32,
@@ -166,6 +176,16 @@ macro_rules! activation_unary_dispatch {
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             UnaryOp::Trunc => hephaestus_rocm::unary_elementwise_strided_into::<
             hephaestus_rocm::TruncOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erf => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::ErfOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Erfc => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::ErfcOp,
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -271,6 +271,8 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::Ceil,
         CpuUnaryOp::Round,
         CpuUnaryOp::Trunc,
+        CpuUnaryOp::Erf,
+        CpuUnaryOp::Erfc,
     ] {
         assert_unary_math!(operation, &bounded_math_input, "bounded unary math");
     }
@@ -296,6 +298,8 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::Relu,
         CpuUnaryOp::Sigmoid,
         CpuUnaryOp::Tanh,
+        CpuUnaryOp::Gelu,
+        CpuUnaryOp::GeluGrad,
         CpuUnaryOp::GeluTanh,
         CpuUnaryOp::Silu,
         CpuUnaryOp::Softplus,

--- a/docs/adr/0028-coeus-hephaestus-gelu-providers.md
+++ b/docs/adr/0028-coeus-hephaestus-gelu-providers.md
@@ -1,0 +1,54 @@
+# ADR-0028: Add Hephaestus exact GELU providers
+
+## Status
+
+Accepted; implementation is complete and exact-head CI is pending.
+
+## Context
+
+Coeus and Leto expose exact f32 `Gelu` and `GeluGrad` operations. Coeus WGPU
+and CUDA already contain equivalent expressions, while the ROCm and Metal
+Hephaestus dispatch tables reject both operations. The provider-owned
+Hephaestus vocabulary must close that consumer capability gap without copying
+kernel expressions into Coeus or silently executing on the CPU.
+
+## Decision
+
+Route `UnaryOp::Gelu` and `UnaryOp::GeluGrad` through the existing ROCm and
+Metal activation dispatch macros using `hephaestus_rocm::GeluOp`,
+`GeluGradOp`, `hephaestus_metal::GeluOp`, and `GeluGradOp`.
+
+The forward contract is
+
+`GELU(x) = 0.5 x (1 + erf(x / sqrt(2)))`.
+
+The gradient contract is
+
+`GELU'(x) = 0.5 (1 + erf(x / sqrt(2))) + x exp(-x² / 2) / sqrt(2π)`.
+
+Both backend suites compare provider output with the Leto CPU oracle over the
+existing bounded activation input domain using the established f32 error
+bound. Integer dispatch remains on the typed unsupported-operation path.
+
+## Alternatives rejected
+
+- Keep ROCm and Metal unsupported: rejected because exact GELU is already part
+  of the CPU and WGPU/CUDA contract.
+- Copy WGPU/CUDA expressions into Coeus: rejected because Hephaestus owns
+  dialect-specific kernel expressions.
+- Substitute `GeluTanh`: rejected because it is a different approximation
+  contract and already has its own operation marker.
+- Fall back to CPU: rejected because it masks missing accelerator capability.
+
+## Verification
+
+Local ROCm and Metal test-target compilation and nextest pass with the
+Hephaestus GELU branch temporarily overlaid. Exact-head WGPU, CUDA, ROCm, and
+Metal provider workflows plus the Coeus consumer matrix are required before
+this item closes; hardware execution remains a separate evidence tier.
+
+## Residual scope
+
+Parameterized activations, `lgamma`, tail-stable `erfc`, and f64/reduced/vector
+contracts remain separate parity items. This decision does not claim complete
+Coeus CPU/backend parity.


### PR DESCRIPTION
## Summary

- route exact Gelu and GeluGrad through Hephaestus ROCm and Metal providers
- include the provider-owned unary/error-function consumer source required by the current main ref
- add Leto CPU differential coverage and ADR/checklist records

## Local verification

- Coeus ROCm and Metal test-target compilation passed with the Hephaestus GELU branch overlaid
- cargo nextest run -p coeus-rocm -p coeus-metal: 6/6 passed
- exact-head provider and consumer CI remains required

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds support for exact GELU (Gaussian Error Linear Unit) activation functions and their gradients to the Hephaestus ROCm and Metal backend providers. The changes route `Gelu`, `GeluGrad`, and various unary math operations (error functions, trigonometric, hyperbolic, logarithmic, and rounding functions) through native Hephaestus f32 providers. Leto CPU differential test coverage is added for validation, and comprehensive ADR documentation and checklist records track the implementation status. The PR also includes routing for 19 additional unparameterized unary math operations to achieve broader parity between backends.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0028-coeus-hephaestus-gelu-providers.md` |
| 2 | `CHECKLIST.md` |
| 3 | `CHANGELOG.md` |
| 4 | `crates/coeus-rocm/src/backend/elementwise.rs` |
| 5 | `crates/coeus-metal/src/backend/elementwise.rs` |
| 6 | `crates/coeus-rocm/tests/elementwise.rs` |
| 7 | `crates/coeus-metal/tests/elementwise.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ROCm and Metal support for GELU, GELU gradient, erf, and erfc operations.
  * Expanded backend operation coverage with CPU-reference comparisons for improved consistency.

* **Documentation**
  * Documented GELU provider support, expected behavior, validation requirements, and remaining parity considerations.
  * Updated release notes and roadmap checklists with implementation and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->