### PR TITLE
feat(backends): Add activation parity

### DIFF
--- a/.github/workflows/backend-parity.yml
+++ b/.github/workflows/backend-parity.yml
@@ -142,7 +142,7 @@ jobs:
           cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-wgpu --all-targets
           cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-wgpu --all-targets --no-deps -- -D warnings
           cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-wgpu \
-            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer)"
+            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer) or test(test_wgpu_elu_parity) or test(test_wgpu_parity_elu)"
           cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-wgpu --doc
 
   cuda:
@@ -270,7 +270,7 @@ jobs:
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-cuda --features cuda --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-cuda --features cuda --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-cuda --features cuda \
-                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops)"
+                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-cuda --features cuda --doc
             '
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
   branch boundary. Exact-head provider/consumer run `30351530489` passed CUDA
   `90249902958`, WGPU `90249903429`, ROCm `90249902939`, and Metal
   `90249903016`; required-device ROCm `90249904831` was skipped because no
-  hosted AMD runner was dispatched. No runtime performance or resident-memory
-  delta is claimed.
+  hosted AMD runner was dispatched. The WGPU and CUDA provider workflow
+  selectors include the new ELU contracts. No runtime performance or
+  resident-memory delta is claimed.
 
 - [patch] Routes native Coeus WGPU and CUDA copy-on-write detachment through
   the shared Hephaestus `ComputeDevice::copy_buffer` contract. This removes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   runtime performance and resident-memory changes are not claimed without a
   controlled benchmark.
 
+- [minor] Complete Coeus f32 Mish and ELU forward/gradient routing across the
+  WGPU, CUDA, ROCm, and Metal backend contracts. ROCm and Metal use the native
+  Hephaestus strided providers; CUDA covers both contiguous and strided ELU
+  launch paths; Leto differential tests cover signed inputs and the zero
+  branch boundary. No runtime performance or resident-memory delta is claimed.
+
 - [patch] Routes native Coeus WGPU and CUDA copy-on-write detachment through
   the shared Hephaestus `ComputeDevice::copy_buffer` contract. This removes
   duplicated encoder and CUDA-driver copy logic while preserving device-local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@
   WGPU, CUDA, ROCm, and Metal backend contracts. ROCm and Metal use the native
   Hephaestus strided providers; CUDA covers both contiguous and strided ELU
   launch paths; Leto differential tests cover signed inputs and the zero
-  branch boundary. No runtime performance or resident-memory delta is claimed.
+  branch boundary. Exact-head provider/consumer run `30351530489` passed CUDA
+  `90249902958`, WGPU `90249903429`, ROCm `90249902939`, and Metal
+  `90249903016`; required-device ROCm `90249904831` was skipped because no
+  hosted AMD runner was dispatched. No runtime performance or resident-memory
+  delta is claimed.
 
 - [patch] Routes native Coeus WGPU and CUDA copy-on-write detachment through
   the shared Hephaestus `ComputeDevice::copy_buffer` contract. This removes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@
   WGPU, CUDA, ROCm, and Metal backend contracts. ROCm and Metal use the native
   Hephaestus strided providers; CUDA covers both contiguous and strided ELU
   launch paths; Leto differential tests cover signed inputs and the zero
-  branch boundary. Exact-head provider/consumer run `30351530489` passed CUDA
-  `90249902958`, WGPU `90249903429`, ROCm `90249902939`, and Metal
-  `90249903016`; required-device ROCm `90249904831` was skipped because no
-  hosted AMD runner was dispatched. The WGPU and CUDA provider workflow
-  selectors include the new ELU contracts. No runtime performance or
-  resident-memory delta is claimed.
+  branch boundary. Targeted exact-head run `30353984154` passed CUDA
+  `90257861209`, WGPU `90257861154`, ROCm `90257861218`, and Metal
+  `90257861119`; required-device ROCm `90257861858` was skipped because no
+  hosted AMD runner was dispatched. The selectors execute the new ELU forward
+  and gradient contracts. No runtime performance or resident-memory delta is
+  claimed.
 
 - [patch] Routes native Coeus WGPU and CUDA copy-on-write detachment through
   the shared Hephaestus `ComputeDevice::copy_buffer` contract. This removes

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -115,7 +115,7 @@ available. ADR 0028 owns the exact GELU contract.
       its gradient, preserving the existing Mish expressions.
 - [x] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
       coverage for forward and gradient activation paths.
-- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
+- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
       the provider and consumer revisions.
 
 Acceptance: all four backends expose the same unparameterized f32 Mish and ELU
@@ -125,13 +125,14 @@ including the zero branch boundary. The existing strided/device-resident
 kernel paths remain in use; no runtime performance or resident-memory delta is
 claimed without a controlled benchmark. ADR 0038 owns the contract.
 
-Status: complete for the unparameterized f32 scope. Exact-head Coeus run
-`30351530489` passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job
-`90249902939`, and Metal job `90249903016`. Required-device ROCm job
-`90249904831` was skipped because no hosted AMD runner was dispatched; no
-physical-device execution claim is made. The external `recurseml/analysis`
-status returned its recurring analyzer error and is not repository-owned
-verification.
+Status: implementation is complete for the unparameterized f32 scope. Baseline
+exact-head Coeus run `30351530489` passed CUDA job `90249902958`, WGPU job
+`90249903429`, ROCm job `90249902939`, and Metal job `90249903016`; its required-
+device ROCm job `90249904831` was skipped because no hosted AMD runner was
+dispatched. The WGPU and CUDA workflow selectors now include the new ELU
+contracts; the exact-head targeted rerun remains required before closure. The
+external `recurseml/analysis` status returned its recurring analyzer error and
+is not repository-owned verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -109,13 +109,13 @@ available. ADR 0028 owns the exact GELU contract.
 
 ## ATLAS-COEUS-HEPHAESTUS-ACTIVATION-TAIL-PARITY-001 [arch][minor]
 
-- [ ] Route `UnaryOp::Mish`, `MishGrad`, `Elu`, and `EluGrad` through the
+- [x] Route `UnaryOp::Mish`, `MishGrad`, `Elu`, and `EluGrad` through the
       provider-owned Hephaestus ROCm and Metal f32 strided kernels.
-- [ ] Extend the CUDA contiguous and strided launch expressions with ELU and
+- [x] Extend the CUDA contiguous and strided launch expressions with ELU and
       its gradient, preserving the existing Mish expressions.
-- [ ] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
+- [x] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
       coverage for forward and gradient activation paths.
-- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
       the provider and consumer revisions.
 
 Acceptance: all four backends expose the same unparameterized f32 Mish and ELU
@@ -124,6 +124,14 @@ operation errors; backend values match the Leto CPU oracle over signed inputs
 including the zero branch boundary. The existing strided/device-resident
 kernel paths remain in use; no runtime performance or resident-memory delta is
 claimed without a controlled benchmark. ADR 0038 owns the contract.
+
+Status: complete for the unparameterized f32 scope. Exact-head Coeus run
+`30351530489` passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job
+`90249902939`, and Metal job `90249903016`. Required-device ROCm job
+`90249904831` was skipped because no hosted AMD runner was dispatched; no
+physical-device execution claim is made. The external `recurseml/analysis`
+status returned its recurring analyzer error and is not repository-owned
+verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -107,6 +107,24 @@ WGPU `90048506717`, and Metal `90048504635` passed; Coeus consumer jobs CUDA
 passed. Hardware-device jobs skipped because no registered runner was
 available. ADR 0028 owns the exact GELU contract.
 
+## ATLAS-COEUS-HEPHAESTUS-ACTIVATION-TAIL-PARITY-001 [arch][minor]
+
+- [ ] Route `UnaryOp::Mish`, `MishGrad`, `Elu`, and `EluGrad` through the
+      provider-owned Hephaestus ROCm and Metal f32 strided kernels.
+- [ ] Extend the CUDA contiguous and strided launch expressions with ELU and
+      its gradient, preserving the existing Mish expressions.
+- [ ] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
+      coverage for forward and gradient activation paths.
+- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
+      the provider and consumer revisions.
+
+Acceptance: all four backends expose the same unparameterized f32 Mish and ELU
+forward/gradient operations; integer providers retain typed unsupported
+operation errors; backend values match the Leto CPU oracle over signed inputs
+including the zero branch boundary. The existing strided/device-resident
+kernel paths remain in use; no runtime performance or resident-memory delta is
+claimed without a controlled benchmark. ADR 0038 owns the contract.
+
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 
 - [x] Route `UnaryOp::Erf` and `UnaryOp::Erfc` through the provider-owned

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -115,7 +115,7 @@ available. ADR 0028 owns the exact GELU contract.
       its gradient, preserving the existing Mish expressions.
 - [x] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
       coverage for forward and gradient activation paths.
-- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
       the provider and consumer revisions.
 
 Acceptance: all four backends expose the same unparameterized f32 Mish and ELU
@@ -125,14 +125,13 @@ including the zero branch boundary. The existing strided/device-resident
 kernel paths remain in use; no runtime performance or resident-memory delta is
 claimed without a controlled benchmark. ADR 0038 owns the contract.
 
-Status: implementation is complete for the unparameterized f32 scope. Baseline
-exact-head Coeus run `30351530489` passed CUDA job `90249902958`, WGPU job
-`90249903429`, ROCm job `90249902939`, and Metal job `90249903016`; its required-
-device ROCm job `90249904831` was skipped because no hosted AMD runner was
-dispatched. The WGPU and CUDA workflow selectors now include the new ELU
-contracts; the exact-head targeted rerun remains required before closure. The
-external `recurseml/analysis` status returned its recurring analyzer error and
-is not repository-owned verification.
+Status: complete for the unparameterized f32 scope. Targeted exact-head Coeus
+run `30353984154` passed CUDA job `90257861209`, WGPU job `90257861154`, ROCm
+job `90257861218`, and Metal job `90257861119`; required-device ROCm job
+`90257861858` was skipped because no hosted AMD runner was dispatched. The
+WGPU and CUDA selectors execute the new ELU forward and gradient contracts.
+The external `recurseml/analysis` status returned its recurring analyzer error
+and is not repository-owned verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 

--- a/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
@@ -157,6 +157,8 @@ pub fn launch_contiguous_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::SiluGrad => "(1.0f / (1.0f + expf(-a[idx]))) * (1.0f + a[idx] * (1.0f - (1.0f / (1.0f + expf(-a[idx])))))",
         coeus_ops::UnaryOp::Mish => "a[idx] * tanhf(logf(1.0f + expf(a[idx])))",
         coeus_ops::UnaryOp::MishGrad => "tanhf(logf(1.0f + expf(a[idx]))) + a[idx] * (1.0f - tanhf(logf(1.0f + expf(a[idx]))) * tanhf(logf(1.0f + expf(a[idx])))) * (1.0f / (1.0f + expf(-a[idx])))",
+        coeus_ops::UnaryOp::Elu => "(a[idx] >= 0.0f) ? a[idx] : (expf(a[idx]) - 1.0f)",
+        coeus_ops::UnaryOp::EluGrad => "(a[idx] >= 0.0f) ? 1.0f : expf(a[idx])",
         coeus_ops::UnaryOp::Recip => "1.0f / a[idx]",
         coeus_ops::UnaryOp::Sign => "(a[idx] > 0.0f) ? 1.0f : ((a[idx] < 0.0f) ? -1.0f : 0.0f)",
         coeus_ops::UnaryOp::Floor => "floorf(a[idx])",

--- a/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
@@ -234,6 +234,8 @@ pub fn launch_strided_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::SiluGrad => "(1.0f / (1.0f + expf(-val_a))) * (1.0f + val_a * (1.0f - (1.0f / (1.0f + expf(-val_a)))))",
         coeus_ops::UnaryOp::Mish => "val_a * tanhf(logf(1.0f + expf(val_a)))",
         coeus_ops::UnaryOp::MishGrad => "tanhf(logf(1.0f + expf(val_a))) + val_a * (1.0f - tanhf(logf(1.0f + expf(val_a))) * tanhf(logf(1.0f + expf(val_a)))) * (1.0f / (1.0f + expf(-val_a)))",
+        coeus_ops::UnaryOp::Elu => "(val_a >= 0.0f) ? val_a : (expf(val_a) - 1.0f)",
+        coeus_ops::UnaryOp::EluGrad => "(val_a >= 0.0f) ? 1.0f : expf(val_a)",
         coeus_ops::UnaryOp::Recip => "1.0f / val_a",
         coeus_ops::UnaryOp::Sign => "(val_a > 0.0f) ? 1.0f : ((val_a < 0.0f) ? -1.0f : 0.0f)",
         coeus_ops::UnaryOp::Floor => "floorf(val_a)",

--- a/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
+++ b/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
@@ -118,6 +118,11 @@ unary_parity!(
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
 );
 unary_parity!(
+    test_cuda_parity_elu,
+    coeus_ops::elu,
+    vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
+);
+unary_parity!(
     test_cuda_parity_exp,
     coeus_ops::exp,
     vec![-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, -2.0, 2.0]
@@ -218,6 +223,11 @@ unary_grad_parity!(
 unary_grad_parity!(
     test_cuda_parity_mish_grad,
     coeus_ops::UnaryOp::MishGrad,
+    vec![-2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 1.5]
+);
+unary_grad_parity!(
+    test_cuda_parity_elu_grad,
+    coeus_ops::UnaryOp::EluGrad,
     vec![-2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 1.5]
 );
 

--- a/crates/coeus-metal/src/backend/elementwise.rs
+++ b/crates/coeus-metal/src/backend/elementwise.rs
@@ -84,6 +84,26 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Mish => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::MishOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::MishGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::MishGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Elu => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::EluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::EluGrad => hephaestus_metal::unary_elementwise_strided_into::<
+            hephaestus_metal::EluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             UnaryOp::Tan => hephaestus_metal::unary_elementwise_strided_into::<
             hephaestus_metal::TanOp,
             f32,

--- a/crates/coeus-metal/tests/elementwise.rs
+++ b/crates/coeus-metal/tests/elementwise.rs
@@ -322,12 +322,16 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::GeluGrad,
         CpuUnaryOp::GeluTanh,
         CpuUnaryOp::Silu,
+        CpuUnaryOp::Mish,
+        CpuUnaryOp::Elu,
         CpuUnaryOp::Softplus,
         CpuUnaryOp::ReluGrad,
         CpuUnaryOp::SigmoidGrad,
         CpuUnaryOp::TanhGrad,
         CpuUnaryOp::GeluTanhGrad,
         CpuUnaryOp::SiluGrad,
+        CpuUnaryOp::MishGrad,
+        CpuUnaryOp::EluGrad,
         CpuUnaryOp::SoftplusGrad,
     ] {
         let mut expected = [0.0_f32; 6];

--- a/crates/coeus-rocm/src/backend/elementwise.rs
+++ b/crates/coeus-rocm/src/backend/elementwise.rs
@@ -84,6 +84,26 @@ macro_rules! activation_unary_dispatch {
             f32,
             N,
         >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Mish => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::MishOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::MishGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::MishGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::Elu => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::EluOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
+            UnaryOp::EluGrad => hephaestus_rocm::unary_elementwise_strided_into::<
+            hephaestus_rocm::EluGradOp,
+            f32,
+            N,
+        >($device, $input, $output, hephaestus_core::BlockWidth::DEFAULT),
             UnaryOp::Tan => hephaestus_rocm::unary_elementwise_strided_into::<
             hephaestus_rocm::TanOp,
             f32,

--- a/crates/coeus-rocm/tests/elementwise.rs
+++ b/crates/coeus-rocm/tests/elementwise.rs
@@ -322,12 +322,16 @@ fn native_elementwise_operations_match_leto_with_broadcasting() {
         CpuUnaryOp::GeluGrad,
         CpuUnaryOp::GeluTanh,
         CpuUnaryOp::Silu,
+        CpuUnaryOp::Mish,
+        CpuUnaryOp::Elu,
         CpuUnaryOp::Softplus,
         CpuUnaryOp::ReluGrad,
         CpuUnaryOp::SigmoidGrad,
         CpuUnaryOp::TanhGrad,
         CpuUnaryOp::GeluTanhGrad,
         CpuUnaryOp::SiluGrad,
+        CpuUnaryOp::MishGrad,
+        CpuUnaryOp::EluGrad,
         CpuUnaryOp::SoftplusGrad,
     ] {
         let mut expected = [0.0_f32; 6];

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/activations.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/activations.rs
@@ -77,3 +77,41 @@ fn test_wgpu_mish_parity() {
         assert!((grad_cpu_slice[i] - grad_gpu_slice[i]).abs() < 1e-5);
     }
 }
+
+#[test]
+fn test_wgpu_elu_parity() {
+    let seq = SequentialBackend::new();
+    let wgpu_b = WgpuBackend::new();
+
+    let input_data = vec![-2.0f32, -1.0, 0.0, 1.0, 2.0];
+    let input_cpu = Tensor::<f32, SequentialBackend>::from_slice([5], &input_data);
+    let input_gpu = input_cpu.to_backend_on(&seq, &wgpu_b);
+
+    let var_cpu = coeus_autograd::Var::new(input_cpu, true);
+    let var_gpu = coeus_autograd::Var::new(input_gpu, true);
+
+    let out_cpu = coeus_nn::elu(&var_cpu);
+    let out_gpu = coeus_nn::elu(&var_gpu);
+
+    let out_gpu_cpu = out_gpu.tensor.to_backend_on(&wgpu_b, &seq);
+    let out_cpu_slice = out_cpu.tensor.as_slice();
+    let out_gpu_slice = out_gpu_cpu.as_slice();
+
+    for i in 0..5 {
+        assert!((out_cpu_slice[i] - out_gpu_slice[i]).abs() < 1e-5);
+    }
+
+    out_cpu.backward();
+    out_gpu.backward();
+
+    let grad_cpu = var_cpu.grad().unwrap();
+    let grad_gpu = var_gpu.grad().unwrap();
+    let grad_gpu_cpu = grad_gpu.to_backend_on(&wgpu_b, &seq);
+
+    let grad_cpu_slice = grad_cpu.as_slice();
+    let grad_gpu_slice = grad_gpu_cpu.as_slice();
+
+    for i in 0..5 {
+        assert!((grad_cpu_slice[i] - grad_gpu_slice[i]).abs() < 1e-5);
+    }
+}

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs
@@ -243,6 +243,11 @@ test_unary_parity!(
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
 );
 test_unary_parity!(
+    test_wgpu_parity_elu,
+    coeus_ops::elu,
+    vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
+);
+test_unary_parity!(
     test_wgpu_parity_softplus,
     coeus_ops::softplus,
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]

--- a/docs/adr/0038-coeus-hephaestus-activation-tail.md
+++ b/docs/adr/0038-coeus-hephaestus-activation-tail.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Accepted; implementation and exact-head provider CI are complete for the
-unparameterized f32 scope.
+Accepted; implementation is complete for the unparameterized f32 scope and
+the targeted workflow rerun is pending.
 
 ## Context
 
@@ -47,11 +47,13 @@ the increment adds no host staging or temporary backend buffer.
 ## Verification
 
 Local format, package compilation, lint, and focused provider contracts cover
-the changed dispatch and expression tables. Exact-head Coeus run `30351530489`
-passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job `90249902939`,
-and Metal job `90249903016`. Required-device ROCm job `90249904831` was
-skipped because no hosted AMD runner was dispatched; no physical-device result
-is inferred. The external `recurseml/analysis` status returned its recurring
+the changed dispatch and expression tables. Baseline exact-head Coeus run
+`30351530489` passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job
+`90249902939`, and Metal job `90249903016`. Its required-device ROCm job
+`90249904831` was skipped because no hosted AMD runner was dispatched; no
+physical-device result is inferred. The WGPU and CUDA workflow selectors now
+include the new ELU contracts; the targeted exact-head rerun is required before
+closure. The external `recurseml/analysis` status returned its recurring
 analyzer error and is not repository-owned verification.
 
 ## Residual scope

--- a/docs/adr/0038-coeus-hephaestus-activation-tail.md
+++ b/docs/adr/0038-coeus-hephaestus-activation-tail.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Accepted; implementation is complete for the unparameterized f32 scope and
-the targeted workflow rerun is pending.
+Accepted; implementation and targeted provider CI are complete for the
+unparameterized f32 scope.
 
 ## Context
 
@@ -47,14 +47,13 @@ the increment adds no host staging or temporary backend buffer.
 ## Verification
 
 Local format, package compilation, lint, and focused provider contracts cover
-the changed dispatch and expression tables. Baseline exact-head Coeus run
-`30351530489` passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job
-`90249902939`, and Metal job `90249903016`. Its required-device ROCm job
-`90249904831` was skipped because no hosted AMD runner was dispatched; no
-physical-device result is inferred. The WGPU and CUDA workflow selectors now
-include the new ELU contracts; the targeted exact-head rerun is required before
-closure. The external `recurseml/analysis` status returned its recurring
-analyzer error and is not repository-owned verification.
+the changed dispatch and expression tables. Targeted exact-head Coeus run
+`30353984154` passed CUDA job `90257861209`, WGPU job `90257861154`, ROCm job
+`90257861218`, and Metal job `90257861119`. Required-device ROCm job
+`90257861858` was skipped because no hosted AMD runner was dispatched; no
+physical-device result is inferred. The WGPU and CUDA selectors execute the new
+ELU forward and gradient contracts. The external `recurseml/analysis` status
+returned its recurring analyzer error and is not repository-owned verification.
 
 ## Residual scope
 

--- a/docs/adr/0038-coeus-hephaestus-activation-tail.md
+++ b/docs/adr/0038-coeus-hephaestus-activation-tail.md
@@ -1,0 +1,59 @@
+# ADR-0038: Complete Hephaestus activation provider parity
+
+## Status
+
+Accepted; implementation is complete locally and exact-head provider CI is
+pending.
+
+## Context
+
+Coeus and Leto define unparameterized f32 `Mish`, `MishGrad`, `Elu`, and
+`EluGrad` operations. Hephaestus already owns native expression markers for
+all four ROCm and Metal operations, and the WGPU expression generator already
+emits their WGSL forms. Coeus ROCm and Metal dispatch rejected all four
+operations. Coeus CUDA implemented Mish in both launch forms but rejected ELU.
+
+## Decision
+
+Route ROCm and Metal `Mish`, `MishGrad`, `Elu`, and `EluGrad` through the
+existing Hephaestus strided elementwise seam. Add the ELU forward and gradient
+expressions to both CUDA contiguous and strided launch tables. Keep WGPU on its
+existing provider expression path. The supported accelerator type remains
+`f32`; integer providers retain typed unsupported-operation errors.
+
+The contracts are:
+
+- `Mish(x) = x * tanh(log(1 + exp(x)))`.
+- `MishGrad(x) = tanh(softplus(x)) + x * (1 - tanh(softplus(x))²) * sigmoid(x)`.
+- `Elu(x) = x` for `x >= 0`, otherwise `exp(x) - 1`.
+- `EluGrad(x) = 1` for `x >= 0`, otherwise `exp(x)`.
+
+Backend suites compare forward and gradient values with the Leto CPU oracle
+over signed inputs containing negative, zero, and positive branch regions.
+The existing device-resident strided and launch paths remain authoritative;
+the increment adds no host staging or temporary backend buffer.
+
+## Alternatives rejected
+
+- Leaving ROCm and Metal unsupported was rejected because the provider markers
+  and the WGPU/CUDA/CPU contracts already exist.
+- Copying the Hephaestus ROCm or Metal expressions into Coeus was rejected
+  because dialect-specific provider expressions belong to Hephaestus.
+- Routing missing operations through Leto was rejected because it would hide
+  provider capability gaps and violate the device-resident output contract.
+- Adding a second CUDA kernel family was rejected because the existing
+  contiguous and strided launch tables are the canonical CUDA dispatch homes.
+
+## Verification
+
+Local format, package compilation, lint, and focused provider contracts cover
+the changed dispatch and expression tables. Exact-head WGPU, CUDA, ROCm, and
+Metal provider/consumer CI is required before this item closes. The
+required-device ROCm lane is reported separately from adapterless compilation;
+no physical-device result is inferred when that lane is skipped.
+
+## Residual scope
+
+Parameterized activations, f64/reduced/vector contracts, and runtime
+performance or resident-memory measurements remain separate work. This ADR
+does not claim complete Leto parity for non-unary or parameterized operations.

--- a/docs/adr/0038-coeus-hephaestus-activation-tail.md
+++ b/docs/adr/0038-coeus-hephaestus-activation-tail.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Accepted; implementation is complete locally and exact-head provider CI is
-pending.
+Accepted; implementation and exact-head provider CI are complete for the
+unparameterized f32 scope.
 
 ## Context
 
@@ -47,10 +47,12 @@ the increment adds no host staging or temporary backend buffer.
 ## Verification
 
 Local format, package compilation, lint, and focused provider contracts cover
-the changed dispatch and expression tables. Exact-head WGPU, CUDA, ROCm, and
-Metal provider/consumer CI is required before this item closes. The
-required-device ROCm lane is reported separately from adapterless compilation;
-no physical-device result is inferred when that lane is skipped.
+the changed dispatch and expression tables. Exact-head Coeus run `30351530489`
+passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job `90249902939`,
+and Metal job `90249903016`. Required-device ROCm job `90249904831` was
+skipped because no hosted AMD runner was dispatched; no physical-device result
+is inferred. The external `recurseml/analysis` status returned its recurring
+analyzer error and is not repository-owned verification.
 
 ## Residual scope
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -126,12 +126,11 @@ physical-device execution remain separate evidence scopes.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
 CI; required-device ROCm is reported independently from adapterless provider
 compilation.
-**Status**: implementation is complete for the unparameterized f32 scope.
-Baseline exact-head Coeus run `30351530489` passed CUDA job `90249902958`, WGPU
-job `90249903429`, ROCm job `90249902939`, and Metal job `90249903016`;
-required-device ROCm job `90249904831` was skipped because no hosted AMD runner
-was dispatched. The WGPU and CUDA workflow selectors now include the new ELU
-contracts; the exact-head targeted rerun remains required before closure. The
+**Status**: complete for the unparameterized f32 scope. Targeted exact-head
+Coeus run `30353984154` passed CUDA job `90257861209`, WGPU job `90257861154`,
+ROCm job `90257861218`, and Metal job `90257861119`; required-device ROCm job
+`90257861858` was skipped because no hosted AMD runner was dispatched. The WGPU
+and CUDA selectors execute the new ELU forward and gradient contracts. The
 external `recurseml/analysis` status returned its recurring analyzer error and
 is not repository-owned verification. ADR 0038 owns the provider and consumer
 contract.

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -126,13 +126,15 @@ physical-device execution remain separate evidence scopes.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
 CI; required-device ROCm is reported independently from adapterless provider
 compilation.
-**Status**: complete for the unparameterized f32 scope. Exact-head Coeus run
-`30351530489` passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job
-`90249902939`, and Metal job `90249903016`. Required-device ROCm job
-`90249904831` was skipped because no hosted AMD runner was dispatched; no
-physical-device execution claim is made. The external `recurseml/analysis`
-status returned its recurring analyzer error and is not repository-owned
-verification. ADR 0038 owns the provider and consumer contract.
+**Status**: implementation is complete for the unparameterized f32 scope.
+Baseline exact-head Coeus run `30351530489` passed CUDA job `90249902958`, WGPU
+job `90249903429`, ROCm job `90249902939`, and Metal job `90249903016`;
+required-device ROCm job `90249904831` was skipped because no hosted AMD runner
+was dispatched. The WGPU and CUDA workflow selectors now include the new ELU
+contracts; the exact-head targeted rerun remains required before closure. The
+external `recurseml/analysis` status returned its recurring analyzer error and
+is not repository-owned verification. ADR 0038 owns the provider and consumer
+contract.
 
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001: f32 forward log-gamma
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -126,8 +126,13 @@ physical-device execution remain separate evidence scopes.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
 CI; required-device ROCm is reported independently from adapterless provider
 compilation.
-**Status**: implementation is pending exact-head CI. ADR 0038 owns the
-provider and consumer contract.
+**Status**: complete for the unparameterized f32 scope. Exact-head Coeus run
+`30351530489` passed CUDA job `90249902958`, WGPU job `90249903429`, ROCm job
+`90249902939`, and Metal job `90249903016`. Required-device ROCm job
+`90249904831` was skipped because no hosted AMD runner was dispatched; no
+physical-device execution claim is made. The external `recurseml/analysis`
+status returned its recurring analyzer error and is not repository-owned
+verification. ADR 0038 owns the provider and consumer contract.
 
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001: f32 forward log-gamma
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -107,6 +107,28 @@ as `e6ba1c14`. Coeus exact-head run `30273987046` passed WGPU `90003264732`,
 CUDA `90003264777`, ROCm `90003265014`, and Metal `90003264805`; required-device
 ROCm `90003265412` was skipped because no registered AMD runner was available.
 
+## ATLAS-COEUS-HEPHAESTUS-ACTIVATION-TAIL-PARITY-001: Mish and ELU
+
+**Location**: the Coeus ROCm and Metal activation dispatch macros, CUDA
+contiguous and strided unary launch expressions, and the four backend contract
+suites.
+**Gap**: Hephaestus already exports native f32 `Mish`, `MishGrad`, `Elu`, and
+`EluGrad` markers for ROCm and Metal, and WGPU already emits all four
+expressions. Coeus ROCm and Metal rejected all four operations, while CUDA
+implemented Mish but rejected ELU in both launch paths.
+**Resolution**: dispatch ROCm and Metal through the existing Hephaestus
+strided marker seam; add the canonical ELU expressions to CUDA's contiguous and
+strided launch tables; retain WGPU's existing provider expression path. Extend
+the backend suites with Leto CPU differential checks for forward and gradient
+operations.
+**Residual**: parameterized activations, f64/reduced/vector contracts, and
+physical-device execution remain separate evidence scopes.
+**Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
+CI; required-device ROCm is reported independently from adapterless provider
+compilation.
+**Status**: implementation is pending exact-head CI. ADR 0038 owns the
+provider and consumer contract.
+
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001: f32 forward log-gamma
 
 **Location**: the WGPU unary expression, CUDA/ROCm/Metal provider elementwise


### PR DESCRIPTION
## Summary\n- route Mish, MishGrad, ELU, and ELUGrad through the existing Hephaestus ROCm and Metal strided provider seams\n- add CUDA ELU expressions to contiguous and strided launch tables\n- extend WGPU, CUDA, ROCm, and Metal Leto differential coverage and record ADR 0038\n\n## Verification\n- WGPU focused activation and ELU parity nextest: passed\n- ROCm and Metal elementwise provider contracts against merged Hephaestus: passed locally\n- package checks for WGPU, CUDA, ROCm, and Metal: passed locally against merged Hephaestus\n- CUDA runtime harness is blocked on this Windows host at MinGW linking: cannot find -lcuda; hosted CUDA CI is authoritative\n- no runtime performance or resident-memory claim\n\nRefs: CHECKLIST.md#atlas-coeus-hephaestus-activation-tail-parity-001

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes activation function parity across WGPU, CUDA, ROCm, and Metal backends by adding support for `Mish`, `MishGrad`, `Elu`, and `EluGrad` operations. ROCm and Metal now route these operations through existing Hephaestus strided providers, while CUDA adds ELU expressions to both contiguous and strided launch tables (Mish was already present). All four backends extend their test suites with Leto CPU differential coverage for forward and gradient paths, including signed inputs and zero boundary cases. The implementation reuses existing device-resident kernel paths with no claimed performance or memory impact.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0038-coeus-hephaestus-activation-tail.md` |
| 2 | `CHECKLIST.md` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-rocm/src/backend/elementwise.rs` |
| 6 | `crates/coeus-metal/src/backend/elementwise.rs` |
| 7 | `crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs` |
| 8 | `crates/coeus-cuda/src/kernels/launch_ops/strided.rs` |
| 9 | `crates/coeus-rocm/tests/elementwise.rs` |
| 10 | `crates/coeus-metal/tests/elementwise.rs` |
| 11 | `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs` |
| 12 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs` |
| 13 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/activations.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ELU and ELU gradient support across CUDA, ROCm, Metal, and WGPU backends.
  * Added Mish and Mish gradient support for ROCm and Metal.
  * Extended activation dispatch so these operations are supported end-to-end with backend parity.
* **Tests**
  * Added CUDA, ROCm, Metal, and WGPU parity tests for ELU forward and gradient behavior.
  * Expanded backend parity test selections in CI.
* **Documentation**
  * Added ADR and audit notes covering activation provider parity contracts and verification expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->