### PR TITLE
Route CUDA common activations through Hephaestus

### DIFF
--- a/.github/workflows/backend-parity.yml
+++ b/.github/workflows/backend-parity.yml
@@ -142,7 +142,7 @@ jobs:
           cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-wgpu --all-targets
           cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-wgpu --all-targets --no-deps -- -D warnings
           cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-wgpu \
-            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer) or test(test_wgpu_elu_parity) or test(test_wgpu_parity_elu)"
+            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer) or test(test_wgpu_elu_parity) or test(test_wgpu_parity_elu) or test(test_wgpu_parity_gelu_tanh) or test(test_wgpu_parity_softplus)"
           cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-wgpu --doc
 
   cuda:
@@ -270,7 +270,7 @@ jobs:
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-cuda --features cuda --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-cuda --features cuda --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-cuda --features cuda \
-                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad)"
+                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad) or test(test_cuda_parity_gelu_tanh) or test(test_cuda_parity_gelu_tanh_grad) or test(test_cuda_parity_softplus) or test(test_cuda_parity_softplus_grad)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-cuda --features cuda --doc
             '
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changed
 
+- [minor] Route Coeus CUDA `GeluTanh`, `GeluTanhGrad`, `Softplus`, and
+  `SoftplusGrad` through the existing Hephaestus marker kernels for contiguous
+  and runtime-shaped strided layouts. Add CUDA/Leto forward and gradient
+  parity coverage and select the WGPU/CUDA contracts in CI. No runtime
+  performance or resident-memory delta is claimed without a controlled
+  benchmark.
+
 - [minor] Route Coeus WGPU, CUDA, and generic Hephaestus COW replacement
   allocations through Hephaestus's overwrite-before-read device allocation
   seam while keeping ordinary storage construction zero-initialized. The

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -73,21 +73,29 @@ verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-ACTIVATION-PARITY-001 [minor]
 
-- [ ] Route CUDA `GeluTanh`, `GeluTanhGrad`, `Softplus`, and `SoftplusGrad`
+- [x] Route CUDA `GeluTanh`, `GeluTanhGrad`, `Softplus`, and `SoftplusGrad`
       through the existing Hephaestus marker kernels for contiguous and
       runtime-shaped strided layouts.
-- [ ] Add CUDA/Leto value-semantic forward and gradient parity coverage and
+- [x] Add CUDA/Leto value-semantic forward and gradient parity coverage and
       select the tests in the CUDA CI contract job.
-- [ ] Record exact-head CUDA, WGPU, ROCm, and Metal CI evidence and preserve
+- [x] Record exact-head CUDA, WGPU, ROCm, and Metal CI evidence and preserve
       the existing typed unsupported-operation behavior for operations outside
       the common marker seam.
 
-Owner: Codex on `codex/coeus-cuda-common-activation-parity`; claimed scope:
+Owner: Codex on `codex/coeus-cuda-common-activation-parity`; completed at
+`dc5dbd5a` pending docs-head rerun. Claimed scope:
 `crates/coeus-cuda/src/backend/ops/math.rs`,
 `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs`,
 `.github/workflows/backend-parity.yml`, `CHECKLIST.md`, and
 `docs/gap_audit.md`. Peer-owned reduction and backend-error files remain
 outside this claim.
+
+Evidence: implementation-head run `30358001986` passed CUDA job `90270630628`,
+WGPU job `90270630619`, ROCm job `90270630584`, and Metal job `90270630599`.
+Required-device ROCm job `90270631213` was skipped because no hosted AMD
+runner was dispatched. The CUDA selector executed the four new forward and
+gradient tests; WGPU selected the GELU-tanh contract. No runtime speedup or
+resident-memory delta is claimed without a matched benchmark.
 
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001 [arch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -83,16 +83,16 @@ verification.
       the common marker seam.
 
 Owner: Codex on `codex/coeus-cuda-common-activation-parity`; completed at
-`dc5dbd5a` pending docs-head rerun. Claimed scope:
+`8a38f392`. Claimed scope:
 `crates/coeus-cuda/src/backend/ops/math.rs`,
 `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs`,
 `.github/workflows/backend-parity.yml`, `CHECKLIST.md`, and
 `docs/gap_audit.md`. Peer-owned reduction and backend-error files remain
 outside this claim.
 
-Evidence: implementation-head run `30358001986` passed CUDA job `90270630628`,
-WGPU job `90270630619`, ROCm job `90270630584`, and Metal job `90270630599`.
-Required-device ROCm job `90270631213` was skipped because no hosted AMD
+Evidence: docs-head run `30359324025` passed CUDA job `90274888940`, WGPU job
+`90274889041`, ROCm job `90274889047`, and Metal job `90274888991`.
+Required-device ROCm job `90274889835` was skipped because no hosted AMD
 runner was dispatched. The CUDA selector executed the four new forward and
 gradient tests; WGPU selected the GELU-tanh contract. No runtime speedup or
 resident-memory delta is claimed without a matched benchmark.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -71,6 +71,24 @@ physical-device execution claim is made. The external `recurseml/analysis`
 status returned its recurring analyzer error and is not repository-owned
 verification.
 
+## ATLAS-COEUS-HEPHAESTUS-CUDA-ACTIVATION-PARITY-001 [minor]
+
+- [ ] Route CUDA `GeluTanh`, `GeluTanhGrad`, `Softplus`, and `SoftplusGrad`
+      through the existing Hephaestus marker kernels for contiguous and
+      runtime-shaped strided layouts.
+- [ ] Add CUDA/Leto value-semantic forward and gradient parity coverage and
+      select the tests in the CUDA CI contract job.
+- [ ] Record exact-head CUDA, WGPU, ROCm, and Metal CI evidence and preserve
+      the existing typed unsupported-operation behavior for operations outside
+      the common marker seam.
+
+Owner: Codex on `codex/coeus-cuda-common-activation-parity`; claimed scope:
+`crates/coeus-cuda/src/backend/ops/math.rs`,
+`crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs`,
+`.github/workflows/backend-parity.yml`, `CHECKLIST.md`, and
+`docs/gap_audit.md`. Peer-owned reduction and backend-error files remain
+outside this claim.
+
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001 [arch]
 
 - [x] Route `UnaryOp::Lgamma` through the provider-owned Hephaestus WGPU,

--- a/crates/coeus-cuda/src/backend/ops/math.rs
+++ b/crates/coeus-cuda/src/backend/ops/math.rs
@@ -140,6 +140,34 @@ where
             ),
             c,
         ),
+        coeus_ops::UnaryOp::GeluTanh => run(
+            hephaestus_cuda::unary_elementwise::<hephaestus_cuda::GeluTanhOp, T>(
+                device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::GeluTanhGrad => run(
+            hephaestus_cuda::unary_elementwise::<hephaestus_cuda::GeluTanhGradOp, T>(
+                device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::Softplus => run(
+            hephaestus_cuda::unary_elementwise::<hephaestus_cuda::SoftplusOp, T>(
+                device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::SoftplusGrad => run(
+            hephaestus_cuda::unary_elementwise::<hephaestus_cuda::SoftplusGradOp, T>(
+                device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
         _ => Ok(false),
     }
 }
@@ -331,6 +359,46 @@ where
             hephaestus_operand(c, c_layout),
             hephaestus_cuda::BlockWidth::DEFAULT,
         )),
+        coeus_ops::UnaryOp::GeluTanh => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::GeluTanhOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::GeluTanhGrad => {
+            run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+                hephaestus_cuda::GeluTanhGradOp,
+                T,
+            >(
+                device,
+                hephaestus_operand(a, a_layout),
+                hephaestus_operand(c, c_layout),
+                hephaestus_cuda::BlockWidth::DEFAULT,
+            ))
+        }
+        coeus_ops::UnaryOp::Softplus => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::SoftplusOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::SoftplusGrad => {
+            run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+                hephaestus_cuda::SoftplusGradOp,
+                T,
+            >(
+                device,
+                hephaestus_operand(a, a_layout),
+                hephaestus_operand(c, c_layout),
+                hephaestus_cuda::BlockWidth::DEFAULT,
+            ))
+        }
         _ => Ok(false),
     }
 }

--- a/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
+++ b/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
@@ -108,6 +108,11 @@ unary_parity!(
     vec![-3.0, -2.3, -1.5, -0.5, 0.5, 1.5, 2.3, 3.0]
 );
 unary_parity!(
+    test_cuda_parity_gelu_tanh,
+    coeus_ops::gelu_tanh,
+    vec![-3.0, -2.3, -1.5, -0.5, 0.5, 1.5, 2.3, 3.0]
+);
+unary_parity!(
     test_cuda_parity_silu,
     coeus_ops::silu,
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
@@ -121,6 +126,11 @@ unary_parity!(
     test_cuda_parity_elu,
     coeus_ops::elu,
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
+);
+unary_parity!(
+    test_cuda_parity_softplus,
+    coeus_ops::softplus,
+    vec![-3.0, -1.0, 0.0, 0.5, 1.0, 2.0, 3.0, 4.0]
 );
 unary_parity!(
     test_cuda_parity_exp,
@@ -216,6 +226,11 @@ unary_grad_parity!(
     vec![-3.0, -2.3, -1.5, -0.5, 0.5, 1.5, 2.3, 3.0]
 );
 unary_grad_parity!(
+    test_cuda_parity_gelu_tanh_grad,
+    coeus_ops::UnaryOp::GeluTanhGrad,
+    vec![-3.0, -2.3, -1.5, -0.5, 0.5, 1.5, 2.3, 3.0]
+);
+unary_grad_parity!(
     test_cuda_parity_silu_grad,
     coeus_ops::UnaryOp::SiluGrad,
     vec![-2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 1.5]
@@ -229,6 +244,11 @@ unary_grad_parity!(
     test_cuda_parity_elu_grad,
     coeus_ops::UnaryOp::EluGrad,
     vec![-2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 1.5]
+);
+unary_grad_parity!(
+    test_cuda_parity_softplus_grad,
+    coeus_ops::UnaryOp::SoftplusGrad,
+    vec![-3.0, -1.0, -0.25, 0.0, 0.25, 1.0, 3.0, 4.0]
 );
 
 // Reductions.

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs
@@ -233,6 +233,11 @@ test_unary_parity!(
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]
 );
 test_unary_parity!(
+    test_wgpu_parity_gelu_tanh,
+    coeus_ops::gelu_tanh,
+    vec![-3.0, -2.3, -1.5, -0.5, 0.5, 1.5, 2.3, 3.0]
+);
+test_unary_parity!(
     test_wgpu_parity_silu,
     coeus_ops::silu,
     vec![-2.0, -1.0, 0.0, 0.5, 1.0, 2.0, -0.5, 1.5]

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -135,6 +135,30 @@ external `recurseml/analysis` status returned its recurring analyzer error and
 is not repository-owned verification. ADR 0038 owns the provider and consumer
 contract.
 
+## ATLAS-COEUS-HEPHAESTUS-CUDA-ACTIVATION-PARITY-001: GELU-tanh and Softplus
+
+**Location**: `crates/coeus-cuda/src/backend/ops/math.rs`, the CUDA parity
+suite, and the WGPU/CUDA backend-parity selectors.
+**Gap**: Coeus ROCm and Metal already routed `GeluTanh`, `GeluTanhGrad`,
+`Softplus`, and `SoftplusGrad` through Hephaestus strided markers, while CUDA
+had no shared-provider arms for these operations. Contiguous and runtime-shaped
+strided CUDA tensors could therefore reach the legacy capability boundary.
+**Resolution**: route the four operations through Hephaestus's existing CUDA
+marker kernels for both allocation-returning contiguous dispatch and caller-
+owned dynamic-rank strided dispatch. Add CUDA/Leto forward and gradient
+differential cases and a WGPU GELU-tanh contract selection.
+**Residual**: parameterized activations, f64/reduced/vector contracts, and
+physical-device execution remain separate evidence scopes. No runtime
+performance or resident-memory delta is claimed without a controlled benchmark.
+**Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
+CI; required-device ROCm is reported independently from adapterless provider
+compilation.
+**Status**: implementation head `dc5dbd5a` passed run `30358001986`: CUDA
+`90270630628`, WGPU `90270630619`, ROCm `90270630584`, and Metal `90270630599`.
+Required-device ROCm `90270631213` was skipped because no hosted AMD runner was
+dispatched. The external `recurseml/analysis` status returned its recurring
+analyzer error and is not repository-owned verification.
+
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001: f32 forward log-gamma
 
 **Location**: the WGPU unary expression, CUDA/ROCm/Metal provider elementwise

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -153,9 +153,9 @@ performance or resident-memory delta is claimed without a controlled benchmark.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
 CI; required-device ROCm is reported independently from adapterless provider
 compilation.
-**Status**: implementation head `dc5dbd5a` passed run `30358001986`: CUDA
-`90270630628`, WGPU `90270630619`, ROCm `90270630584`, and Metal `90270630599`.
-Required-device ROCm `90270631213` was skipped because no hosted AMD runner was
+**Status**: docs head `8a38f392` passed run `30359324025`: CUDA
+`90274888940`, WGPU `90274889041`, ROCm `90274889047`, and Metal `90274888991`.
+Required-device ROCm `90274889835` was skipped because no hosted AMD runner was
 dispatched. The external `recurseml/analysis` status returned its recurring
 analyzer error and is not repository-owned verification.
 


### PR DESCRIPTION
Route CUDA GELU-tanh and Softplus forward/gradient operations through the existing Hephaestus marker kernels for contiguous and runtime-shaped strided layouts. Add CUDA/Leto parity cases and execute the corresponding WGPU/CUDA contracts in CI. Peer-owned reduction and backend-error edits remain uncommitted and outside this change.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR routes CUDA `GeluTanh` and `Softplus` activation operations (including their gradients) through the existing Hephaestus marker kernels for both contiguous and runtime-shaped strided layouts. It adds corresponding CUDA/Leto parity tests for forward and gradient operations and updates the CI workflows to execute these new tests for both WGPU and CUDA backends.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHECKLIST.md` |
| 2 | `crates/coeus-cuda/src/backend/ops/math.rs` |
| 3 | `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs` |
| 4 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs` |
| 5 | `.github/workflows/backend-parity.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA support for GELU-tanh and Softplus operations, including gradient calculations, across contiguous and dynamically shaped strided tensors.
  * Added cross-backend parity coverage for CUDA and WGPU results.

* **Documentation**
  * Updated the changelog, roadmap checklist, and capability-gap documentation with activation support and validation details.

* **Tests**
  * Expanded automated contract and parity testing for the new activation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->