### PR TITLE
perf(coeus-hephaestus): Keep COW copies on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- [patch] Keeps Coeus Hephaestus storage COW detachment on the provider
+  device. Replacement buffers retain the source memory tier and use the
+  shared device-local copy contract, removing the full-size host staging
+  allocation and two host/device transfers.
+
 - [arch] Routes Coeus `lgamma` through the provider-owned Hephaestus WGPU,
   CUDA, ROCm, and Metal f32 implementations. CUDA/ROCm use native device
   functions; WGPU/Metal use the shared Lanczos/reflection expression. Leto

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -12,7 +12,14 @@ Evidence: `cargo check` and the focused `coeus-hephaestus` Nextest storage
 contract pass under the local Atlas overlay. This is a static allocation-path
 and value-semantic result; no runtime speedup claim is made without a matched
 device benchmark. The infallible `StorageMut::make_unique` boundary remains a
-separate typed-error migration item.
+separate typed-error migration item. Hosted exact-head run `30336317894`
+passed the CUDA provider contracts job `90201872163`, WGPU provider contracts
+job `90201872262`, ROCm provider contracts job `90201872299`, and Metal
+provider contracts job `90201872213`. The required-device ROCm job
+`90201873084` was skipped because no hosted AMD runner was dispatched; no
+physical-device execution claim is made. The external `recurseml/analysis`
+status returned its recurring analyzer error and is not repository-owned
+verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001 [arch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,19 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-COEUS-SAFETY-001 Device-local COW increment [patch]
+
+- [x] Replace Hephaestus storage COW host staging with one source-tier device
+      allocation and the shared completed device-local copy seam.
+- [x] Add a generic storage regression proving copied values, retained memory
+      tier, one device copy, and zero COW downloads.
+- [x] Synchronize the changelog, gap audit, and ADR 0036.
+
+Evidence: `cargo check` and the focused `coeus-hephaestus` Nextest storage
+contract pass under the local Atlas overlay. This is a static allocation-path
+and value-semantic result; no runtime speedup claim is made without a matched
+device benchmark. The infallible `StorageMut::make_unique` boundary remains a
+separate typed-error migration item.
+
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001 [arch]
 
 - [x] Route `UnaryOp::Lgamma` through the provider-owned Hephaestus WGPU,

--- a/crates/coeus-hephaestus/src/storage.rs
+++ b/crates/coeus-hephaestus/src/storage.rs
@@ -107,13 +107,257 @@ where
         if Arc::strong_count(&self.buffer) <= 1 {
             return;
         }
-        let mut host = vec![T::zero(); self.buffer.len()];
-        P::device()
-            .download(self.buffer.as_ref(), &mut host)
-            .expect("Hephaestus storage uniqueness download failed");
-        let replacement = P::device()
-            .upload(&host)
-            .expect("Hephaestus storage uniqueness upload failed");
+        // COW detachment is a storage operation, so preserve the provider's
+        // allocation tier and keep the full payload on-device. The
+        // `StorageMut` contract is infallible; provider failures therefore
+        // remain explicit invariant failures until that upstream contract is
+        // made fallible.
+        let device = P::device();
+        let replacement = device
+            .alloc_zeroed_with_hint(self.buffer.len(), PlacementHint::Tier(self.buffer.tier()))
+            .expect("Hephaestus storage uniqueness allocation failed");
+        device
+            .copy_buffer(self.buffer.as_ref(), &replacement)
+            .expect("Hephaestus storage uniqueness device copy failed");
         self.buffer = Arc::new(replacement);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reduction::HephaestusProvider;
+    use hephaestus_core::{ComputeDevice, DeviceBuffer, HephaestusError};
+    use std::{
+        marker::PhantomData,
+        sync::atomic::{AtomicUsize, Ordering},
+        sync::{Arc, Mutex},
+    };
+
+    static DOWNLOADS: AtomicUsize = AtomicUsize::new(0);
+    static DEVICE_COPIES: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, Clone)]
+    struct TestBuffer<T: bytemuck::Pod> {
+        bytes: Arc<Mutex<Vec<u8>>>,
+        len: usize,
+        tier: MemoryTier,
+        marker: PhantomData<T>,
+    }
+
+    impl<T: bytemuck::Pod> DeviceBuffer<T> for TestBuffer<T> {
+        fn len(&self) -> usize {
+            self.len
+        }
+
+        fn tier(&self) -> MemoryTier {
+            self.tier
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, Default)]
+    struct TestProvider;
+
+    #[derive(Debug, Clone, Copy, Default)]
+    struct TestDevice;
+
+    fn byte_len<T: bytemuck::Pod>(len: usize) -> hephaestus_core::Result<usize> {
+        len.checked_mul(std::mem::size_of::<T>())
+            .ok_or_else(|| HephaestusError::AllocationFailed {
+                message: "test buffer size overflow".to_owned(),
+            })
+    }
+
+    fn empty_buffer<T: bytemuck::Pod>(
+        len: usize,
+        tier: MemoryTier,
+    ) -> hephaestus_core::Result<TestBuffer<T>> {
+        Ok(TestBuffer {
+            bytes: Arc::new(Mutex::new(vec![0; byte_len::<T>(len)?])),
+            len,
+            tier,
+            marker: PhantomData,
+        })
+    }
+
+    fn require_len<T: bytemuck::Pod>(
+        buffer: &TestBuffer<T>,
+        len: usize,
+    ) -> hephaestus_core::Result<()> {
+        if buffer.len == len {
+            Ok(())
+        } else {
+            Err(HephaestusError::LengthMismatch {
+                host_len: len,
+                device_len: buffer.len,
+            })
+        }
+    }
+
+    impl ComputeDevice for TestDevice {
+        type Buffer<T: bytemuck::Pod> = TestBuffer<T>;
+
+        fn backend_name(&self) -> &'static str {
+            "test"
+        }
+
+        fn alloc_zeroed_with_hint<T: bytemuck::Pod>(
+            &self,
+            len: usize,
+            hint: PlacementHint,
+        ) -> hephaestus_core::Result<Self::Buffer<T>> {
+            empty_buffer(
+                len,
+                match hint {
+                    PlacementHint::Tier(tier) => tier,
+                    _ => MemoryTier::Device,
+                },
+            )
+        }
+
+        fn upload_with_hint<T: bytemuck::Pod>(
+            &self,
+            host: &[T],
+            hint: PlacementHint,
+        ) -> hephaestus_core::Result<Self::Buffer<T>> {
+            let buffer = self.alloc_zeroed_with_hint(host.len(), hint)?;
+            self.write_buffer(&buffer, host)?;
+            Ok(buffer)
+        }
+
+        fn download<T: bytemuck::Pod>(
+            &self,
+            buffer: &Self::Buffer<T>,
+            out: &mut [T],
+        ) -> hephaestus_core::Result<()> {
+            DOWNLOADS.fetch_add(1, Ordering::Relaxed);
+            require_len(buffer, out.len())?;
+            let bytes = buffer
+                .bytes
+                .lock()
+                .map_err(|_| HephaestusError::TransferFailed {
+                    message: "test buffer lock poisoned".to_owned(),
+                })?;
+            bytemuck::cast_slice_mut(out).copy_from_slice(&bytes);
+            Ok(())
+        }
+
+        fn write_buffer<T: bytemuck::Pod>(
+            &self,
+            buffer: &Self::Buffer<T>,
+            host: &[T],
+        ) -> hephaestus_core::Result<()> {
+            require_len(buffer, host.len())?;
+            let mut bytes = buffer
+                .bytes
+                .lock()
+                .map_err(|_| HephaestusError::TransferFailed {
+                    message: "test buffer lock poisoned".to_owned(),
+                })?;
+            bytes.copy_from_slice(bytemuck::cast_slice(host));
+            Ok(())
+        }
+
+        fn write_sub_buffer<T: bytemuck::Pod>(
+            &self,
+            buffer: &Self::Buffer<T>,
+            offset: usize,
+            host: &[T],
+        ) -> hephaestus_core::Result<()> {
+            let end = offset
+                .checked_add(host.len())
+                .ok_or(HephaestusError::LengthMismatch {
+                    host_len: host.len(),
+                    device_len: buffer.len,
+                })?;
+            if end > buffer.len {
+                return Err(HephaestusError::LengthMismatch {
+                    host_len: end,
+                    device_len: buffer.len,
+                });
+            }
+            let mut bytes = buffer
+                .bytes
+                .lock()
+                .map_err(|_| HephaestusError::TransferFailed {
+                    message: "test buffer lock poisoned".to_owned(),
+                })?;
+            let start_bytes = offset * std::mem::size_of::<T>();
+            let host_bytes = bytemuck::cast_slice(host);
+            bytes[start_bytes..start_bytes + host_bytes.len()].copy_from_slice(host_bytes);
+            Ok(())
+        }
+
+        fn copy_buffer<T: bytemuck::Pod>(
+            &self,
+            src: &Self::Buffer<T>,
+            dst: &Self::Buffer<T>,
+        ) -> hephaestus_core::Result<()> {
+            require_len(dst, src.len)?;
+            let src_bytes = src
+                .bytes
+                .lock()
+                .map_err(|_| HephaestusError::TransferFailed {
+                    message: "test source lock poisoned".to_owned(),
+                })?;
+            let mut dst_bytes = dst
+                .bytes
+                .lock()
+                .map_err(|_| HephaestusError::TransferFailed {
+                    message: "test destination lock poisoned".to_owned(),
+                })?;
+            dst_bytes.copy_from_slice(&src_bytes);
+            DEVICE_COPIES.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn synchronize(&self) -> hephaestus_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    // SAFETY: The test device uses Arc<Mutex<_>> for buffer storage and has no
+    // thread-affine state, satisfying the provider buffer ownership contract.
+    unsafe impl HephaestusProvider for TestProvider {
+        type Device = TestDevice;
+
+        const NAME: &'static str = "test";
+
+        fn device() -> &'static Self::Device {
+            static DEVICE: TestDevice = TestDevice;
+            &DEVICE
+        }
+    }
+
+    #[test]
+    fn make_unique_copies_device_data_without_host_download() {
+        DOWNLOADS.store(0, Ordering::Relaxed);
+        DEVICE_COPIES.store(0, Ordering::Relaxed);
+
+        let device = TestProvider::device();
+        let mut storage = HephaestusStorage::<TestProvider, u32>::new(4);
+        device
+            .write_buffer(storage.buffer.as_ref(), &[1, 2, 3, 4])
+            .expect("write test storage");
+        let shared = storage.clone();
+        let downloads_before = DOWNLOADS.load(Ordering::Relaxed);
+
+        StorageMut::make_unique(&mut storage);
+
+        assert_eq!(DOWNLOADS.load(Ordering::Relaxed), downloads_before);
+        assert_eq!(DEVICE_COPIES.load(Ordering::Relaxed), 1);
+
+        let mut detached = [0; 4];
+        let mut retained = [0; 4];
+        device
+            .download(storage.buffer.as_ref(), &mut detached)
+            .expect("read detached storage");
+        device
+            .download(shared.buffer.as_ref(), &mut retained)
+            .expect("read retained storage");
+        assert_eq!(detached, [1, 2, 3, 4]);
+        assert_eq!(retained, [1, 2, 3, 4]);
+        assert_eq!(storage.buffer.tier(), MemoryTier::Device);
+        assert_eq!(shared.buffer.tier(), MemoryTier::Device);
     }
 }

--- a/docs/adr/0036-device-local-cow-copy.md
+++ b/docs/adr/0036-device-local-cow-copy.md
@@ -1,0 +1,44 @@
+# ADR-0036: Keep accelerator COW copies on-device
+
+## Status
+
+Accepted; the Coeus Hephaestus storage increment is implemented.
+
+## Context
+
+`HephaestusStorage::make_unique` detached shared storage by allocating a
+full-size host vector, downloading the source buffer, and uploading the host
+copy. This made copy-on-write proportional to host memory, discarded the
+source allocation tier, and performed two unnecessary transfers.
+
+## Decision
+
+Detach shared storage through the provider-native `ComputeDevice::copy_buffer`
+contract. The consumer acquires one device reference, allocates the
+replacement with `PlacementHint::Tier(source.tier())`, copies the complete
+typed buffer device-to-device, and retains the replacement behind the existing
+`Arc` handle. The shared Hephaestus contract requires the copy to complete
+before returning, so the storage mutation does not expose an in-flight buffer.
+
+The implementation remains generic over the provider and scalar type. It does
+not add vendor imports, host fallback logic, or a second COW algorithm.
+
+## Alternatives rejected
+
+- Retain the host round trip: rejected because it allocates O(n) host storage
+  and performs two avoidable transfers.
+- Add provider-specific COW implementations: rejected because it duplicates
+  storage ownership logic across WGPU, CUDA, ROCm, and Metal consumers.
+- Make `StorageMut::make_unique` silently recover from provider failure:
+  rejected because the current trait is infallible and a fallback would hide a
+  failed device operation. The fallible storage-boundary migration remains a
+  separate tracked item.
+
+## Verification
+
+The generic storage contract uses a fake device implementation only as a test
+double for the public provider seam. It asserts copied values, source-tier
+preservation, exactly one device copy, and zero downloads during COW. Provider
+integration compilation and the existing WGPU, CUDA, ROCm, and Metal contract
+suites remain the backend execution evidence. No runtime performance claim is
+made without a matched device benchmark.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -110,7 +110,14 @@ upload round trip are removed. A generic storage contract verifies copied
 values, tier preservation, one device copy, and no COW-triggered download.
 The `StorageMut::make_unique` method is still infallible, so allocation and
 copy failures remain the explicit residual of this broader failure-boundary
-migration rather than being reclassified as closed here.
+migration rather than being reclassified as closed here. Hosted exact-head run
+`30336317894` passed the CUDA provider contracts job `90201872163`, WGPU
+provider contracts job `90201872262`, ROCm provider contracts job `90201872299`,
+and Metal provider contracts job `90201872213`. The required-device ROCm job
+`90201873084` was skipped because no hosted AMD runner was dispatched; no
+physical-device execution claim is made. The external `recurseml/analysis`
+status returned its recurring analyzer error and is not repository-owned
+verification.
 
 ## ATLAS-CUDA-SAFETY-016: Remaining CUDA launch-parameter narrowing
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -101,6 +101,17 @@ and provider feature gates on hosts with and without the required hardware.
 **Status**: open; deliberately outside the native comparison-provider item
 because it is a separate public failure-boundary migration.
 
+### Device-local COW increment
+
+`crates/coeus-hephaestus/src/storage.rs` now acquires the provider once,
+allocates the replacement with the source buffer's `MemoryTier`, and invokes
+`ComputeDevice::copy_buffer`. The old full-size host allocation and download /
+upload round trip are removed. A generic storage contract verifies copied
+values, tier preservation, one device copy, and no COW-triggered download.
+The `StorageMut::make_unique` method is still infallible, so allocation and
+copy failures remain the explicit residual of this broader failure-boundary
+migration rather than being reclassified as closed here.
+
 ## ATLAS-CUDA-SAFETY-016: Remaining CUDA launch-parameter narrowing
 
 **Location**: remaining non-convolution launchers under


### PR DESCRIPTION
## Summary
- preserve accelerator COW copies on the provider device
- allocate replacement storage at the source MemoryTier and copy through ComputeDevice::copy_buffer
- remove the host Vec/download/upload round trip
- add a generic storage contract for copied values, tier preservation, one device copy, and zero COW downloads
- document the contract and the remaining infallible StorageMut failure-boundary residual

## Verification
- cargo fmt --package coeus-hephaestus -- --check
- cargo check --offline -p coeus-hephaestus (local merged-Hephaestus path overlay)
- cargo nextest run --offline -p coeus-hephaestus (3 passed)
- cargo clippy --offline -p coeus-hephaestus --all-targets --no-deps -- -D warnings
- cargo test --offline -p coeus-hephaestus --doc

Full-workspace Coeus formatting and lint retain pre-existing unrelated drift; Cargo.lock is pre-existing Atlas overlay churn and is excluded.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes copy-on-write (COW) detachment in Coeus Hephaestus storage by keeping buffers on the accelerator device during COW operations. Instead of the previous approach that downloaded data to host memory and uploaded it back, the implementation now allocates replacement storage directly on the device at the source memory tier and uses `ComputeDevice::copy_buffer` for device-to-device copies. This eliminates unnecessary host-device transfers and preserves the original memory tier allocation. A comprehensive test suite verifies that the new implementation maintains correct values, preserves memory tiers, performs exactly one device copy, and avoids host downloads during COW operations.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/coeus-hephaestus/src/storage.rs` |
| 2 | `docs/adr/0036-device-local-cow.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `CHANGELOG.md` |
| 5 | `CHECKLIST.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Copy-on-write storage detachment now keeps data on the device instead of transferring it through host memory.
  * Preserves the original device memory tier for replacement buffers.
  * Reduces memory usage and avoids unnecessary host/device transfers.

* **Documentation**
  * Added documentation describing device-local copy-on-write behavior, validation coverage, and known error-handling boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->