### PR TITLE
perf(coeus): Share native COW copy seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- [patch] Routes native Coeus WGPU and CUDA copy-on-write detachment through
+  the shared Hephaestus `ComputeDevice::copy_buffer` contract. This removes
+  duplicated encoder and CUDA-driver copy logic while preserving device-local
+  values in both the detached and retained buffers.
+
 - [patch] Keeps Coeus Hephaestus storage COW detachment on the provider
   device. Replacement buffers retain the source memory tier and use the
   shared device-local copy contract, removing the full-size host staging

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,21 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-COEUS-SAFETY-002 Native COW seam consolidation [arch][patch]
+
+- [x] Route native Coeus WGPU and CUDA COW detachment through
+      `ComputeDevice::copy_buffer`.
+- [x] Add WGPU and CUDA value-semantic regressions covering detached and
+      retained device buffers.
+- [x] Synchronize the changelog, gap audit, and ADR 0036.
+
+Acceptance: the native WGPU and CUDA storage paths contain no provider-local
+COW transfer implementation, and their focused backend contract suites verify
+that detachment preserves values in both buffers. Local WGPU compilation,
+warning-denied Clippy, doctests (3/3), and Nextest (104/104) pass. Local CUDA
+feature compilation and warning-denied library Clippy pass; CUDA Nextest and
+doctests are blocked by the Windows MinGW linker error `cannot find -lcuda`.
+Hosted exact-head provider evidence is pending for this increment.
+
 ## ATLAS-COEUS-SAFETY-001 Device-local COW increment [patch]
 
 - [x] Replace Hephaestus storage COW host staging with one source-tier device

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,7 +14,11 @@ that detachment preserves values in both buffers. Local WGPU compilation,
 warning-denied Clippy, doctests (3/3), and Nextest (104/104) pass. Local CUDA
 feature compilation and warning-denied library Clippy pass; CUDA Nextest and
 doctests are blocked by the Windows MinGW linker error `cannot find -lcuda`.
-Hosted exact-head provider evidence is pending for this increment.
+Hosted exact-head run `30339683483` passed the CUDA provider contracts job
+`90212208770`, WGPU provider contracts job `90212208755`, ROCm provider
+contracts job `90212208702`, and Metal provider contracts job `90212208797`.
+The required-device ROCm job `90212209211` was skipped because no hosted AMD
+runner was dispatched; no physical-device execution claim is made.
 
 ## ATLAS-COEUS-SAFETY-001 Device-local COW increment [patch]
 

--- a/crates/coeus-cuda/src/storage.rs
+++ b/crates/coeus-cuda/src/storage.rs
@@ -74,20 +74,10 @@ impl<T: Scalar> StorageMut<T> for CudaStorage<T> {
     fn make_unique(&mut self) {
         if Arc::strong_count(&self.buffer) > 1 {
             let device = crate::backend::get_cuda_device();
-            let len = self.buffer.len();
-            let new_buffer = Self::alloc_device_zeroed(len);
-
-            if len > 0 {
-                let bytes = len * std::mem::size_of::<T>();
-                device.bind().expect("Failed to bind CUDA device");
-                unsafe {
-                    let res =
-                        cuda_core::sys::cuMemcpyDtoD_v2(new_buffer.raw(), self.buffer.raw(), bytes);
-                    if res != 0 {
-                        panic!("cuMemcpyDtoD_v2 failed with code: {}", res);
-                    }
-                }
-            }
+            let new_buffer = Self::alloc_device_zeroed(self.buffer.len());
+            device
+                .copy_buffer(self.buffer.as_ref(), &new_buffer)
+                .expect("CudaStorage::make_unique failed to copy the device buffer");
 
             self.buffer = Arc::new(new_buffer);
         }
@@ -120,5 +110,33 @@ mod tests {
             .download(&staging, &mut roundtrip)
             .expect("failed to download from host-pinned tier");
         assert_eq!(roundtrip, input);
+    }
+
+    #[test]
+    fn copy_on_write_preserves_values_in_both_device_buffers() {
+        let device = crate::backend::get_cuda_device();
+        let input = vec![1.0f32, -2.5, 3.25, 8.0];
+        let source = device
+            .upload_with_hint(&input, PlacementHint::Tier(MemoryTier::Device))
+            .expect("failed to upload COW source");
+        let mut writable = CudaStorage {
+            buffer: Arc::new(source),
+        };
+        let retained = writable.clone();
+
+        writable.make_unique();
+
+        assert!(!Arc::ptr_eq(&writable.buffer, &retained.buffer));
+        let mut writable_values = vec![0.0f32; input.len()];
+        let mut retained_values = vec![0.0f32; input.len()];
+        device
+            .download(&writable.buffer, &mut writable_values)
+            .expect("failed to download detached COW buffer");
+        device
+            .download(&retained.buffer, &mut retained_values)
+            .expect("failed to download retained COW buffer");
+
+        assert_eq!(writable_values, input);
+        assert_eq!(retained_values, input);
     }
 }

--- a/crates/coeus-wgpu/src/storage.rs
+++ b/crates/coeus-wgpu/src/storage.rs
@@ -67,19 +67,11 @@ impl<T: Scalar> StorageMut<T> for WgpuStorage<T> {
 
     fn make_unique(&mut self) {
         if Arc::strong_count(&self.buffer) > 1 {
-            let len = self.buffer.len();
             let ctx = get_wgpu_context();
-            let new_buffer = Self::alloc_device_zeroed(len);
-
-            let size_in_bytes = (len * std::mem::size_of::<T>()).max(4) as u64;
-
-            let mut encoder = ctx
-                .device
-                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("coeus-wgpu-cow-copy"),
-                });
-            encoder.copy_buffer_to_buffer(self.buffer.raw(), 0, new_buffer.raw(), 0, size_in_bytes);
-            ctx.queue.submit(std::iter::once(encoder.finish()));
+            let new_buffer = Self::alloc_device_zeroed(self.buffer.len());
+            ctx.hephaestus_device
+                .copy_buffer(self.buffer.as_ref(), &new_buffer)
+                .expect("WgpuStorage::make_unique failed to copy the device buffer");
 
             self.buffer = Arc::new(new_buffer);
         }
@@ -127,5 +119,34 @@ mod tests {
             ),
             other => panic!("expected allocation failure, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn copy_on_write_preserves_values_in_both_device_buffers() {
+        let ctx = get_wgpu_context();
+        let input = vec![1.0f32, -2.5, 3.25, 8.0];
+        let source = ctx
+            .hephaestus_device
+            .upload_with_hint(&input, PlacementHint::Tier(MemoryTier::Device))
+            .expect("failed to upload COW source");
+        let mut writable = WgpuStorage {
+            buffer: Arc::new(source),
+        };
+        let retained = writable.clone();
+
+        writable.make_unique();
+
+        assert!(!Arc::ptr_eq(&writable.buffer, &retained.buffer));
+        let mut writable_values = vec![0.0f32; input.len()];
+        let mut retained_values = vec![0.0f32; input.len()];
+        ctx.hephaestus_device
+            .download(&writable.buffer, &mut writable_values)
+            .expect("failed to download detached COW buffer");
+        ctx.hephaestus_device
+            .download(&retained.buffer, &mut retained_values)
+            .expect("failed to download retained COW buffer");
+
+        assert_eq!(writable_values, input);
+        assert_eq!(retained_values, input);
     }
 }

--- a/docs/adr/0036-device-local-cow-copy.md
+++ b/docs/adr/0036-device-local-cow-copy.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted; the Coeus Hephaestus storage increment is implemented.
+Accepted; the generic Coeus Hephaestus storage increment and native WGPU/CUDA
+consumer cutover are implemented.
 
 ## Context
 
@@ -20,8 +21,11 @@ typed buffer device-to-device, and retains the replacement behind the existing
 `Arc` handle. The shared Hephaestus contract requires the copy to complete
 before returning, so the storage mutation does not expose an in-flight buffer.
 
-The implementation remains generic over the provider and scalar type. It does
-not add vendor imports, host fallback logic, or a second COW algorithm.
+The implementation remains generic over the provider and scalar type. Native
+Coeus WGPU and CUDA storage consumers call the same seam rather than
+reimplementing provider transfer mechanics. The change does not add vendor
+imports to the shared storage contract, host fallback logic, or a second COW
+algorithm.
 
 ## Alternatives rejected
 
@@ -39,6 +43,7 @@ not add vendor imports, host fallback logic, or a second COW algorithm.
 The generic storage contract uses a fake device implementation only as a test
 double for the public provider seam. It asserts copied values, source-tier
 preservation, exactly one device copy, and zero downloads during COW. Provider
-integration compilation and the existing WGPU, CUDA, ROCm, and Metal contract
-suites remain the backend execution evidence. No runtime performance claim is
-made without a matched device benchmark.
+integration compilation and the WGPU, CUDA, ROCm, and Metal contract suites
+remain the backend execution evidence. The native WGPU and CUDA storage tests
+download both COW results and assert equal values. No runtime performance claim
+is made without a matched device benchmark.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -127,7 +127,10 @@ WGPU command encoder or a raw CUDA driver copy. Each provider storage test
 detaches a shared device buffer, downloads both the detached and retained
 buffers, and asserts value preservation. This consolidates the transfer
 primitive without claiming a runtime speedup; matched device benchmarks remain
-outside this increment.
+outside this increment. Hosted exact-head run `30339683483` passed CUDA
+(`90212208770`), WGPU (`90212208755`), ROCm (`90212208702`), and Metal
+(`90212208797`) provider contracts. Required-device ROCm (`90212209211`) was
+skipped because no hosted AMD runner was dispatched.
 
 ## ATLAS-CUDA-SAFETY-016: Remaining CUDA launch-parameter narrowing
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -119,6 +119,16 @@ physical-device execution claim is made. The external `recurseml/analysis`
 status returned its recurring analyzer error and is not repository-owned
 verification.
 
+### Native COW seam consolidation
+
+The native Coeus WGPU and CUDA storage implementations now call the shared
+Hephaestus `ComputeDevice::copy_buffer` contract instead of duplicating a
+WGPU command encoder or a raw CUDA driver copy. Each provider storage test
+detaches a shared device buffer, downloads both the detached and retained
+buffers, and asserts value preservation. This consolidates the transfer
+primitive without claiming a runtime speedup; matched device benchmarks remain
+outside this increment.
+
 ## ATLAS-CUDA-SAFETY-016: Remaining CUDA launch-parameter narrowing
 
 **Location**: remaining non-convolution launchers under


### PR DESCRIPTION
## Summary\n\n- route native Coeus WGPU and CUDA COW detachment through Hephaestus ComputeDevice::copy_buffer\n- remove duplicated WGPU encoder and raw CUDA driver copy logic\n- add value-semantic retained/detached buffer regressions\n- synchronize ADR 0036, checklist, changelog, and gap audit\n\n## Verification\n\n- local WGPU check, warning-denied Clippy, doctests 3/3, and nextest 104/104 pass\n- local CUDA feature check and warning-denied library Clippy pass\n- local CUDA test/doctest execution is blocked by Windows MinGW linker error: cannot find -lcuda\n- hosted Backend parity matrix is required for CUDA, WGPU, ROCm, and Metal\n- no runtime speedup claim is made without a matched device benchmark\n\nRefs: CHECKLIST.md#atlas-coeus-safety-002-native-cow-seam-consolidation

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR consolidates the copy-on-write (COW) buffer detachment logic for native WGPU and CUDA storage implementations by routing both through the shared Hephaestus `ComputeDevice::copy_buffer` contract. Previously, each backend duplicated device-to-device transfer code using provider-specific APIs (WGPU command encoders and raw CUDA driver calls). The refactor removes this duplication while preserving device-local values in both detached and retained buffers. New regression tests verify that COW operations correctly preserve values in both buffer copies for each backend. Supporting documentation updates include the changelog, ADR 0036, checklist, and gap audit to reflect this architectural consolidation.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHECKLIST.md` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/adr/0036-device-local-cow-copy.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-wgpu/src/storage.rs` |
| 6 | `crates/coeus-cuda/src/storage.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-on-write behavior for GPU-backed data, ensuring both retained and detached buffers preserve their values across WGPU and CUDA workflows.
  * Consolidated device-side buffer copying for more consistent storage behavior.

* **Tests**
  * Added coverage verifying value preservation after copy-on-write operations across supported GPU backends.

* **Documentation**
  * Updated the changelog, architecture decision record, checklist, and gap audit with implementation and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->