### PR TITLE
feat(backends): Route lgamma through providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ### Changed
 
+- [arch] Routes Coeus `lgamma` through the provider-owned Hephaestus WGPU,
+  CUDA, ROCm, and Metal f32 implementations. CUDA/ROCm use native device
+  functions; WGPU/Metal use the shared Lanczos/reflection expression. Leto
+  differential coverage includes positive values, reflection, and poles;
+  exact-head CI remains open for this increment.
+
 - [arch] Routes Coeus exact `Gelu` and `GeluGrad` through the Hephaestus ROCm
   and Metal f32 providers with Leto CPU differential coverage. Exact-head
-  provider and consumer CI remains open for this increment.
+  provider and consumer CI passed; hardware-device execution is not claimed
+  because the required-device lanes skipped.
 
 - [arch] Routes Coeus `erf` and `erfc` through the Hephaestus ROCm and Metal
   f32 providers with Leto CPU differential coverage. Exact-head WGPU, CUDA,

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,16 +1,36 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001 [arch]
+
+- [x] Route `UnaryOp::Lgamma` through the provider-owned Hephaestus WGPU,
+      CUDA, ROCm, and Metal f32 implementations.
+- [x] Extend CUDA, ROCm, and Metal backend suites with Leto CPU differential
+      cases covering positive inputs, reflection, and gamma poles.
+- [x] Replace the WGPU unsupported-operation assertion with a provider
+      expression contract assertion.
+- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+      Hephaestus expression seam and the Coeus consumer head.
+
+Status: source integration and local contract coverage are complete; exact-head
+provider and consumer CI is required before this item closes. The WGPU and
+Metal paths use the provider-owned Lanczos/reflection expression; CUDA and ROCm
+use their native `lgammaf`/`lgamma` device functions. No digamma gradient or
+non-f32 contract is implied.
+
 ## ATLAS-COEUS-HEPHAESTUS-GELU-PARITY-001 [arch]
 
 - [x] Route `UnaryOp::Gelu` and `UnaryOp::GeluGrad` through the shared
       Hephaestus ROCm and Metal f32 dispatch arms.
 - [x] Extend both backend elementwise suites with Leto CPU differential cases
       over the existing activation input domain.
-- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
       Hephaestus expression seam and the Coeus consumer head.
 
-Status: provider and consumer source changes are complete; exact-head CI and
-merge remain open. ADR 0028 owns the exact GELU contract.
+Evidence: Hephaestus provider jobs CUDA `90048504061`, ROCm `90048505968`,
+WGPU `90048506717`, and Metal `90048504635` passed; Coeus consumer jobs CUDA
+`90061390565`, ROCm `90061390546`, WGPU `90061390522`, and Metal `90061390499`
+passed. Hardware-device jobs skipped because no registered runner was
+available. ADR 0028 owns the exact GELU contract.
 
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 
@@ -188,8 +208,9 @@ Rustdoc now pass; the remaining WGPU all-target and infallible autograd/NN
 residuals are separate migration work.
 
 Unary dispatch increment: both unary kernel entry points now return typed
-backend errors, use checked layout conversion, reject unsupported `lgamma`, and
-validate workgroup rounding before converting to the WGPU `u32` dispatch ABI.
+backend errors, use checked layout conversion, route `lgamma` through the
+provider-owned Hephaestus marker, and validate workgroup rounding before
+converting to the WGPU `u32` dispatch ABI.
 The new unit tests cover supported rounding, arithmetic overflow, ABI range,
 and unsupported-operation behavior without a device. Direct nightly rustfmt
 and `git diff --check` pass; the locked `coeus-ops` check and focused tests pass

--- a/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
@@ -135,6 +135,7 @@ pub fn launch_contiguous_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::Log => "logf(a[idx])",
         coeus_ops::UnaryOp::Erf => "erff(a[idx])",
         coeus_ops::UnaryOp::Erfc => "erfcf(a[idx])",
+        coeus_ops::UnaryOp::Lgamma => "lgammaf(a[idx])",
         coeus_ops::UnaryOp::Tan => "tanf(a[idx])",
         coeus_ops::UnaryOp::Asin => "asinf(a[idx])",
         coeus_ops::UnaryOp::Acos => "acosf(a[idx])",

--- a/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
@@ -212,6 +212,7 @@ pub fn launch_strided_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::Log => "logf(val_a)",
         coeus_ops::UnaryOp::Erf => "erff(val_a)",
         coeus_ops::UnaryOp::Erfc => "erfcf(val_a)",
+        coeus_ops::UnaryOp::Lgamma => "lgammaf(val_a)",
         coeus_ops::UnaryOp::Tan => "tanf(val_a)",
         coeus_ops::UnaryOp::Asin => "asinf(val_a)",
         coeus_ops::UnaryOp::Acos => "acosf(val_a)",

--- a/crates/coeus-cuda/tests/cuda/parity.rs
+++ b/crates/coeus-cuda/tests/cuda/parity.rs
@@ -56,6 +56,17 @@ pub(super) fn to_cpu(
 pub(super) fn assert_parity_tol(label: &str, cpu: &[f32], gpu: &[f32], tol: f32) {
     assert_eq!(cpu.len(), gpu.len(), "{label}: length mismatch");
     for (i, (&c, &g)) in cpu.iter().zip(gpu.iter()).enumerate() {
+        if c.is_nan() {
+            assert!(g.is_nan(), "{label}[{i}]: expected NaN, got {g}");
+            continue;
+        }
+        if c.is_infinite() {
+            assert!(
+                g.is_infinite() && g.is_sign_positive() == c.is_sign_positive(),
+                "{label}[{i}]: cpu={c} gpu={g}"
+            );
+            continue;
+        }
         let diff = (c - g).abs();
         assert!(
             diff < tol,

--- a/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
+++ b/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
@@ -128,6 +128,16 @@ unary_parity!(
     vec![0.1, 0.5, 1.0, 2.0, 4.0, 8.0, 0.25, 16.0]
 );
 unary_parity!(
+    test_cuda_parity_lgamma,
+    coeus_ops::lgamma,
+    vec![-0.25, -1.5, 0.25, 0.5, 1.0, 2.0, 4.0, 16.0]
+);
+unary_parity!(
+    test_cuda_parity_lgamma_poles,
+    coeus_ops::lgamma,
+    vec![0.0, -1.0, -2.0]
+);
+unary_parity!(
     test_cuda_parity_sqrt,
     coeus_ops::sqrt,
     vec![0.25, 1.0, 2.0, 4.0, 9.0, 16.0, 0.5, 25.0]

--- a/crates/coeus-metal/src/backend/elementwise.rs
+++ b/crates/coeus-metal/src/backend/elementwise.rs
@@ -189,6 +189,11 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Lgamma => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::LgammaOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -17,6 +17,17 @@ fn require_device() -> bool {
 
 fn assert_close(actual: &[f32], expected: &[f32], operation: &str) {
     for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        if expected.is_nan() {
+            assert!(actual.is_nan(), "Metal {operation} expected NaN at {index}");
+            continue;
+        }
+        if expected.is_infinite() {
+            assert!(
+                actual.is_infinite() && actual.is_sign_positive() == expected.is_sign_positive(),
+                "Metal {operation} expected {expected} at {index}, got {actual}"
+            );
+            continue;
+        }
         let tolerance = f32::EPSILON * 512.0 * expected.abs().max(1.0);
         assert!(
             (actual - expected).abs() <= tolerance,
@@ -286,6 +297,15 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
     ] {
         assert_unary_math!(operation, &positive_math_input, "positive unary math");
     }
+
+    let lgamma_reflection_input = [-0.25_f32, -1.5, 0.25, 0.5, 1.0, 4.0];
+    assert_unary_math!(
+        CpuUnaryOp::Lgamma,
+        &lgamma_reflection_input,
+        "lgamma reflection"
+    );
+    let lgamma_pole_input = [0.0_f32, -1.0, -2.0];
+    assert_unary_math!(CpuUnaryOp::Lgamma, &lgamma_pole_input, "lgamma poles");
 
     let acosh_input = [1.0_f32, 1.25, 2.0, 4.0, 8.0];
     assert_unary_math!(CpuUnaryOp::Acosh, &acosh_input, "acosh");

--- a/crates/coeus-rocm/src/backend/elementwise.rs
+++ b/crates/coeus-rocm/src/backend/elementwise.rs
@@ -189,6 +189,11 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Lgamma => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::LgammaOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             _ => Err(unsupported_unary_operation($operation)),
         }
     };

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -17,6 +17,17 @@ fn require_device() -> bool {
 
 fn assert_close(actual: &[f32], expected: &[f32], operation: &str) {
     for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        if expected.is_nan() {
+            assert!(actual.is_nan(), "ROCm {operation} expected NaN at {index}");
+            continue;
+        }
+        if expected.is_infinite() {
+            assert!(
+                actual.is_infinite() && actual.is_sign_positive() == expected.is_sign_positive(),
+                "ROCm {operation} expected {expected} at {index}, got {actual}"
+            );
+            continue;
+        }
         let tolerance = f32::EPSILON * 512.0 * expected.abs().max(1.0);
         assert!(
             (actual - expected).abs() <= tolerance,
@@ -286,6 +297,15 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
     ] {
         assert_unary_math!(operation, &positive_math_input, "positive unary math");
     }
+
+    let lgamma_reflection_input = [-0.25_f32, -1.5, 0.25, 0.5, 1.0, 4.0];
+    assert_unary_math!(
+        CpuUnaryOp::Lgamma,
+        &lgamma_reflection_input,
+        "lgamma reflection"
+    );
+    let lgamma_pole_input = [0.0_f32, -1.0, -2.0];
+    assert_unary_math!(CpuUnaryOp::Lgamma, &lgamma_pole_input, "lgamma poles");
 
     let acosh_input = [1.0_f32, 1.25, 2.0, 4.0, 8.0];
     assert_unary_math!(CpuUnaryOp::Acosh, &acosh_input, "acosh");

--- a/crates/coeus-wgpu/src/backend/ops/mod.rs
+++ b/crates/coeus-wgpu/src/backend/ops/mod.rs
@@ -206,6 +206,11 @@ fn try_hephaestus_strided_unary_wgpu<
                     T,
                     $n,
                 >(dev, a_op, c_op, BlockWidth::DEFAULT)),
+                UnaryOp::Lgamma => ok(unary_elementwise_strided_into::<
+                    hephaestus_wgpu::LgammaOp,
+                    T,
+                    $n,
+                >(dev, a_op, c_op, BlockWidth::DEFAULT)),
                 _ => Ok(false),
             }
         }};
@@ -364,6 +369,15 @@ fn try_hephaestus_contiguous_unary<
         )),
         coeus_ops::UnaryOp::Recip => run(hephaestus_wgpu::unary_elementwise_into::<
             hephaestus_wgpu::RecipOp,
+            T,
+        >(
+            &ctx.hephaestus_device,
+            a.buffer.as_ref(),
+            c.buffer.as_ref(),
+            BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Lgamma => run(hephaestus_wgpu::unary_elementwise_into::<
+            hephaestus_wgpu::LgammaOp,
             T,
         >(
             &ctx.hephaestus_device,

--- a/crates/coeus-wgpu/src/kernels/unary.rs
+++ b/crates/coeus-wgpu/src/kernels/unary.rs
@@ -20,9 +20,9 @@ fn unary_expr(op: coeus_ops::UnaryOp) -> Result<String, WgpuBackendError> {
         coeus_ops::UnaryOp::Erfc => {
             format!("(1.0 - ({}))", coeus_ops::fuse::wgsl_erf_approx_expr("val"))
         }
-        coeus_ops::UnaryOp::Lgamma => {
-            return Err(WgpuBackendError::UnsupportedOperation { operation: "lgamma" });
-        }
+        coeus_ops::UnaryOp::Lgamma => <hephaestus_core::LgammaOp as
+            hephaestus_core::UnaryExpr<hephaestus_core::Wgsl>>::EXPR
+            .replace("x", "val"),
         coeus_ops::UnaryOp::Tan => "tan(val)".to_string(),
         coeus_ops::UnaryOp::Asin => "asin(val)".to_string(),
         coeus_ops::UnaryOp::Acos => "acos(val)".to_string(),
@@ -428,15 +428,12 @@ pub fn dispatch_contiguous_unary<T: WgpuScalar>(
 #[cfg(test)]
 mod tests {
     use super::unary_expr;
-    use crate::backend::WgpuBackendError;
 
     #[test]
-    fn rejects_unsupported_lgamma_without_panicking() {
-        assert!(matches!(
-            unary_expr(coeus_ops::UnaryOp::Lgamma),
-            Err(WgpuBackendError::UnsupportedOperation {
-                operation: "lgamma"
-            })
-        ));
+    fn uses_provider_lgamma_expression() {
+        let expression = unary_expr(coeus_ops::UnaryOp::Lgamma).expect("provider expression");
+        assert!(expression.contains("676.5203681218851"));
+        assert!(expression.contains("isInf(val)"));
+        assert!(expression.contains("trunc(val)"));
     }
 }

--- a/crates/coeus-wgpu/src/kernels/unary.rs
+++ b/crates/coeus-wgpu/src/kernels/unary.rs
@@ -433,7 +433,7 @@ mod tests {
     fn uses_provider_lgamma_expression() {
         let expression = unary_expr(coeus_ops::UnaryOp::Lgamma).expect("provider expression");
         assert!(expression.contains("676.5203681218851"));
-        assert!(expression.contains("isInf(val)"));
+        assert!(expression.contains("abs(val) > 3.402823466e+38"));
         assert!(expression.contains("trunc(val)"));
     }
 }

--- a/docs/adr/0020-wgpu-fallible-dispatch-boundary.md
+++ b/docs/adr/0020-wgpu-fallible-dispatch-boundary.md
@@ -89,10 +89,10 @@ peer fallible-operation migration. No runtime performance or memory claim is
 made without profile and benchmark evidence.
 
 The unary WGPU kernel family now consumes `GpuLayoutInfo::try_from_layout`,
-returns `Result` through both contiguous and strided dispatch paths, rejects
-the unsupported `lgamma` operation with a typed backend error, and validates
-the rounded workgroup count before the WGPU ABI boundary. Unit tests cover
-rounding, overflow, out-of-range counts, and the unsupported operation without
+returns `Result` through both contiguous and strided dispatch paths, routes
+`lgamma` through the provider-owned Hephaestus expression, and validates the
+rounded workgroup count before the WGPU ABI boundary. Unit tests cover
+rounding, overflow, out-of-range counts, and the provider expression without
 initializing a device. Direct nightly rustfmt and `git diff --check` pass. The
 locked `coeus-ops` check, 110/110 nextest tests, 22/22 doctests, warning-denied
 Clippy, and no-deps Rustdoc now pass; WGPU all-target verification remains

--- a/docs/adr/0029-coeus-hephaestus-lgamma-provider.md
+++ b/docs/adr/0029-coeus-hephaestus-lgamma-provider.md
@@ -1,0 +1,56 @@
+# ADR-0029: Route Coeus lgamma through Hephaestus providers
+
+## Status
+
+Accepted; implementation is complete and exact-head CI is pending.
+
+## Context
+
+Leto already exposes `UnaryOp::Lgamma` as the natural logarithm of the
+absolute gamma function. Coeus's WGPU unary kernel rejected the operation,
+CUDA had no device expression, and the ROCm and Metal Hephaestus dispatch
+tables did not route it. This left the f32 backend capability set below the
+CPU contract.
+
+## Decision
+
+Route the operation through the existing provider seams:
+
+- WGPU dispatch uses `hephaestus_wgpu::LgammaOp`, whose WGSL expression uses
+  the provider-owned Lanczos approximation, reflection identity, infinity, and
+  non-positive integer pole handling.
+- Metal dispatch uses the same provider marker and expression through the
+  existing Hephaestus Metal/WGPU path.
+- CUDA emits the native `lgammaf` device function for both contiguous and
+  strided kernels.
+- ROCm dispatch uses `hephaestus_rocm::LgammaOp`, whose HIP expression emits
+  the native `lgamma` function.
+
+All backend tests compare with the Leto CPU oracle. Finite cases cover
+positive and reflected non-integer inputs. Pole cases require matching
+positive infinity rather than applying a finite tolerance to `∞ - ∞`.
+
+## Alternatives rejected
+
+- Keep WGPU unsupported: rejected because it violates the existing Leto CPU
+  contract.
+- Copy the Lanczos formula into Coeus: rejected because Hephaestus owns the
+  dialect-specific expression.
+- Fall back to Leto CPU: rejected because it hides missing accelerator
+  capability and changes the backend execution contract.
+- Implement a digamma-based gradient here: rejected because Coeus does not
+  currently expose a digamma provider contract; that is a separate operation
+  slice.
+
+## Verification
+
+The affected Coeus crates require locked local checks and nextest. Exact-head
+WGPU, CUDA, ROCm, and Metal provider workflows plus the Coeus consumer matrix
+are required before closure. Hardware execution remains a separate evidence
+tier and is not claimed when required-device jobs skip.
+
+## Residual scope
+
+This decision covers f32 forward `lgamma` only. It does not claim digamma
+gradients, f64/reduced/vector contracts, tail-stable `erfc`, parameterized
+activations, or complete parity for non-elementwise Leto operations.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -329,11 +329,11 @@
   infallible autograd/NN boundary stay tracked as separate residuals.
 - Unary dispatch increment: `dispatch_unary` and
   `dispatch_contiguous_unary` now return the backend `Result`, consume checked
-  layout metadata, reject unsupported `lgamma` with a typed error, and route
-  workgroup rounding through one checked `u32` ABI helper. Unit tests cover the
-  unsupported operation and workgroup boundaries. Direct nightly rustfmt and
-  `git diff --check` pass; the locked `coeus-ops` check and focused tests pass
-  after the provider-identity cutover.
+  layout metadata, route `lgamma` through the provider-owned Hephaestus
+  expression, and route workgroup rounding through one checked `u32` ABI
+  helper. Unit tests cover the provider expression and workgroup boundaries.
+  Direct nightly rustfmt and `git diff --check` pass; the locked `coeus-ops`
+  check and focused tests pass after the provider-identity cutover.
 - Binary dispatch increment: contiguous and general/broadcasting binary kernels
   now return the backend `Result`, consume checked layout metadata, and use the
   same checked workgroup-count helper. The public WGPU `add` wrapper and the


### PR DESCRIPTION
## Summary
- route Coeus UnaryOp::Lgamma through Hephaestus WGPU, CUDA, ROCm, and Metal f32 providers
- use provider-owned WGPU/Metal Lanczos-reflection expression and native CUDA/ROCm device functions
- add Leto differential coverage for positive values, reflection, poles, infinities, and NaN-aware comparison
- update backend parity ADR, checklist, backlog, and changelog

## Verification
- local cargo check --offline -p coeus-cuda --tests passed
- local cargo nextest run --offline -p coeus-wgpu -p coeus-rocm -p coeus-metal passed: 109/109
- exact provider CI is required before merge
- physical GPU execution is not claimed where required-device lanes are unavailable

## Scope
This is the f32 forward lgamma slice. Digamma gradients, reduced precision, f64, vector contracts, and broader non-elementwise Leto operations remain separate gaps.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR routes the `lgamma` (log-gamma) unary operation through provider-owned Hephaestus implementations across all four GPU backends (WGPU, CUDA, ROCm, and Metal) for f32 precision. CUDA and ROCm use native device functions (`lgammaf`/`lgamma`), while WGPU and Metal use a provider-owned Lanczos-reflection expression. The changes include comprehensive test coverage for positive values, reflection cases, and gamma poles with NaN/infinity-aware assertions, plus updates to documentation, checklists, and changelogs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0029-coeus-hephaestus-lgamma-provider.md` |
| 2 | `CHECKLIST.md` |
| 3 | `CHANGELOG.md` |
| 4 | `crates/coeus-wgpu/src/kernels/unary.rs` |
| 5 | `crates/coeus-wgpu/src/backend/ops/mod.rs` |
| 6 | `crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs` |
| 7 | `crates/coeus-cuda/src/kernels/launch_ops/strided.rs` |
| 8 | `crates/coeus-rocm/src/backend/elementwise.rs` |
| 9 | `crates/coeus-metal/src/backend/elementwise.rs` |
| 10 | `crates/coeus-cuda/tests/cuda/parity.rs` |
| 11 | `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs` |
| 12 | `crates/coeus-rocm/tests/elementwise.rs` |
| 13 | `crates/coeus-metal/tests/elementwise.rs` |
| 14 | `docs/adr/0020-wgpu-fallible-dispatch-boundary.md` |
| 15 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lgamma` support across CUDA, ROCm, Metal, and WGPU backends.
  * Added handling for `lgamma` reflection, poles, NaN, and infinity results.

* **Bug Fixes**
  * Improved parity checks for non-finite floating-point values.
  * Added validation for safe WGPU workgroup dispatch boundaries.

* **Documentation**
  * Documented backend behavior, validation status, and `lgamma` provider architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->