### PR TITLE
docs(coeus): Close GELU provider evidence

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -23,9 +23,9 @@ Owner: Codex on `codex/coeus-cuda-common-activation-parity`; claimed scope:
 `crates/coeus-cuda/src/fallback/ops/{mod,pool}.rs`, and
 `crates/coeus-wgpu/src/backend/ops/{pool,impls/pool}.rs`, plus the migrated
 WGPU pooling contract tests under
-`crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/pooling.rs`. The live peer owns
-the dirty reduction, backend-error, and lockfile files; they remain outside
-this increment.
+`crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/pooling.rs`. The stale
+reduction and backend-error edits were reconciled to the merged implementation;
+only the Atlas-overlay-generated `Cargo.lock` remains outside this increment.
 
 Implementation head `f861cea6` is complete. The pool repair propagates WGPU
 kernel errors, removes the CUDA 2-D/3-D host fallback module, and returns typed
@@ -123,8 +123,8 @@ Owner: Codex on `codex/coeus-cuda-common-activation-parity`; completed at
 `crates/coeus-cuda/src/backend/ops/math.rs`,
 `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs`,
 `.github/workflows/backend-parity.yml`, `CHECKLIST.md`, and
-`docs/gap_audit.md`. Peer-owned reduction and backend-error files remain
-outside this claim.
+`docs/gap_audit.md`. No reduction or backend-error residual remains; the
+Atlas-overlay-generated `Cargo.lock` remains outside this claim.
 
 Evidence: docs-head run `30359324025` passed CUDA job `90274888940`, WGPU job
 `90274889041`, ROCm job `90274889047`, and Metal job `90274888991`.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -10,11 +10,12 @@
       block the exact-head provider matrix.
 - [x] Split the mixed CUDA math dispatcher into elementwise, matmul, and
       reduction leaves without changing the backend method surface.
-- [ ] Record exact-head WGPU, CUDA, ROCm, and Metal CI evidence without making
+- [x] Record exact-head WGPU, CUDA, ROCm, and Metal CI evidence without making
       an unmeasured runtime or resident-memory claim.
 
 Owner: Codex on `codex/coeus-cuda-common-activation-parity`; claimed scope:
-`crates/coeus-cuda/src/backend/ops/math.rs`,
+`crates/coeus-cuda/src/backend/ops/math.rs` and
+`crates/coeus-cuda/src/backend/ops/math/elementwise.rs`,
 `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs`,
 `.github/workflows/backend-parity.yml`, `docs/backlog.md`, `CHECKLIST.md`, and
 `docs/gap_audit.md`. The stale pool-wrapper repair additionally claims only
@@ -26,11 +27,14 @@ WGPU pooling contract tests under
 the dirty reduction, backend-error, and lockfile files; they remain outside
 this increment.
 
-Implementation head `a8dcc51c` is complete. The pool repair propagates WGPU
+Implementation head `f861cea6` is complete. The pool repair propagates WGPU
 kernel errors, removes the CUDA 2-D/3-D host fallback module, and returns typed
-CUDA context or launch failures. Hosted exact-head evidence is pending. The
-local locked package check is blocked before compilation because the live
-peer's provider-overlay lockfile requires regeneration.
+CUDA context or launch failures. Exact-head run `30379272710` passed CUDA
+`90342897802`, WGPU `90342897872`, ROCm `90342897673`, and Metal
+`90342897752`. Required-device ROCm `90342898718` was skipped because no hosted
+AMD runner was dispatched. The local locked package check remains blocked
+before compilation because the live peer's provider-overlay lockfile requires
+regeneration. No runtime or resident-memory claim is made.
 
 ## ATLAS-COEUS-SAFETY-003 Uninitialized COW replacement [arch][minor][perf]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,10 +1,10 @@
 # Coeus Project Backlog & Historical Archives
 
-## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001 — Route exact GELU through Hephaestus [minor] — in-progress
+## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001 — Route exact GELU through Hephaestus [minor] — complete
 
 - Owner: Codex on `codex/coeus-cuda-common-activation-parity`; scope:
-  `crates/coeus-cuda/src/backend/ops/math.rs`, the CUDA unary parity tests,
-  the backend-parity selector, and owner-local PM evidence.
+  `crates/coeus-cuda/src/backend/ops/math/elementwise.rs`, the CUDA unary
+  parity tests, the backend-parity selector, and owner-local PM evidence.
 - Outcome: route CUDA f32 `Gelu` and `GeluGrad` through the existing
   Hephaestus exact-erf marker kernels for contiguous and runtime-shaped
   strided layouts, matching the already-native ROCm and Metal paths.
@@ -16,8 +16,11 @@
   pass; no runtime or resident-memory delta is claimed without a benchmark.
 - Risk/change class: `[minor]` provider-capability routing with additive CI
   coverage.
-- Status: implementation complete at `a8dcc51c`; final exact-head evidence
-  remains pending.
+- Status: complete at `f861cea6`. Exact-head run `30379272710` passed CUDA
+  `90342897802`, WGPU `90342897872`, ROCm `90342897673`, and Metal
+  `90342897752`. Required-device ROCm `90342898718` was skipped because no
+  hosted AMD runner was dispatched; no physical-device execution, runtime, or
+  resident-memory claim is made.
 - Structural note: the touched CUDA math dispatcher is now vertically split
   into elementwise, matmul, and reduction leaves under
   `crates/coeus-cuda/src/backend/ops/math/`; ADR-0040 records the boundary.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -43,9 +43,8 @@
 - Risk/change class: `[arch]` public failure-contract migration.
 - Status: implementation complete at `b5491ef8`; rustfmt, metadata, diff
   hygiene, and residual scans pass. The locked package check, clippy, doctest,
-  and Nextest gates stop before compilation because the peer-owned `Cargo.lock`
-  contains a local overlay change that requires regeneration; the lockfile and
-  peer reduction/error files remain outside this claim.
+  and Nextest gates stop before compilation because the Atlas-overlay-generated
+  `Cargo.lock` requires regeneration; the lockfile remains outside this claim.
 
 ## ATLAS-COEUS-DISPATCH-002 — Remove the ConvTranspose3d host fallback [arch]
 
@@ -317,7 +316,8 @@
   backend-operation return contract.
 - Current claim: shared-tree slice owned by this session; scope is the native
   WGPU PoolOps 3D forward/backward dispatch and its CPU/WGPU/CUDA callers.
-  Peer reduction/error edits and the dirty lockfile remain outside this claim.
+  Stale reduction/error edits were reconciled to the merged implementation;
+  only the Atlas-overlay-generated `Cargo.lock` remains outside this claim.
 - Outcome: replace unchecked `usize`→WGSL `u32` layout metadata narrowing and
   input-dependent dispatch panics with one typed validation/error boundary.
 - Acceptance: every WGPU kernel consumes the validated metadata type; failure
@@ -417,15 +417,16 @@
   Themis, and Melinoe packages and removed the committed sibling-path patch
   tables. The generated Atlas root overlay now supplies local provider
   checkouts without changing Coeus's standalone dependency identity. Locked
-  no-deps metadata passes from this worktree; the dirty lockfile and peer
-  reduction/error edits remain outside this claim.
+  no-deps metadata passes from this worktree; only the Atlas-overlay-generated
+  `Cargo.lock` remains outside this claim.
 - Pool3d increment: all four 3D `PoolOps` methods now return the
   backend-associated result across CPU, WGPU, and CUDA. WGPU derives output and
   gradient counts from canonical layouts, validates rank-five layout metadata,
   parameter narrowing, checked element counts, and workgroup bounds before
   native WGSL submission. Autograd, NN, and CUDA parity callers use explicit
-  invariant diagnostics. Package compilation remains blocked by the peer-owned
-  dirty lockfile requiring regeneration after the provider graph repair.
+  invariant diagnostics. Local package compilation remains blocked by the
+  Atlas-overlay-generated lockfile requiring regeneration after the provider
+  graph repair.
 
 ## ATLAS-CUDA-TREE-003 — Split fused operation-tag tree [arch] — done
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -161,8 +161,8 @@ analyzer error and is not repository-owned verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001: exact GELU forward and gradient
 
-**Location**: `crates/coeus-cuda/src/backend/ops/math.rs`, the CUDA unary
-parity tests, and the backend-parity CUDA selector.
+**Location**: `crates/coeus-cuda/src/backend/ops/math/elementwise.rs`, the CUDA
+unary parity tests, and the backend-parity CUDA selector.
 **Gap**: Hephaestus already exposes exact-erf `GeluOp` and `GeluGradOp`, and
 ROCm/Metal route both operations through the shared strided provider seam, but
 CUDA's generic math dispatch left them to the legacy kernel table. The CUDA
@@ -174,10 +174,12 @@ through the Hephaestus exact-erf markers and select
 physical-device execution remain separate evidence scopes. No runtime
 performance or resident-memory delta is claimed without a controlled
 benchmark.
-**Status**: implementation head `a8dcc51c` is complete; exact-head WGPU,
-CUDA, ROCm, and Metal CI remains pending. Local locked CUDA package checking is
-blocked before compilation by the pre-existing dual-local Eunomia lockfile
-collision.
+**Status**: complete at `f861cea6`. Exact-head run `30379272710` passed CUDA
+`90342897802`, WGPU `90342897872`, ROCm `90342897673`, and Metal
+`90342897752`. Required-device ROCm `90342898718` was skipped because no hosted
+AMD runner was dispatched. Local locked CUDA package checking remains blocked
+before compilation by the peer-owned provider-overlay lockfile. No
+physical-device, runtime-performance, or resident-memory claim is made.
 
 ## ATLAS-COEUS-HEPHAESTUS-LGAMMA-PARITY-001: f32 forward log-gamma
 
@@ -272,11 +274,13 @@ fallback residual, updated no-CUDA and CUDA-feature callers, warning-denied
 package checks, focused Nextest, and CUDA differential tests when a device and
 linker are available.
 **Status**: implementation complete for the claimed files. Rustfmt, locked
-metadata, diff hygiene, and residual scans pass. The locked package check,
-clippy, doctest, and Nextest gates stop before compilation because the
-peer-owned lockfile contains a local overlay change that requires regeneration;
-the peer-owned lockfile/reduction work remains outside this increment. No CUDA
-runtime or performance claim is made.
+metadata, diff hygiene, and residual scans pass. Exact-head run `30379272710`
+passed the CUDA package check, warning-denied Clippy, selected provider
+contracts, and doctests in job `90342897802`; WGPU, ROCm, and Metal provider
+jobs also passed. The local locked package check remains blocked before
+compilation because the peer-owned lockfile contains a provider-overlay change
+that requires regeneration; the peer-owned lockfile/reduction work remains
+outside this increment. No CUDA runtime or performance claim is made.
 
 ## ATLAS-CUDA-SAFETY-016: Remaining CUDA launch-parameter narrowing
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -278,9 +278,10 @@ metadata, diff hygiene, and residual scans pass. Exact-head run `30379272710`
 passed the CUDA package check, warning-denied Clippy, selected provider
 contracts, and doctests in job `90342897802`; WGPU, ROCm, and Metal provider
 jobs also passed. The local locked package check remains blocked before
-compilation because the peer-owned lockfile contains a provider-overlay change
-that requires regeneration; the peer-owned lockfile/reduction work remains
-outside this increment. No CUDA runtime or performance claim is made.
+compilation because the Atlas-overlay-generated lockfile requires regeneration;
+the lockfile remains outside this increment. Stale reduction and backend-error
+edits were reconciled to the merged implementation. No CUDA runtime or
+performance claim is made.
 
 ## ATLAS-CUDA-SAFETY-016: Remaining CUDA launch-parameter narrowing
 


### PR DESCRIPTION
Records the exact-head WGPU, CUDA, ROCm, and Metal provider-matrix results for the merged GELU dispatch slice. Updates the relocated CUDA math module path and preserves the skipped required-device ROCm limitation without runtime or memory claims.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR closes out the GELU provider evidence task by recording exact-head CI results across WGPU, CUDA, ROCm, and Metal providers. The changes update documentation to reflect that implementation head `f861cea6` has completed with exact-head run `30379272710`, marking the GELU dispatch work as complete. The documentation also updates the CUDA math module path reference from `math.rs` to `math/elementwise.rs` and clarifies that no runtime or resident-memory claims are made for this work.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHECKLIST.md` |
| 2 | `docs/gap_audit.md` |
| 3 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->