### PR TITLE
perf(storage): Skip redundant COW initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changed
 
+- [minor] Route Coeus WGPU, CUDA, and generic Hephaestus COW replacement
+  allocations through Hephaestus's overwrite-before-read device allocation
+  seam while keeping ordinary storage construction zero-initialized. The
+  complete device-local copy remains the value-semantic initialization step;
+  runtime performance and resident-memory changes are not claimed without a
+  controlled benchmark.
+
 - [patch] Routes native Coeus WGPU and CUDA copy-on-write detachment through
   the shared Hephaestus `ComputeDevice::copy_buffer` contract. This removes
   duplicated encoder and CUDA-driver copy logic while preserving device-local

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -21,6 +21,10 @@ provider CI is required for device execution.
 
 Implementation owner: Codex on `codex/coeus-uninitialized-cow-copy`; ADR 0037.
 
+Provider prerequisite: Hephaestus PR #136 merged at `da785b53`; the consumer
+branch now targets the merged `ComputeDevice::alloc_uninitialized_with_hint`
+contract in hosted CI.
+
 ## ATLAS-COEUS-SAFETY-002 Native COW seam consolidation [arch][patch]
 
 - [x] Route native Coeus WGPU and CUDA COW detachment through

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -9,7 +9,7 @@
       device-local copy.
 - [x] Extend the generic Hephaestus test device and preserve detached and
       retained value semantics.
-- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal Coeus provider/consumer CI
+- [x] Run exact-head WGPU, CUDA, ROCm, and Metal Coeus provider/consumer CI
       after the Hephaestus provider seam merges.
 
 Acceptance: every changed COW path fully overwrites the replacement through
@@ -24,6 +24,11 @@ Implementation owner: Codex on `codex/coeus-uninitialized-cow-copy`; ADR 0037.
 Provider prerequisite: Hephaestus PR #136 merged at `da785b53`; the consumer
 branch now targets the merged `ComputeDevice::alloc_uninitialized_with_hint`
 contract in hosted CI.
+
+Hosted exact-head Coeus run `30345002409` passed CUDA job `90229046185`, WGPU
+job `90229046271`, ROCm job `90229046258`, and Metal job `90229046242`. The
+required-device ROCm job `90229047328` was skipped because no hosted AMD
+runner was dispatched; no physical-device execution claim is made.
 
 ## ATLAS-COEUS-SAFETY-002 Native COW seam consolidation [arch][patch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,26 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-COEUS-SAFETY-003 Uninitialized COW replacement [arch][minor][perf]
+
+- [x] Keep ordinary WGPU, CUDA, and generic Hephaestus storage construction
+      zero-initialized.
+- [x] Allocate only COW replacement buffers through
+      `ComputeDevice::alloc_uninitialized_with_hint` before the complete
+      device-local copy.
+- [x] Extend the generic Hephaestus test device and preserve detached and
+      retained value semantics.
+- [ ] Run exact-head WGPU, CUDA, ROCm, and Metal Coeus provider/consumer CI
+      after the Hephaestus provider seam merges.
+
+Acceptance: every changed COW path fully overwrites the replacement through
+`ComputeDevice::copy_buffer` before it can be read; ordinary defined-content
+allocation remains zero-initialized; focused value-semantic tests pass. This is
+static allocation-path and structural memory-bandwidth evidence, not a runtime
+speed or resident-memory claim. The local CUDA feature check passes; hosted
+provider CI is required for device execution.
+
+Implementation owner: Codex on `codex/coeus-uninitialized-cow-copy`; ADR 0037.
+
 ## ATLAS-COEUS-SAFETY-002 Native COW seam consolidation [arch][patch]
 
 - [x] Route native Coeus WGPU and CUDA COW detachment through

--- a/crates/coeus-cuda/src/storage.rs
+++ b/crates/coeus-cuda/src/storage.rs
@@ -33,6 +33,14 @@ impl<T: Scalar> CudaStorage<T> {
             .expect("CudaStorage::new failed to allocate GPU buffer in device tier")
     }
 
+    #[inline]
+    fn alloc_device_uninitialized(len: usize) -> CudaBuffer<T> {
+        let device = crate::backend::get_cuda_device();
+        device
+            .alloc_uninitialized_with_hint(len, PlacementHint::Tier(MemoryTier::Device))
+            .expect("CudaStorage::make_unique failed to allocate GPU buffer in device tier")
+    }
+
     /// Allocate a new GPU device buffer.
     pub fn new(len: usize) -> Self {
         let buffer = Self::alloc_device_zeroed(len);
@@ -74,7 +82,7 @@ impl<T: Scalar> StorageMut<T> for CudaStorage<T> {
     fn make_unique(&mut self) {
         if Arc::strong_count(&self.buffer) > 1 {
             let device = crate::backend::get_cuda_device();
-            let new_buffer = Self::alloc_device_zeroed(self.buffer.len());
+            let new_buffer = Self::alloc_device_uninitialized(self.buffer.len());
             device
                 .copy_buffer(self.buffer.as_ref(), &new_buffer)
                 .expect("CudaStorage::make_unique failed to copy the device buffer");

--- a/crates/coeus-hephaestus/src/storage.rs
+++ b/crates/coeus-hephaestus/src/storage.rs
@@ -108,13 +108,18 @@ where
             return;
         }
         // COW detachment is a storage operation, so preserve the provider's
-        // allocation tier and keep the full payload on-device. The
-        // `StorageMut` contract is infallible; provider failures therefore
+        // allocation tier and keep the full payload on-device. The device
+        // copy overwrites every element before the detached buffer is exposed,
+        // so the replacement does not require a redundant initialization pass.
+        // The `StorageMut` contract is infallible; provider failures therefore
         // remain explicit invariant failures until that upstream contract is
         // made fallible.
         let device = P::device();
         let replacement = device
-            .alloc_zeroed_with_hint(self.buffer.len(), PlacementHint::Tier(self.buffer.tier()))
+            .alloc_uninitialized_with_hint(
+                self.buffer.len(),
+                PlacementHint::Tier(self.buffer.tier()),
+            )
             .expect("Hephaestus storage uniqueness allocation failed");
         device
             .copy_buffer(self.buffer.as_ref(), &replacement)
@@ -202,6 +207,20 @@ mod tests {
         }
 
         fn alloc_zeroed_with_hint<T: bytemuck::Pod>(
+            &self,
+            len: usize,
+            hint: PlacementHint,
+        ) -> hephaestus_core::Result<Self::Buffer<T>> {
+            empty_buffer(
+                len,
+                match hint {
+                    PlacementHint::Tier(tier) => tier,
+                    _ => MemoryTier::Device,
+                },
+            )
+        }
+
+        fn alloc_uninitialized_with_hint<T: bytemuck::Pod>(
             &self,
             len: usize,
             hint: PlacementHint,

--- a/crates/coeus-wgpu/src/storage.rs
+++ b/crates/coeus-wgpu/src/storage.rs
@@ -33,6 +33,14 @@ impl<T: Scalar> WgpuStorage<T> {
             .expect("Failed to allocate GPU buffer in device tier")
     }
 
+    #[inline]
+    fn alloc_device_uninitialized(len: usize) -> hephaestus_wgpu::WgpuBuffer<T> {
+        let ctx = get_wgpu_context();
+        ctx.hephaestus_device
+            .alloc_uninitialized_with_hint(len, PlacementHint::Tier(MemoryTier::Device))
+            .expect("Failed to allocate GPU buffer in device tier")
+    }
+
     /// Allocate a new GPU buffer for `len` elements.
     pub fn new(len: usize) -> Self {
         let buffer = Self::alloc_device_zeroed(len);
@@ -68,7 +76,7 @@ impl<T: Scalar> StorageMut<T> for WgpuStorage<T> {
     fn make_unique(&mut self) {
         if Arc::strong_count(&self.buffer) > 1 {
             let ctx = get_wgpu_context();
-            let new_buffer = Self::alloc_device_zeroed(self.buffer.len());
+            let new_buffer = Self::alloc_device_uninitialized(self.buffer.len());
             ctx.hephaestus_device
                 .copy_buffer(self.buffer.as_ref(), &new_buffer)
                 .expect("WgpuStorage::make_unique failed to copy the device buffer");

--- a/docs/adr/0037-uninitialized-cow-consumer.md
+++ b/docs/adr/0037-uninitialized-cow-consumer.md
@@ -1,6 +1,6 @@
 # ADR 0037: Use overwrite-before-read allocation for accelerator COW
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-07-28
 - Scope: Coeus WGPU, CUDA, and generic Hephaestus storage uniqueness
 - Change class: `[arch]`/`[minor]`
@@ -42,7 +42,11 @@ retained values, tier preservation, one device copy, and zero COW downloads.
 Coeus WGPU and generic Hephaestus all-target checks plus the CUDA feature
 all-target check pass against the provider branch; the focused generic storage
 Nextest test passes. The Hephaestus provider seam merged in PR #136 at
-`da785b53`; exact-head provider/consumer CI remains required for this consumer.
+`da785b53`. Hosted exact-head Coeus run `30345002409` passed CUDA job
+`90229046185`, WGPU job `90229046271`, ROCm job `90229046258`, and Metal job
+`90229046242`. The required-device ROCm job `90229047328` was skipped because
+no hosted AMD runner was dispatched; no physical-device execution claim is
+made.
 This change supplies static allocation-path evidence only; runtime bandwidth,
 latency, and resident-memory claims require
 a controlled benchmark.

--- a/docs/adr/0037-uninitialized-cow-consumer.md
+++ b/docs/adr/0037-uninitialized-cow-consumer.md
@@ -41,9 +41,10 @@ The generic Hephaestus storage regression continues to assert copied values,
 retained values, tier preservation, one device copy, and zero COW downloads.
 Coeus WGPU and generic Hephaestus all-target checks plus the CUDA feature
 all-target check pass against the provider branch; the focused generic storage
-Nextest test passes. Exact-head provider/consumer CI must run after the
-Hephaestus provider seam merges. This change supplies static allocation-path
-evidence only; runtime bandwidth, latency, and resident-memory claims require
+Nextest test passes. The Hephaestus provider seam merged in PR #136 at
+`da785b53`; exact-head provider/consumer CI remains required for this consumer.
+This change supplies static allocation-path evidence only; runtime bandwidth,
+latency, and resident-memory claims require
 a controlled benchmark.
 
 ## Revisit trigger

--- a/docs/adr/0037-uninitialized-cow-consumer.md
+++ b/docs/adr/0037-uninitialized-cow-consumer.md
@@ -1,0 +1,52 @@
+# ADR 0037: Use overwrite-before-read allocation for accelerator COW
+
+- Status: proposed
+- Date: 2026-07-28
+- Scope: Coeus WGPU, CUDA, and generic Hephaestus storage uniqueness
+- Change class: `[arch]`/`[minor]`
+
+## Context
+
+Coeus storage uniqueness detaches shared accelerator storage by allocating a
+replacement in the source buffer's memory tier and copying the complete source
+buffer on-device. The copy writes every element before the detached storage is
+exposed. Requesting zero-initialized storage for that replacement therefore
+adds an initialization pass that the copy immediately overwrites on CUDA and
+ROCm.
+
+## Decision
+
+Keep `new` and other ordinary storage construction on
+`alloc_zeroed_with_hint`. Use `alloc_uninitialized_with_hint` only for COW
+replacement buffers, followed immediately by the existing synchronous
+`ComputeDevice::copy_buffer` contract. The generic Hephaestus test device
+implements the seam with the same value-semantic storage model.
+
+The provider owns the allocation behavior: Coeus does not call CUDA, HIP,
+WGPU, or Metal APIs directly and does not add a host staging fallback. The
+source memory tier remains the replacement tier.
+
+## Alternatives rejected
+
+- Continue zeroing every COW replacement: rejected because CUDA and ROCm
+  perform a redundant full-buffer write before the full device copy.
+- Add provider-specific uninitialized helpers in Coeus: rejected because it
+  duplicates the Hephaestus backend seam and forks vendor policy.
+- Read from the replacement before the copy: rejected by the provider
+  overwrite-before-read contract.
+
+## Verification
+
+The generic Hephaestus storage regression continues to assert copied values,
+retained values, tier preservation, one device copy, and zero COW downloads.
+Coeus WGPU and generic Hephaestus all-target checks plus the CUDA feature
+all-target check pass against the provider branch; the focused generic storage
+Nextest test passes. Exact-head provider/consumer CI must run after the
+Hephaestus provider seam merges. This change supplies static allocation-path
+evidence only; runtime bandwidth, latency, and resident-memory claims require
+a controlled benchmark.
+
+## Revisit trigger
+
+Revisit if a provider cannot provide a real overwrite-before-read allocation or
+if a controlled COW benchmark shows its initialization pass is not material.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -13,15 +13,20 @@ contract and route only COW replacements through the explicit Hephaestus
 overwrite-before-read allocation seam. The generic Hephaestus test device
 implements the seam without changing the value-semantic copy regression.
 **Residual**: the Hephaestus provider seam prerequisite is satisfied by PR #136
-merged at `da785b53`. Exact-head Coeus provider/consumer CI remains open, and no
-runtime bandwidth, latency, or resident-memory delta is claimed without a
-controlled benchmark. The infallible `StorageMut::make_unique` failure
-boundary remains the separate `ATLAS-COEUS-SAFETY-001` item.
+merged at `da785b53`. Hosted exact-head Coeus run `30345002409` passed CUDA job
+`90229046185`, WGPU job `90229046271`, ROCm job `90229046258`, and Metal job
+`90229046242`; required-device ROCm job `90229047328` was skipped because no
+hosted AMD runner was dispatched. No runtime bandwidth, latency, or
+resident-memory delta is claimed without a controlled benchmark. The
+infallible `StorageMut::make_unique` failure boundary remains the separate
+`ATLAS-COEUS-SAFETY-001` item.
 **Local evidence**: Coeus WGPU and generic Hephaestus all-target checks pass
 against the provider branch; the CUDA feature all-target check also passes.
 The focused generic Hephaestus Nextest storage contract passes. Temporary
 provider path overlays were restored after verification.
-**Status**: consumer implementation in progress.
+**Status**: complete for the consumer allocation path and hosted provider
+matrix; physical-device execution and runtime performance measurement remain
+explicit residuals.
 
 ## ATLAS-COEUS-DISPATCH-002: Unsupported ConvTranspose3d fallback
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,28 @@
 # Coeus Gap Audit
 
+## ATLAS-COEUS-SAFETY-003: Uninitialized COW replacement allocation
+
+**Location**: `crates/coeus-hephaestus/src/storage.rs`,
+`crates/coeus-wgpu/src/storage.rs`, and `crates/coeus-cuda/src/storage.rs`.
+**Gap**: device-local COW allocates a replacement and immediately overwrites
+every element through `ComputeDevice::copy_buffer`, but the previous consumer
+path requested zero-initialized storage. CUDA and ROCm therefore paid a full
+initialization pass before the full device-to-device copy.
+**Resolution**: keep public storage construction on the zeroed allocation
+contract and route only COW replacements through the explicit Hephaestus
+overwrite-before-read allocation seam. The generic Hephaestus test device
+implements the seam without changing the value-semantic copy regression.
+**Residual**: this consumer branch depends on the Hephaestus provider seam
+merging first. Exact-head Coeus provider/consumer CI remains open, and no
+runtime bandwidth, latency, or resident-memory delta is claimed without a
+controlled benchmark. The infallible `StorageMut::make_unique` failure
+boundary remains the separate `ATLAS-COEUS-SAFETY-001` item.
+**Local evidence**: Coeus WGPU and generic Hephaestus all-target checks pass
+against the provider branch; the CUDA feature all-target check also passes.
+The focused generic Hephaestus Nextest storage contract passes. Temporary
+provider path overlays were restored after verification.
+**Status**: consumer implementation in progress.
+
 ## ATLAS-COEUS-DISPATCH-002: Unsupported ConvTranspose3d fallback
 
 **Location**: `crates/coeus-ops/src/backend_ops/traits/conv.rs`,

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -12,8 +12,8 @@ initialization pass before the full device-to-device copy.
 contract and route only COW replacements through the explicit Hephaestus
 overwrite-before-read allocation seam. The generic Hephaestus test device
 implements the seam without changing the value-semantic copy regression.
-**Residual**: this consumer branch depends on the Hephaestus provider seam
-merging first. Exact-head Coeus provider/consumer CI remains open, and no
+**Residual**: the Hephaestus provider seam prerequisite is satisfied by PR #136
+merged at `da785b53`. Exact-head Coeus provider/consumer CI remains open, and no
 runtime bandwidth, latency, or resident-memory delta is claimed without a
 controlled benchmark. The infallible `StorageMut::make_unique` failure
 boundary remains the separate `ATLAS-COEUS-SAFETY-001` item.


### PR DESCRIPTION
## Summary\n\n- keep ordinary storage construction zero-initialized\n- allocate WGPU, CUDA, and generic Hephaestus COW replacements through ComputeDevice::alloc_uninitialized_with_hint\n- preserve the existing synchronous device-local copy and value semantics\n- document the provider-first memory contract in ADR 0037\n\n## Provider dependency\n\nHephaestus PR #136 merged at da785b53 and provides the required allocation seam.\n\n## Verification\n\n- rustfmt and git diff --check\n- cargo check --offline -p coeus-hephaestus -p coeus-wgpu --all-targets against the provider branch\n- cargo check --offline -p coeus-cuda --features cuda --all-targets against the provider branch\n- focused cargo nextest storage value-semantic regression passes\n- temporary local provider path overlay restored before commit\n\nThis is static allocation-path and structural memory-bandwidth evidence. Runtime performance and resident-memory changes require a controlled benchmark and are not claimed.\n\nRefs: CHECKLIST.md#atlas-coeus-safety-003-uninitialized-cow-replacement-archminorperf

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes copy-on-write (COW) storage detachment for GPU accelerators by eliminating redundant zero-initialization of replacement buffers. When COW detaches shared storage, it allocates a replacement buffer and immediately overwrites every element via a complete device-to-device copy, making the initial zero-initialization redundant. The change routes COW replacement allocations through Hephaestus's `alloc_uninitialized_with_hint` while keeping ordinary storage construction zero-initialized, preserving existing value semantics and relying on the synchronous `copy_buffer` contract to ensure data is written before reads. The changes apply to WGPU, CUDA, and generic Hephaestus storage backends and are documented in ADR 0037.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0037-uninitialized-cow-consumer.md` |
| 2 | `crates/coeus-hephaestus/src/storage.rs` |
| 3 | `crates/coeus-wgpu/src/storage.rs` |
| 4 | `crates/coeus-cuda/src/storage.rs` |
| 5 | `CHECKLIST.md` |
| 6 | `docs/gap_audit.md` |
| 7 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved copy-on-write replacement allocation across CUDA, WGPU, and generic accelerator storage paths by avoiding unnecessary initial zeroing before contents are copied.
  * Preserved zero-initialized behavior for ordinary storage creation.
  * Maintained device-local copying and memory-tier placement during copy-on-write updates.

* **Documentation**
  * Added release notes, architecture guidance, safety checklist criteria, and verification details for the updated allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->