### PR TITLE
docs(coeus): Close lgamma parity evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
   CUDA, ROCm, and Metal f32 implementations. CUDA/ROCm use native device
   functions; WGPU/Metal use the shared Lanczos/reflection expression. Leto
   differential coverage includes positive values, reflection, and poles;
-  exact-head CI remains open for this increment.
+  exact-head provider and consumer CI passes; required-device ROCm remains
+  skipped when no hosted AMD runner is available.
 
 - [arch] Routes Coeus exact `Gelu` and `GeluGrad` through the Hephaestus ROCm
   and Metal f32 providers with Leto CPU differential coverage. Exact-head

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -79,14 +79,18 @@ verification.
       cases covering positive inputs, reflection, and gamma poles.
 - [x] Replace the WGPU unsupported-operation assertion with a provider
       expression contract assertion.
-- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for the
       Hephaestus expression seam and the Coeus consumer head.
 
-Status: source integration and local contract coverage are complete; exact-head
-provider and consumer CI is required before this item closes. The WGPU and
-Metal paths use the provider-owned Lanczos/reflection expression; CUDA and ROCm
-use their native `lgammaf`/`lgamma` device functions. No digamma gradient or
-non-f32 contract is implied.
+Status: complete for f32 forward dispatch. The WGPU and Metal paths use the
+provider-owned Lanczos/reflection expression; CUDA and ROCm use their native
+`lgammaf`/`lgamma` device functions. Hephaestus PR #118 passed WGPU
+`90086428952`, CUDA `90086430178`, ROCm `90086430143`, and Metal `90086428160`.
+Coeus PR #231 merged at `971fab9614b97bd708a716d01684da58fd1331ba`; its
+consumer jobs passed WGPU `90088836682`, CUDA `90088836688`, ROCm `90088836731`,
+and Metal `90088836675`. Required-device ROCm `90088837591` was skipped because
+no hosted AMD runner was dispatched. No digamma gradient or non-f32 contract is
+implied.
 
 ## ATLAS-COEUS-HEPHAESTUS-GELU-PARITY-001 [arch]
 

--- a/docs/adr/0029-coeus-hephaestus-lgamma-provider.md
+++ b/docs/adr/0029-coeus-hephaestus-lgamma-provider.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted; implementation is complete and exact-head CI is pending.
+Accepted; implementation and exact-head CI are complete for the f32 forward
+provider/consumer boundary.
 
 ## Context
 
@@ -44,10 +45,14 @@ positive infinity rather than applying a finite tolerance to `∞ - ∞`.
 
 ## Verification
 
-The affected Coeus crates require locked local checks and nextest. Exact-head
-WGPU, CUDA, ROCm, and Metal provider workflows plus the Coeus consumer matrix
-are required before closure. Hardware execution remains a separate evidence
-tier and is not claimed when required-device jobs skip.
+The affected Coeus crates require locked local checks and nextest. Hephaestus
+PR #118 passed WGPU `90086428952`, CUDA `90086430178`, ROCm `90086430143`, and
+Metal `90086428160`. Coeus PR #231 merged at
+`971fab9614b97bd708a716d01684da58fd1331ba`; its consumer jobs passed WGPU
+`90088836682`, CUDA `90088836688`, ROCm `90088836731`, and Metal `90088836675`.
+Required-device ROCm `90088837591` was skipped because no hosted AMD runner was
+dispatched. Hardware execution remains a separate evidence tier and is not
+claimed when the required-device job skips.
 
 ## Residual scope
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -97,14 +97,34 @@ ROCm and Metal provider matches.
 **Resolution**: route each operation through the shared Hephaestus marker and
 strided kernel, with valid-domain Leto differential coverage. Keep integer
 providers on their typed arithmetic-only rejection path.
-**Residual**: `erf`, `erfc`, `lgamma`, parameterized activations, and f64/vector
-contracts remain separate capability slices.
+**Residual**: `erf`, `erfc`, parameterized activations, and f64/vector contracts
+remain separate capability slices; `lgamma` is closed by the dedicated item
+below.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal CI; hardware lanes
 are reported independently from adapterless provider compilation.
 **Status**: complete for the 19-operation f32 scope. Hephaestus PR #112 merged
 as `e6ba1c14`. Coeus exact-head run `30273987046` passed WGPU `90003264732`,
 CUDA `90003264777`, ROCm `90003265014`, and Metal `90003264805`; required-device
 ROCm `90003265412` was skipped because no registered AMD runner was available.
+
+## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001: f32 forward log-gamma
+
+**Location**: the WGPU unary expression, CUDA/ROCm/Metal provider elementwise
+dispatch, and their backend contract suites.
+**Resolution**: route `UnaryOp::Lgamma` through the Hephaestus provider marker
+on all four backends. WGPU and Metal use the shared Lanczos/reflection
+expression; CUDA and ROCm use native device functions. Backend tests compare
+positive, reflected non-integer, and non-positive integer pole inputs with the
+Leto CPU oracle, requiring positive infinity at poles.
+**Evidence**: Hephaestus PR #118 passed WGPU `90086428952`, CUDA `90086430178`,
+ROCm `90086430143`, and Metal `90086428160`. Coeus PR #231 merged at
+`971fab9614b97bd708a716d01684da58fd1331ba`; its consumer jobs passed WGPU
+`90088836682`, CUDA `90088836688`, ROCm `90088836731`, and Metal `90088836675`.
+Required-device ROCm `90088837591` was skipped because no hosted AMD runner was
+dispatched; physical-device execution is not claimed.
+**Residual**: digamma gradients, f64/reduced/vector contracts, and complete
+non-elementwise Leto parity remain outside this item.
+**Status**: complete for the f32 forward provider/consumer boundary.
 
 ## ATLAS-COEUS-SAFETY-001: Hephaestus provider failure boundary
 


### PR DESCRIPTION
Record the merged Hephaestus and Coeus exact-head provider matrices for f32 forward lgamma, close the stale checklist/gap-audit state, and preserve the digamma/non-f32 residual scope.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates documentation to record the completion of f32 forward `lgamma` implementation across WGPU, CUDA, ROCm, and Metal backends. It closes the checklist item and gap audit entry by documenting successful CI runs from both Hephaestus provider PR #118 and Coeus consumer PR #231, including specific run IDs for each backend. The documentation clarifies that the scope is limited to f32 forward dispatch and explicitly excludes digamma gradients and non-f32 contracts as residual work.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHECKLIST.md` |
| 2 | `docs/adr/0029-coeus-hephaestus-lgamma-provider.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->