### PR TITLE
fix(coeus): Route ELU through Hephaestus

### DIFF
--- a/.github/workflows/backend-parity.yml
+++ b/.github/workflows/backend-parity.yml
@@ -142,7 +142,7 @@ jobs:
           cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-wgpu --all-targets
           cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-wgpu --all-targets --no-deps -- -D warnings
           cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-wgpu \
-            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer) or test(test_wgpu_elu_parity) or test(test_wgpu_parity_elu) or test(test_wgpu_parity_gelu_tanh) or test(test_wgpu_parity_softplus)"
+            -E "test(cumulative_scans_match_cpu_on_rank_two_device_tensors) or test(product_axis_matches_cpu_on_rank_two_device_tensors) or test(test_wgpu_parity_add) or test(test_wgpu_hephaestus_contiguous_unary_reuses_output_buffer) or test(test_wgpu_elu_parity) or test(test_wgpu_parity_elu) or test(test_wgpu_strided_elu_transposed_matches_cpu) or test(test_wgpu_strided_elu_gradient_transposed_matches_cpu) or test(test_wgpu_aliasing_elu_rejects_provider_bypass) or test(test_wgpu_parity_gelu_tanh) or test(test_wgpu_parity_softplus)"
           cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-wgpu --doc
 
   cuda:
@@ -270,7 +270,7 @@ jobs:
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-cuda --features cuda --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-cuda --features cuda --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-cuda --features cuda \
-                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad) or test(test_cuda_parity_gelu) or test(test_cuda_parity_gelu_grad) or test(test_cuda_parity_gelu_tanh) or test(test_cuda_parity_gelu_tanh_grad) or test(test_cuda_parity_softplus) or test(test_cuda_parity_softplus_grad)"
+                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad) or test(test_cuda_strided_elu_matches_cpu) or test(test_cuda_strided_elu_gradient_matches_cpu) or test(test_cuda_parity_gelu) or test(test_cuda_parity_gelu_grad) or test(test_cuda_parity_gelu_tanh) or test(test_cuda_parity_gelu_tanh_grad) or test(test_cuda_parity_softplus) or test(test_cuda_parity_softplus_grad)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-cuda --features cuda --doc
             '
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -173,11 +173,11 @@ available. ADR 0028 owns the exact GELU contract.
 
 - [x] Route `UnaryOp::Mish`, `MishGrad`, `Elu`, and `EluGrad` through the
       provider-owned Hephaestus ROCm and Metal f32 strided kernels.
-- [x] Extend the CUDA contiguous and strided launch expressions with ELU and
-      its gradient, preserving the existing Mish expressions.
+- [x] Replace the consumer-owned CUDA and WGPU ELU expressions with
+      Hephaestus `EluOp` and `EluGradOp` contiguous and strided dispatch.
 - [x] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
       coverage for forward and gradient activation paths.
-- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
+- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
       the provider and consumer revisions.
 
 Acceptance: all four backends expose the same unparameterized f32 Mish and ELU
@@ -187,13 +187,11 @@ including the zero branch boundary. The existing strided/device-resident
 kernel paths remain in use; no runtime performance or resident-memory delta is
 claimed without a controlled benchmark. ADR 0038 owns the contract.
 
-Status: complete for the unparameterized f32 scope. Targeted exact-head Coeus
-run `30353984154` passed CUDA job `90257861209`, WGPU job `90257861154`, ROCm
-job `90257861218`, and Metal job `90257861119`; required-device ROCm job
-`90257861858` was skipped because no hosted AMD runner was dispatched. The
-WGPU and CUDA selectors execute the new ELU forward and gradient contracts.
-The external `recurseml/analysis` status returned its recurring analyzer error
-and is not repository-owned verification.
+Status: provider-ownership correction in progress. The previous value-parity
+run `30353984154` did not distinguish the consumer-local expressions from the
+Hephaestus markers. CUDA and WGPU now have no local ELU expression; contiguous
+and transposed-strided forward/gradient contracts exercise the marker routes.
+Exact-head provider CI remains required before closure.
 
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise.rs
@@ -167,6 +167,20 @@ where
             ),
             c,
         ),
+        coeus_ops::UnaryOp::Elu => run(
+            hephaestus_cuda::unary_elementwise::<hephaestus_cuda::EluOp, T>(
+                device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::UnaryOp::EluGrad => run(
+            hephaestus_cuda::unary_elementwise::<hephaestus_cuda::EluGradOp, T>(
+                device,
+                a.buffer.as_ref(),
+            ),
+            c,
+        ),
         coeus_ops::UnaryOp::Softplus => run(
             hephaestus_cuda::unary_elementwise::<hephaestus_cuda::SoftplusOp, T>(
                 device,
@@ -290,7 +304,7 @@ fn try_hephaestus_strided_unary<T>(
 where
     T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
 {
-    if !can_route_dynamic_strided(&[a_layout], c_layout) {
+    if Arc::ptr_eq(&a.buffer, &c.buffer) || !can_route_dynamic_strided(&[a_layout], c_layout) {
         return Ok(false);
     }
     let device = crate::backend::get_cuda_device();
@@ -410,6 +424,24 @@ where
                 hephaestus_cuda::BlockWidth::DEFAULT,
             ))
         }
+        coeus_ops::UnaryOp::Elu => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::EluOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::EluGrad => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::EluGradOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
         coeus_ops::UnaryOp::Softplus => run(hephaestus_cuda::unary_elementwise_strided_dyn_into::<
             hephaestus_cuda::SoftplusOp,
             T,
@@ -495,6 +527,12 @@ impl CudaBackend {
     {
         if get_cuda_context().is_some() {
             let Some(n) = kernels::checked_numel(c_layout) else {
+                if matches!(op, coeus_ops::UnaryOp::Elu | coeus_ops::UnaryOp::EluGrad) {
+                    return Err(CudaBackendError::kernel(
+                        "elementwise unary",
+                        "Hephaestus ELU dispatch requires a CUDA-representable element count",
+                    ));
+                }
                 self.fallback_unary(op, a, a_layout, c, c_layout)?;
                 return Ok(());
             };
@@ -512,6 +550,12 @@ impl CudaBackend {
                     return Ok(());
                 }
             }
+        }
+        if matches!(op, coeus_ops::UnaryOp::Elu | coeus_ops::UnaryOp::EluGrad) {
+            return Err(CudaBackendError::kernel(
+                "elementwise unary",
+                "Hephaestus ELU dispatch requirements are not satisfied",
+            ));
         }
         self.fallback_unary(op, a, a_layout, c, c_layout)?;
         Ok(())

--- a/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::backend::CudaScalar;
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::storage::CudaStorage;
 
 /// Launch a contiguous binary element-wise kernel on the GPU.
@@ -128,7 +128,9 @@ pub fn launch_contiguous_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::Gelu => "0.5f * a[idx] * (1.0f + erff(a[idx] * 0.70710678f))",
         // d/dx of exact GELU: 0.5(1 + erf(x/sqrt(2))) + x/sqrt(2pi) exp(-x^2/2).
         // 0.3989422804f = 1/sqrt(2pi).
-        coeus_ops::UnaryOp::GeluGrad => "0.5f * (1.0f + erff(a[idx] * 0.70710678f)) + a[idx] * 0.3989422804f * expf(-0.5f * a[idx] * a[idx])",
+        coeus_ops::UnaryOp::GeluGrad => {
+            "0.5f * (1.0f + erff(a[idx] * 0.70710678f)) + a[idx] * 0.3989422804f * expf(-0.5f * a[idx] * a[idx])"
+        }
         coeus_ops::UnaryOp::Sin => "sinf(a[idx])",
         coeus_ops::UnaryOp::Cos => "cosf(a[idx])",
         coeus_ops::UnaryOp::Exp => "expf(a[idx])",
@@ -154,11 +156,13 @@ pub fn launch_contiguous_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::Abs => "fabsf(a[idx])",
         coeus_ops::UnaryOp::Sqrt => "sqrtf(a[idx])",
         coeus_ops::UnaryOp::Silu => "a[idx] / (1.0f + expf(-a[idx]))",
-        coeus_ops::UnaryOp::SiluGrad => "(1.0f / (1.0f + expf(-a[idx]))) * (1.0f + a[idx] * (1.0f - (1.0f / (1.0f + expf(-a[idx])))))",
+        coeus_ops::UnaryOp::SiluGrad => {
+            "(1.0f / (1.0f + expf(-a[idx]))) * (1.0f + a[idx] * (1.0f - (1.0f / (1.0f + expf(-a[idx])))))"
+        }
         coeus_ops::UnaryOp::Mish => "a[idx] * tanhf(logf(1.0f + expf(a[idx])))",
-        coeus_ops::UnaryOp::MishGrad => "tanhf(logf(1.0f + expf(a[idx]))) + a[idx] * (1.0f - tanhf(logf(1.0f + expf(a[idx]))) * tanhf(logf(1.0f + expf(a[idx])))) * (1.0f / (1.0f + expf(-a[idx])))",
-        coeus_ops::UnaryOp::Elu => "(a[idx] >= 0.0f) ? a[idx] : (expf(a[idx]) - 1.0f)",
-        coeus_ops::UnaryOp::EluGrad => "(a[idx] >= 0.0f) ? 1.0f : expf(a[idx])",
+        coeus_ops::UnaryOp::MishGrad => {
+            "tanhf(logf(1.0f + expf(a[idx]))) + a[idx] * (1.0f - tanhf(logf(1.0f + expf(a[idx]))) * tanhf(logf(1.0f + expf(a[idx])))) * (1.0f / (1.0f + expf(-a[idx])))"
+        }
         coeus_ops::UnaryOp::Recip => "1.0f / a[idx]",
         coeus_ops::UnaryOp::Sign => "(a[idx] > 0.0f) ? 1.0f : ((a[idx] < 0.0f) ? -1.0f : 0.0f)",
         coeus_ops::UnaryOp::Floor => "floorf(a[idx])",

--- a/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::backend::{CudaBackend, CudaScalar};
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
 use coeus_core::{ComputeBackend, Layout};
@@ -205,7 +205,9 @@ pub fn launch_strided_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::Gelu => "0.5f * val_a * (1.0f + erff(val_a * 0.70710678f))",
         // d/dx of exact GELU: 0.5(1 + erf(x/sqrt(2))) + x/sqrt(2pi) exp(-x^2/2).
         // 0.3989422804f = 1/sqrt(2pi).
-        coeus_ops::UnaryOp::GeluGrad => "0.5f * (1.0f + erff(val_a * 0.70710678f)) + val_a * 0.3989422804f * expf(-0.5f * val_a * val_a)",
+        coeus_ops::UnaryOp::GeluGrad => {
+            "0.5f * (1.0f + erff(val_a * 0.70710678f)) + val_a * 0.3989422804f * expf(-0.5f * val_a * val_a)"
+        }
         coeus_ops::UnaryOp::Sin => "sinf(val_a)",
         coeus_ops::UnaryOp::Cos => "cosf(val_a)",
         coeus_ops::UnaryOp::Exp => "expf(val_a)",
@@ -231,11 +233,13 @@ pub fn launch_strided_unary<T: CudaScalar>(
         coeus_ops::UnaryOp::Abs => "fabsf(val_a)",
         coeus_ops::UnaryOp::Sqrt => "sqrtf(val_a)",
         coeus_ops::UnaryOp::Silu => "val_a / (1.0f + expf(-val_a))",
-        coeus_ops::UnaryOp::SiluGrad => "(1.0f / (1.0f + expf(-val_a))) * (1.0f + val_a * (1.0f - (1.0f / (1.0f + expf(-val_a)))))",
+        coeus_ops::UnaryOp::SiluGrad => {
+            "(1.0f / (1.0f + expf(-val_a))) * (1.0f + val_a * (1.0f - (1.0f / (1.0f + expf(-val_a)))))"
+        }
         coeus_ops::UnaryOp::Mish => "val_a * tanhf(logf(1.0f + expf(val_a)))",
-        coeus_ops::UnaryOp::MishGrad => "tanhf(logf(1.0f + expf(val_a))) + val_a * (1.0f - tanhf(logf(1.0f + expf(val_a))) * tanhf(logf(1.0f + expf(val_a)))) * (1.0f / (1.0f + expf(-val_a)))",
-        coeus_ops::UnaryOp::Elu => "(val_a >= 0.0f) ? val_a : (expf(val_a) - 1.0f)",
-        coeus_ops::UnaryOp::EluGrad => "(val_a >= 0.0f) ? 1.0f : expf(val_a)",
+        coeus_ops::UnaryOp::MishGrad => {
+            "tanhf(logf(1.0f + expf(val_a))) + val_a * (1.0f - tanhf(logf(1.0f + expf(val_a))) * tanhf(logf(1.0f + expf(val_a)))) * (1.0f / (1.0f + expf(-val_a)))"
+        }
         coeus_ops::UnaryOp::Recip => "1.0f / val_a",
         coeus_ops::UnaryOp::Sign => "(val_a > 0.0f) ? 1.0f : ((val_a < 0.0f) ? -1.0f : 0.0f)",
         coeus_ops::UnaryOp::Floor => "floorf(val_a)",

--- a/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
+++ b/crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs
@@ -251,4 +251,32 @@ unary_grad_parity!(
     vec![-3.0, -1.0, -0.25, 0.0, 0.25, 1.0, 3.0, 4.0]
 );
 
+fn assert_strided_elu_parity(op: coeus_ops::UnaryOp, operation: &'static str) {
+    let Some((sequential, cuda)) = backends() else {
+        return;
+    };
+    let data = [
+        -3.0f32, -2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 3.0, -0.5, 0.5, 1.5,
+    ];
+    let host = Tensor::<f32, SequentialBackend>::from_slice([3, 4], &data);
+    let host_transposed = host.t();
+    let cpu = coeus_ops::elementwise_unary(&host_transposed, &sequential, op)
+        .expect("valid CPU strided ELU dispatch");
+    let device_transposed = to_gpu(&host, &sequential, &cuda).t();
+    let gpu = coeus_ops::elementwise_unary(&device_transposed, &cuda, op)
+        .expect("valid CUDA Hephaestus strided ELU dispatch");
+    let gpu = to_cpu(&gpu, &cuda, &sequential);
+    assert_parity_tol(operation, cpu.as_slice(), gpu.as_slice(), CUDA_TOL);
+}
+
+#[test]
+fn test_cuda_strided_elu_matches_cpu() {
+    assert_strided_elu_parity(coeus_ops::UnaryOp::Elu, "strided_elu");
+}
+
+#[test]
+fn test_cuda_strided_elu_gradient_matches_cpu() {
+    assert_strided_elu_parity(coeus_ops::UnaryOp::EluGrad, "strided_elu_gradient");
+}
+
 // Reductions.

--- a/crates/coeus-wgpu/src/backend/ops/mod.rs
+++ b/crates/coeus-wgpu/src/backend/ops/mod.rs
@@ -3,8 +3,8 @@ use crate::kernels;
 use coeus_core::{Layout, Storage};
 use hephaestus_core::BlockWidth;
 use hephaestus_wgpu::{
-    binary_elementwise_strided_into, unary_elementwise_strided_into, StridedOperand,
-    MAX_STRIDED_RANK,
+    MAX_STRIDED_RANK, StridedOperand, binary_elementwise_strided_into,
+    unary_elementwise_strided_into,
 };
 use leto::Layout as LetoLayout;
 use std::sync::Arc;
@@ -145,6 +145,10 @@ fn try_hephaestus_strided_unary_wgpu<
 ) -> Result<bool, WgpuBackendError> {
     use coeus_ops::UnaryOp;
 
+    if Arc::ptr_eq(&a_buf.buffer, &c_buf.buffer) {
+        return Ok(false);
+    }
+
     macro_rules! dispatch_n {
         ($n:expr) => {{
             let la = coeus_to_leto_layout!(a_layout, $n);
@@ -208,6 +212,16 @@ fn try_hephaestus_strided_unary_wgpu<
                 >(dev, a_op, c_op, BlockWidth::DEFAULT)),
                 UnaryOp::Lgamma => ok(unary_elementwise_strided_into::<
                     hephaestus_wgpu::LgammaOp,
+                    T,
+                    $n,
+                >(dev, a_op, c_op, BlockWidth::DEFAULT)),
+                UnaryOp::Elu => ok(unary_elementwise_strided_into::<
+                    hephaestus_wgpu::EluOp,
+                    T,
+                    $n,
+                >(dev, a_op, c_op, BlockWidth::DEFAULT)),
+                UnaryOp::EluGrad => ok(unary_elementwise_strided_into::<
+                    hephaestus_wgpu::EluGradOp,
                     T,
                     $n,
                 >(dev, a_op, c_op, BlockWidth::DEFAULT)),
@@ -378,6 +392,24 @@ fn try_hephaestus_contiguous_unary<
         )),
         coeus_ops::UnaryOp::Lgamma => run(hephaestus_wgpu::unary_elementwise_into::<
             hephaestus_wgpu::LgammaOp,
+            T,
+        >(
+            &ctx.hephaestus_device,
+            a.buffer.as_ref(),
+            c.buffer.as_ref(),
+            BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::Elu => run(hephaestus_wgpu::unary_elementwise_into::<
+            hephaestus_wgpu::EluOp,
+            T,
+        >(
+            &ctx.hephaestus_device,
+            a.buffer.as_ref(),
+            c.buffer.as_ref(),
+            BlockWidth::DEFAULT,
+        )),
+        coeus_ops::UnaryOp::EluGrad => run(hephaestus_wgpu::unary_elementwise_into::<
+            hephaestus_wgpu::EluGradOp,
             T,
         >(
             &ctx.hephaestus_device,

--- a/crates/coeus-wgpu/src/kernels/unary.rs
+++ b/crates/coeus-wgpu/src/kernels/unary.rs
@@ -44,8 +44,11 @@ fn unary_expr(op: coeus_ops::UnaryOp) -> Result<String, WgpuBackendError> {
         coeus_ops::UnaryOp::SiluGrad => "(1.0 / (1.0 + exp(-val))) * (1.0 + val * (1.0 - (1.0 / (1.0 + exp(-val)))))".to_string(),
         coeus_ops::UnaryOp::Mish => "val * tanh(log(1.0 + exp(val)))".to_string(),
         coeus_ops::UnaryOp::MishGrad => "tanh(log(1.0 + exp(val))) + val * (1.0 - tanh(log(1.0 + exp(val))) * tanh(log(1.0 + exp(val)))) * (1.0 / (1.0 + exp(-val)))".to_string(),
-        coeus_ops::UnaryOp::Elu => "select(exp(val) - 1.0, val, val >= 0.0)".to_string(),
-        coeus_ops::UnaryOp::EluGrad => "select(exp(val), 1.0, val >= 0.0)".to_string(),
+        coeus_ops::UnaryOp::Elu | coeus_ops::UnaryOp::EluGrad => {
+            return Err(WgpuBackendError::UnsupportedOperation {
+                operation: "ELU must dispatch through Hephaestus",
+            });
+        }
         coeus_ops::UnaryOp::Softplus => "log(1.0 + exp(val))".to_string(),
         coeus_ops::UnaryOp::SoftplusGrad => "1.0 / (1.0 + exp(-val))".to_string(),
         coeus_ops::UnaryOp::GeluTanh => "0.5 * val * (1.0 + tanh(0.7978845608 * (val + 0.044715 * val * val * val)))".to_string(),

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs
@@ -167,6 +167,50 @@ fn test_wgpu_aliasing_unary_neg_matches_cpu() {
 }
 
 #[test]
+fn test_wgpu_aliasing_elu_rejects_provider_bypass() {
+    let w = wgpu();
+    let x_cpu = Tensor::from_slice(vec![2, 2], &[-2.0f32, -0.5, 0.5, 2.0]);
+    let x_gpu = to_gpu(&x_cpu);
+
+    // Hephaestus requires distinct input and output buffers. An aliased ELU
+    // must fail instead of executing a consumer-owned fallback expression.
+    let mut out_storage = x_gpu.storage().clone();
+    let error = w
+        .elementwise_unary(
+            coeus_ops::UnaryOp::Elu,
+            x_gpu.storage(),
+            x_gpu.layout(),
+            &mut out_storage,
+            x_gpu.layout(),
+        )
+        .expect_err("aliased ELU must not bypass Hephaestus");
+
+    assert!(matches!(
+        error,
+        coeus_wgpu::WgpuBackendError::UnsupportedOperation { operation }
+            if operation == "ELU must dispatch through Hephaestus"
+    ));
+
+    let transposed = x_gpu.t();
+    let mut strided_out_storage = transposed.storage().clone();
+    let error = w
+        .elementwise_unary(
+            coeus_ops::UnaryOp::Elu,
+            transposed.storage(),
+            transposed.layout(),
+            &mut strided_out_storage,
+            transposed.layout(),
+        )
+        .expect_err("aliased strided ELU must not bypass Hephaestus");
+
+    assert!(matches!(
+        error,
+        coeus_wgpu::WgpuBackendError::UnsupportedOperation { operation }
+            if operation == "ELU must dispatch through Hephaestus"
+    ));
+}
+
+#[test]
 fn test_wgpu_aliasing_binary_add_matches_cpu() {
     let s = seq();
     let w = wgpu();

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/strided.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/strided.rs
@@ -109,6 +109,52 @@ fn test_wgpu_strided_sqrt_transposed_matches_cpu() {
 }
 
 #[test]
+fn test_wgpu_strided_elu_transposed_matches_cpu() {
+    let s = seq();
+    let w = wgpu();
+    let data = [
+        -3.0f32, -2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 3.0, -0.5, 0.5, 1.5,
+    ];
+    let a = Tensor::<f32, SequentialBackend>::from_slice(vec![3, 4], &data);
+    let at = a.t();
+    let cpu_out = coeus_ops::elementwise_unary(&at, &s, coeus_ops::UnaryOp::Elu)
+        .expect("valid CPU strided ELU input");
+    let a_gpu = to_gpu(&a).t();
+    let gpu_out = to_cpu(
+        &coeus_ops::elementwise_unary(&a_gpu, &w, coeus_ops::UnaryOp::Elu)
+            .expect("valid WGPU Hephaestus strided ELU input"),
+    );
+    assert_parity(
+        "strided_elu_transposed",
+        cpu_out.as_slice(),
+        gpu_out.as_slice(),
+    );
+}
+
+#[test]
+fn test_wgpu_strided_elu_gradient_transposed_matches_cpu() {
+    let s = seq();
+    let w = wgpu();
+    let data = [
+        -3.0f32, -2.0, -1.0, -0.25, 0.0, 0.25, 1.0, 2.0, 3.0, -0.5, 0.5, 1.5,
+    ];
+    let a = Tensor::<f32, SequentialBackend>::from_slice(vec![3, 4], &data);
+    let at = a.t();
+    let cpu_out = coeus_ops::elementwise_unary(&at, &s, coeus_ops::UnaryOp::EluGrad)
+        .expect("valid CPU strided ELU gradient input");
+    let a_gpu = to_gpu(&a).t();
+    let gpu_out = to_cpu(
+        &coeus_ops::elementwise_unary(&a_gpu, &w, coeus_ops::UnaryOp::EluGrad)
+            .expect("valid WGPU Hephaestus strided ELU gradient input"),
+    );
+    assert_parity(
+        "strided_elu_gradient_transposed",
+        cpu_out.as_slice(),
+        gpu_out.as_slice(),
+    );
+}
+
+#[test]
 fn test_wgpu_strided_rank3_binary_matches_cpu() {
     let s = seq();
     let w = wgpu();

--- a/docs/adr/0038-coeus-hephaestus-activation-tail.md
+++ b/docs/adr/0038-coeus-hephaestus-activation-tail.md
@@ -2,24 +2,27 @@
 
 ## Status
 
-Accepted; implementation and targeted provider CI are complete for the
+Accepted; the provider-ownership correction is in progress for the
 unparameterized f32 scope.
 
 ## Context
 
 Coeus and Leto define unparameterized f32 `Mish`, `MishGrad`, `Elu`, and
 `EluGrad` operations. Hephaestus already owns native expression markers for
-all four ROCm and Metal operations, and the WGPU expression generator already
-emits their WGSL forms. Coeus ROCm and Metal dispatch rejected all four
-operations. Coeus CUDA implemented Mish in both launch forms but rejected ELU.
+all four accelerator providers. Coeus ROCm and Metal originally rejected all
+four operations. Coeus CUDA and WGPU later implemented ELU with consumer-owned
+runtime expressions, bypassing the Hephaestus operation markers.
 
 ## Decision
 
 Route ROCm and Metal `Mish`, `MishGrad`, `Elu`, and `EluGrad` through the
-existing Hephaestus strided elementwise seam. Add the ELU forward and gradient
-expressions to both CUDA contiguous and strided launch tables. Keep WGPU on its
-existing provider expression path. The supported accelerator type remains
-`f32`; integer providers retain typed unsupported-operation errors.
+existing Hephaestus strided elementwise seam. Route CUDA and WGPU ELU forward
+and gradient through the corresponding Hephaestus contiguous and strided
+operation markers. Delete the superseded consumer-owned CUDA and WGSL
+expressions. A CUDA or WGPU ELU request that cannot satisfy the Hephaestus
+dispatch contract returns a typed backend error; it does not enter a local
+kernel or CPU capability path. The supported accelerator type remains `f32`;
+integer providers retain typed unsupported-operation errors.
 
 The contracts are:
 
@@ -30,8 +33,8 @@ The contracts are:
 
 Backend suites compare forward and gradient values with the Leto CPU oracle
 over signed inputs containing negative, zero, and positive branch regions.
-The existing device-resident strided and launch paths remain authoritative;
-the increment adds no host staging or temporary backend buffer.
+The existing device-resident Hephaestus paths remain authoritative; the
+increment adds no host staging or temporary backend buffer.
 
 ## Alternatives rejected
 
@@ -41,19 +44,18 @@ the increment adds no host staging or temporary backend buffer.
   because dialect-specific provider expressions belong to Hephaestus.
 - Routing missing operations through Leto was rejected because it would hide
   provider capability gaps and violate the device-resident output contract.
-- Adding a second CUDA kernel family was rejected because the existing
-  contiguous and strided launch tables are the canonical CUDA dispatch homes.
+- Keeping the CUDA and WGPU ELU expression copies was rejected because the
+  Hephaestus markers are the operation SSOT and consumer-owned copies can
+  diverge.
 
 ## Verification
 
-Local format, package compilation, lint, and focused provider contracts cover
-the changed dispatch and expression tables. Targeted exact-head Coeus run
-`30353984154` passed CUDA job `90257861209`, WGPU job `90257861154`, ROCm job
-`90257861218`, and Metal job `90257861119`. Required-device ROCm job
-`90257861858` was skipped because no hosted AMD runner was dispatched; no
-physical-device result is inferred. The WGPU and CUDA selectors execute the new
-ELU forward and gradient contracts. The external `recurseml/analysis` status
-returned its recurring analyzer error and is not repository-owned verification.
+The correction requires format, package compilation, warning-denied Clippy,
+contiguous and strided Leto differential contracts, doctests, and exact-head
+CUDA/WGPU/ROCm/Metal provider CI. The prior targeted run `30353984154` proved
+value parity but did not prove provider ownership because the consumer-local
+expressions computed the same values. No physical-device, runtime-performance,
+or resident-memory result is inferred.
 
 ## Residual scope
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,22 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-HEPHAESTUS-ELU-DISPATCH-001 — Own ELU in Hephaestus [arch] — in-progress
+
+- Owner: Codex; scope: CUDA/WGPU contiguous and strided ELU forward/gradient
+  dispatch, superseded consumer expressions, differential tests, ADR-0038, and
+  provider-matrix evidence.
+- Outcome: make the Hephaestus `EluOp` and `EluGradOp` markers the SSOT for
+  accelerator ELU execution while CPU semantics remain in Leto.
+- Non-goals: parameterized activations, Mish ownership, reduced/vector scalar
+  contracts, pooling, and unrelated elementwise operations.
+- Acceptance: CUDA and WGPU contiguous and transposed-strided ELU
+  forward/gradient match Leto; no consumer-local ELU expression or CUDA CPU
+  fallback remains; exact-head CUDA/WGPU/ROCm/Metal provider CI passes.
+- Risk/change class: `[arch]` provider-ownership correction with no public API
+  change.
+- Status: implementation and value-semantic regressions are present locally;
+  exact-head provider verification remains pending.
+
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001 — Route exact GELU through Hephaestus [minor] — complete
 
 - Owner: Codex on `codex/coeus-cuda-common-activation-parity`; scope:

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -109,31 +109,27 @@ ROCm `90003265412` was skipped because no registered AMD runner was available.
 
 ## ATLAS-COEUS-HEPHAESTUS-ACTIVATION-TAIL-PARITY-001: Mish and ELU
 
-**Location**: the Coeus ROCm and Metal activation dispatch macros, CUDA
-contiguous and strided unary launch expressions, and the four backend contract
-suites.
+**Location**: the Coeus accelerator activation dispatch tables and the four
+backend contract suites.
 **Gap**: Hephaestus already exports native f32 `Mish`, `MishGrad`, `Elu`, and
-`EluGrad` markers for ROCm and Metal, and WGPU already emits all four
-expressions. Coeus ROCm and Metal rejected all four operations, while CUDA
-implemented Mish but rejected ELU in both launch paths.
+`EluGrad` markers for every accelerator provider. Coeus ROCm and Metal
+originally rejected all four operations, while CUDA and WGPU later computed
+ELU through consumer-owned expressions instead of the Hephaestus markers.
 **Resolution**: dispatch ROCm and Metal through the existing Hephaestus
-strided marker seam; add the canonical ELU expressions to CUDA's contiguous and
-strided launch tables; retain WGPU's existing provider expression path. Extend
-the backend suites with Leto CPU differential checks for forward and gradient
-operations.
+strided marker seam; dispatch CUDA and WGPU ELU forward and gradient through
+Hephaestus contiguous and strided markers; delete the superseded consumer
+expressions. Extend the backend suites with Leto CPU differential checks for
+contiguous and transposed-strided forward and gradient operations.
 **Residual**: parameterized activations, f64/reduced/vector contracts, and
 physical-device execution remain separate evidence scopes.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
 CI; required-device ROCm is reported independently from adapterless provider
 compilation.
-**Status**: complete for the unparameterized f32 scope. Targeted exact-head
-Coeus run `30353984154` passed CUDA job `90257861209`, WGPU job `90257861154`,
-ROCm job `90257861218`, and Metal job `90257861119`; required-device ROCm job
-`90257861858` was skipped because no hosted AMD runner was dispatched. The WGPU
-and CUDA selectors execute the new ELU forward and gradient contracts. The
-external `recurseml/analysis` status returned its recurring analyzer error and
-is not repository-owned verification. ADR 0038 owns the provider and consumer
-contract.
+**Status**: provider-ownership correction in progress. The previous exact-head
+run `30353984154` established value parity but could not distinguish the
+consumer-local expressions from the Hephaestus routes. CUDA and WGPU now reject
+ELU fallthrough rather than entering local-kernel or CPU paths. Exact-head
+provider CI remains the closure gate. ADR 0038 owns the provider contract.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-ACTIVATION-PARITY-001: GELU-tanh and Softplus
 


### PR DESCRIPTION
## Change
- route CUDA and WGPU ELU/ELU-gradient contiguous and strided execution through Hephaestus markers
- remove consumer-owned CUDA/WGSL ELU expressions and reject provider bypass
- align strided unary alias guards with the provider distinct-buffer contract
- add Leto differential and alias-bypass regressions, and execute them in the backend matrix

## Local evidence
- WGPU all-target check and warning-denied package Clippy passed
- WGPU focused nextest: 5 passed
- CUDA all-target check and warning-denied package Clippy passed
- WGPU doctests: 3 passed; CUDA doctests: 0 present, command passed
- local CUDA nextest reached native linking but MinGW cannot find -lcuda; hosted CUDA is the runtime gate

## Scope
No runtime-performance or resident-memory claim. Atlas overlay lockfile regeneration is excluded from the change.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR routes CUDA and WGPU ELU (Exponential Linear Unit) and ELU-gradient operations through the Hephaestus provider layer instead of using consumer-owned kernel expressions. The change removes duplicated CUDA and WGSL ELU expressions, ensuring that Hephaestus operation markers become the single source of truth for accelerator ELU execution. Both contiguous and strided (transposed) execution paths are updated, and alias-bypass guards are added to enforce Hephaestus's distinct-buffer contract. New regression tests validate forward and gradient differential behavior against the Leto CPU oracle for both contiguous and transposed-strided layouts.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0038-coeus-hephaestus-activation-tail.md` |
| 2 | `CHECKLIST.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-wgpu/src/kernels/unary.rs` |
| 6 | `crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs` |
| 7 | `crates/coeus-cuda/src/kernels/launch_ops/strided.rs` |
| 8 | `crates/coeus-wgpu/src/backend/ops/mod.rs` |
| 9 | `crates/coeus-cuda/src/backend/ops/math/elementwise.rs` |
| 10 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/elementwise.rs` |
| 11 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/parity/strided.rs` |
| 12 | `crates/coeus-cuda/tests/cuda/parity/unfold_fold.rs` |
| 13 | `.github/workflows/backend-parity.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA and WGPU support for ELU and ELU gradient operations, including contiguous and strided layouts.
  * Added parity coverage for transposed ELU operations across CPU, CUDA, and WGPU.

* **Bug Fixes**
  * Prevented unsupported aliased ELU operations from silently using fallback paths.
  * Improved error reporting when accelerator dispatch requirements are not met.

* **Documentation**
  * Updated activation dispatch architecture, verification status, and backlog tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->