### PR TITLE
docs(coeus): Close ELU provider evidence

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -177,7 +177,7 @@ available. ADR 0028 owns the exact GELU contract.
       Hephaestus `EluOp` and `EluGradOp` contiguous and strided dispatch.
 - [x] Extend WGPU, CUDA, ROCm, and Metal contracts with Leto CPU differential
       coverage for forward and gradient activation paths.
-- [ ] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
+- [x] Run and record exact-head WGPU, CUDA, ROCm, and Metal provider CI for
       the provider and consumer revisions.
 
 Acceptance: all four backends expose the same unparameterized f32 Mish and ELU
@@ -187,11 +187,12 @@ including the zero branch boundary. The existing strided/device-resident
 kernel paths remain in use; no runtime performance or resident-memory delta is
 claimed without a controlled benchmark. ADR 0038 owns the contract.
 
-Status: provider-ownership correction in progress. The previous value-parity
-run `30353984154` did not distinguish the consumer-local expressions from the
-Hephaestus markers. CUDA and WGPU now have no local ELU expression; contiguous
-and transposed-strided forward/gradient contracts exercise the marker routes.
-Exact-head provider CI remains required before closure.
+Status: complete for the unparameterized f32 scope. Exact-head Coeus run
+`30387168252` passed CUDA job `90369248008`, WGPU job `90369248023`, ROCm job
+`90369247910`, and Metal job `90369248013`; required-device ROCm job
+`90369248641` was skipped because no hosted AMD runner was dispatched. The
+external `recurseml/analysis` status returned its recurring analyzer error and
+is not repository-owned verification.
 
 ## ATLAS-COEUS-HEPHAESTUS-ERROR-FUNCTION-PARITY-001 [arch]
 

--- a/docs/adr/0038-coeus-hephaestus-activation-tail.md
+++ b/docs/adr/0038-coeus-hephaestus-activation-tail.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-Accepted; the provider-ownership correction is in progress for the
-unparameterized f32 scope.
+Accepted and implemented for the unparameterized f32 scope.
 
 ## Context
 
@@ -50,11 +49,15 @@ increment adds no host staging or temporary backend buffer.
 
 ## Verification
 
-The correction requires format, package compilation, warning-denied Clippy,
-contiguous and strided Leto differential contracts, doctests, and exact-head
-CUDA/WGPU/ROCm/Metal provider CI. The prior targeted run `30353984154` proved
-value parity but did not prove provider ownership because the consumer-local
-expressions computed the same values. No physical-device, runtime-performance,
+Local format, package compilation, warning-denied Clippy, focused WGPU
+contiguous/strided/alias contracts, and CUDA/WGPU doctests passed. Local CUDA
+nextest reached native linking but the MinGW environment had no CUDA import
+library (`ld: cannot find -lcuda`), so no local CUDA runtime result is inferred.
+Exact-head Coeus run `30387168252` passed CUDA job `90369248008`, WGPU job
+`90369248023`, ROCm job `90369247910`, and Metal job `90369248013`.
+Required-device ROCm job `90369248641` was skipped because no hosted AMD runner
+was dispatched. The external `recurseml/analysis` status returned its recurring
+analyzer error and is not repository-owned verification. No runtime-performance
 or resident-memory result is inferred.
 
 ## Residual scope

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,6 @@
 # Coeus Project Backlog & Historical Archives
 
-## ATLAS-COEUS-HEPHAESTUS-ELU-DISPATCH-001 — Own ELU in Hephaestus [arch] — in-progress
+## ATLAS-COEUS-HEPHAESTUS-ELU-DISPATCH-001 — Own ELU in Hephaestus [arch] — complete
 
 - Owner: Codex; scope: CUDA/WGPU contiguous and strided ELU forward/gradient
   dispatch, superseded consumer expressions, differential tests, ADR-0038, and
@@ -14,8 +14,10 @@
   fallback remains; exact-head CUDA/WGPU/ROCm/Metal provider CI passes.
 - Risk/change class: `[arch]` provider-ownership correction with no public API
   change.
-- Status: implementation and value-semantic regressions are present locally;
-  exact-head provider verification remains pending.
+- Status: merged by PR #241 at `fe92e3f7`. Exact-head run `30387168252`
+  passed CUDA `90369248008`, WGPU `90369248023`, ROCm `90369247910`, and
+  Metal `90369248013`; required-device ROCm `90369248641` was skipped because
+  no hosted AMD runner was dispatched.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001 — Route exact GELU through Hephaestus [minor] — complete
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -125,11 +125,13 @@ physical-device execution remain separate evidence scopes.
 **Evidence target**: exact-head WGPU, CUDA, ROCm, and Metal provider/consumer
 CI; required-device ROCm is reported independently from adapterless provider
 compilation.
-**Status**: provider-ownership correction in progress. The previous exact-head
-run `30353984154` established value parity but could not distinguish the
-consumer-local expressions from the Hephaestus routes. CUDA and WGPU now reject
-ELU fallthrough rather than entering local-kernel or CPU paths. Exact-head
-provider CI remains the closure gate. ADR 0038 owns the provider contract.
+**Status**: complete for the unparameterized f32 scope. CUDA and WGPU reject
+ELU fallthrough rather than entering local-kernel or CPU paths. Exact-head run
+`30387168252` passed CUDA job `90369248008`, WGPU job `90369248023`, ROCm job
+`90369247910`, and Metal job `90369248013`; required-device ROCm job
+`90369248641` was skipped because no hosted AMD runner was dispatched. The
+external `recurseml/analysis` status returned its recurring analyzer error and
+is not repository-owned verification. ADR 0038 owns the provider contract.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-ACTIVATION-PARITY-001: GELU-tanh and Softplus
 


### PR DESCRIPTION
Record the exact-head provider matrix for the merged ELU dispatch correction: CUDA, WGPU, ROCm, and Metal passed; required-device ROCm was skipped because no hosted AMD runner was dispatched. Also records the local MinGW CUDA-link limitation and excludes runtime-performance or resident-memory claims.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates documentation to record the completion of ELU (Exponential Linear Unit) provider verification across multiple backends. The changes document that exact-head provider CI run `30387168252` successfully passed on CUDA, WGPU, ROCm, and Metal platforms, marking the ELU dispatch correction as complete. The updates also note a MinGW CUDA linking limitation encountered locally and clarify that no runtime performance or memory claims are being made without controlled benchmarks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/backlog.md` |
| 2 | `CHECKLIST.md` |
| 3 | `docs/gap_audit.md` |
| 4 | `docs/adr/0038-coeus-hephaestus-activation-tail.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->