### PR TITLE
fix(coeus-cuda): Bound pooling indices

### DIFF
--- a/.github/workflows/backend-parity.yml
+++ b/.github/workflows/backend-parity.yml
@@ -260,6 +260,13 @@ jobs:
                 crates/coeus-ops/src/backend_ops/defaults/reductions.rs \
                 crates/coeus-ops/src/reduction/cumsum.rs \
                 crates/coeus-cuda/src/backend/ops/impls/reduction.rs \
+                crates/coeus-cuda/src/kernels/validation.rs \
+                crates/coeus-cuda/src/kernels/pool/validation.rs \
+                crates/coeus-cuda/src/kernels/pool/pool1d.rs \
+                crates/coeus-cuda/src/kernels/pool/max.rs \
+                crates/coeus-cuda/src/kernels/pool/avg.rs \
+                crates/coeus-cuda/src/kernels/pool/max3d.rs \
+                crates/coeus-cuda/src/kernels/pool/avg3d.rs \
                 crates/coeus-cuda/tests/cuda/parity/reduction.rs
               cargo "+$RUST_TOOLCHAIN" update \
                 --manifest-path /workspace/coeus/Cargo.toml --workspace
@@ -270,7 +277,7 @@ jobs:
               cargo "+$RUST_TOOLCHAIN" check --locked --package coeus-cuda --features cuda --all-targets
               cargo "+$RUST_TOOLCHAIN" clippy --locked --package coeus-cuda --features cuda --all-targets --no-deps -- -D warnings
               cargo "+$RUST_TOOLCHAIN" nextest run --locked --package coeus-cuda --features cuda \
-                -E "test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad) or test(test_cuda_strided_elu_matches_cpu) or test(test_cuda_strided_elu_gradient_matches_cpu) or test(test_cuda_parity_gelu) or test(test_cuda_parity_gelu_grad) or test(test_cuda_parity_gelu_tanh) or test(test_cuda_parity_gelu_tanh_grad) or test(test_cuda_parity_softplus) or test(test_cuda_parity_softplus_grad)"
+                -E "test(cuda_storage_validation_checks_physical_bound_and_writable_aliasing) or test(pool_storage_validation_rejects_undersized_and_overflowed_layouts) or test(pool_signed_index_validation_covers_forward_and_backward_extrema) or test(test_cuda_parity_cumulative_scans) or test(test_cuda_parity_prod_axis) or test(test_cuda_backend_ops) or test(test_cuda_parity_elu) or test(test_cuda_parity_elu_grad) or test(test_cuda_strided_elu_matches_cpu) or test(test_cuda_strided_elu_gradient_matches_cpu) or test(test_cuda_parity_gelu) or test(test_cuda_parity_gelu_grad) or test(test_cuda_parity_gelu_tanh) or test(test_cuda_parity_gelu_tanh_grad) or test(test_cuda_parity_softplus) or test(test_cuda_parity_softplus_grad)"
               cargo "+$RUST_TOOLCHAIN" test --locked --package coeus-cuda --features cuda --doc
             '
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,29 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-CUDA-SAFETY-017 Pooling physical-index contract [arch][patch]
+
+- [x] Promote physical layout/allocation validation into the shared CUDA
+      validation leaf and remove the fused and unfold/fold duplicates.
+- [x] Validate complete 1-D/2-D/3-D pooling forward and backward signed
+      coordinate extrema before kernel compilation.
+- [x] Reject undersized storage, unrepresentable physical offsets, and
+      writable zero-stride output aliasing across every pooling dispatcher.
+- [x] Add pure boundary regressions, select them in hosted CUDA CI, and record
+      ADR-0041.
+
+Acceptance: pooling cannot launch when its maximum physical address exceeds
+the storage allocation or CUDA layout ABI, or when any signed window
+coordinate can overflow. The validation is allocation-free and executes once
+at dispatch; native kernels and scalar monomorphization remain unchanged.
+Feature-enabled all-target check and warning-denied package Clippy pass. Local
+Nextest reaches the Windows GNU linker and fails before execution because
+`-lcuda` is unavailable; hosted CUDA provider CI remains the device evidence
+gate. The broader Clippy graph also exposes 143 pre-existing ignored `Result`
+errors in `coeus-autograd`; package `--no-deps` Clippy isolates this increment.
+A subsequent live-overlay rerun stops in Leto `application/stencil.rs` because
+`T: UnitScalar` is missing; the earlier Git-sourced Coeus check and Clippy
+results remain the local compiled evidence for this diff.
+
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001 [minor]
 
 - [x] Route CUDA `Gelu` and `GeluGrad` through the existing Hephaestus exact-

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -17,12 +17,15 @@ coordinate can overflow. The validation is allocation-free and executes once
 at dispatch; native kernels and scalar monomorphization remain unchanged.
 Feature-enabled all-target check and warning-denied package Clippy pass. Local
 Nextest reaches the Windows GNU linker and fails before execution because
-`-lcuda` is unavailable; hosted CUDA provider CI remains the device evidence
-gate. The broader Clippy graph also exposes 143 pre-existing ignored `Result`
-errors in `coeus-autograd`; package `--no-deps` Clippy isolates this increment.
-A subsequent live-overlay rerun stops in Leto `application/stencil.rs` because
-`T: UnitScalar` is missing; the earlier Git-sourced Coeus check and Clippy
-results remain the local compiled evidence for this diff.
+`-lcuda` is unavailable. Exact-head run `30391721824` passes CUDA
+(`90384681039`), WGPU (`90384681127`), Metal (`90384681124`), and ROCm
+(`90384681137`); required-device ROCm (`90384681768`) is intentionally
+skipped. The broader Clippy graph also exposes 143 pre-existing ignored
+`Result` errors in `coeus-autograd`; package `--no-deps` Clippy isolates this
+increment. A subsequent live-overlay rerun stops in Leto
+`application/stencil.rs` because `T: UnitScalar` is missing; the earlier
+Git-sourced Coeus check and Clippy results remain the local compiled evidence
+for this diff.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001 [minor]
 

--- a/crates/coeus-cuda/src/kernels/fuse.rs
+++ b/crates/coeus-cuda/src/kernels/fuse.rs
@@ -1,16 +1,15 @@
 use super::GpuLayoutInfo;
+use crate::CudaBackendError;
 use crate::backend::{CudaBackend, CudaScalar};
-use crate::driver::{get_cuda_context, CUdeviceptr, CUfunction, CUmodule, CudaDriver, NvrtcDriver};
+use crate::driver::{CUdeviceptr, CUfunction, CUmodule, CudaDriver, NvrtcDriver, get_cuda_context};
 use crate::kernels::validation::{
-    checked_layout_storage_len, checked_numel, cuda_u32, launch_grid_size, layouts_fit_cuda,
-    CUDA_BLOCK_SIZE,
+    CUDA_BLOCK_SIZE, checked_numel, cuda_u32, launch_grid_size, layout_fits_cuda_storage,
 };
 use crate::storage::CudaStorage;
-use crate::CudaBackendError;
 use coeus_core::{Layout, Storage};
 use coeus_ops::fuse::ExprNode;
-use coeus_tensor::broadcast::broadcast_shapes;
 use coeus_tensor::Tensor;
+use coeus_tensor::broadcast::broadcast_shapes;
 use hephaestus_cuda::ComputeDevice;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
@@ -254,13 +253,8 @@ pub fn dispatch_fused<T: CudaScalar, E: ExprNode<T, CudaBackend>>(
                 "input and output layouts are not broadcast-compatible",
             ));
         };
-        let required = checked_layout_storage_len(input_layout).ok_or_else(|| {
-            CudaBackendError::fusion(OPERATION, "input storage-bound arithmetic overflow")
-        })?;
         if broadcast_shape.as_ref() != out_layout.shape()
-            || !layouts_fit_cuda(&[input_layout])
-            || required.checked_sub(1).and_then(cuda_u32).is_none()
-            || input.storage().len() < required
+            || !layout_fits_cuda_storage(input_layout, input.storage().len(), false)
         {
             return Err(CudaBackendError::fusion(
                 OPERATION,

--- a/crates/coeus-cuda/src/kernels/pool/avg.rs
+++ b/crates/coeus-cuda/src/kernels/pool/avg.rs
@@ -1,15 +1,16 @@
 #![allow(clippy::too_many_arguments)]
 
-use super::validation::{
-    checked_pool_parameters, checked_pool_work, pool_layouts_are_valid, pool_prefix_matches,
-    POOL_BLOCK_SIZE,
-};
 use super::POOL_COMMON_SRC;
+use super::validation::{
+    POOL_BLOCK_SIZE, checked_pool_parameters, checked_pool_work, pool_index_arithmetic_is_valid,
+    pool_layouts_are_valid, pool_prefix_matches,
+};
 use crate::backend::CudaScalar;
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::kernels::fuse::get_or_create_kernel;
+use crate::kernels::validation::layout_fits_cuda_storage;
 use crate::storage::CudaStorage;
-use coeus_core::Layout;
+use coeus_core::{Layout, Storage};
 
 /// Dispatch the 2-D average pooling forward kernel on the GPU.
 ///
@@ -31,13 +32,32 @@ pub fn dispatch_avg_pool2d<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[input_layout, output_layout], 4)
         || !pool_prefix_matches(input_layout, output_layout)
+        || !pool_index_arithmetic_is_valid(
+            input_layout,
+            output_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            2,
+        )
+        || !layout_fits_cuda_storage(input_layout, input.len(), false)
+        || !layout_fits_cuda_storage(output_layout, output.len(), true)
     {
         return false;
     }
@@ -181,13 +201,32 @@ pub fn dispatch_avg_pool2d_backward<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[grad_out_layout, grad_input_layout], 4)
         || !pool_prefix_matches(grad_out_layout, grad_input_layout)
+        || !pool_index_arithmetic_is_valid(
+            grad_input_layout,
+            grad_out_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            2,
+        )
+        || !layout_fits_cuda_storage(grad_out_layout, grad_out.len(), false)
+        || !layout_fits_cuda_storage(grad_input_layout, grad_input.len(), true)
     {
         return false;
     }

--- a/crates/coeus-cuda/src/kernels/pool/avg3d.rs
+++ b/crates/coeus-cuda/src/kernels/pool/avg3d.rs
@@ -1,15 +1,16 @@
 #![allow(clippy::too_many_arguments)]
 
-use super::validation::{
-    checked_pool_parameters, checked_pool_work, pool_layouts_are_valid, pool_prefix_matches,
-    POOL_BLOCK_SIZE,
-};
 use super::POOL_COMMON_SRC;
+use super::validation::{
+    POOL_BLOCK_SIZE, checked_pool_parameters, checked_pool_work, pool_index_arithmetic_is_valid,
+    pool_layouts_are_valid, pool_prefix_matches,
+};
 use crate::backend::CudaScalar;
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::kernels::fuse::get_or_create_kernel;
+use crate::kernels::validation::layout_fits_cuda_storage;
 use crate::storage::CudaStorage;
-use coeus_core::Layout;
+use coeus_core::{Layout, Storage};
 
 /// Dispatch the 3-D average pooling forward kernel on the GPU.
 ///
@@ -31,13 +32,32 @@ pub fn dispatch_avg_pool3d<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[input_layout, output_layout], 5)
         || !pool_prefix_matches(input_layout, output_layout)
+        || !pool_index_arithmetic_is_valid(
+            input_layout,
+            output_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            3,
+        )
+        || !layout_fits_cuda_storage(input_layout, input.len(), false)
+        || !layout_fits_cuda_storage(output_layout, output.len(), true)
     {
         return false;
     }
@@ -189,13 +209,32 @@ pub fn dispatch_avg_pool3d_backward<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[grad_out_layout, grad_input_layout], 5)
         || !pool_prefix_matches(grad_out_layout, grad_input_layout)
+        || !pool_index_arithmetic_is_valid(
+            grad_input_layout,
+            grad_out_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            3,
+        )
+        || !layout_fits_cuda_storage(grad_out_layout, grad_out.len(), false)
+        || !layout_fits_cuda_storage(grad_input_layout, grad_input.len(), true)
     {
         return false;
     }

--- a/crates/coeus-cuda/src/kernels/pool/max.rs
+++ b/crates/coeus-cuda/src/kernels/pool/max.rs
@@ -1,15 +1,16 @@
 #![allow(clippy::too_many_arguments)]
 
-use super::validation::{
-    checked_pool_parameters, checked_pool_work, pool_layouts_are_valid, pool_prefix_matches,
-    pool_shapes_match, POOL_BLOCK_SIZE,
-};
 use super::POOL_COMMON_SRC;
+use super::validation::{
+    POOL_BLOCK_SIZE, checked_pool_parameters, checked_pool_work, pool_index_arithmetic_is_valid,
+    pool_layouts_are_valid, pool_prefix_matches, pool_shapes_match,
+};
 use crate::backend::CudaScalar;
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::kernels::fuse::get_or_create_kernel;
+use crate::kernels::validation::layout_fits_cuda_storage;
 use crate::storage::CudaStorage;
-use coeus_core::Layout;
+use coeus_core::{Layout, Storage};
 
 /// Dispatch the 2-D max pooling forward kernel on the GPU.
 ///
@@ -31,13 +32,32 @@ pub fn dispatch_max_pool2d<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[input_layout, output_layout], 4)
         || !pool_prefix_matches(input_layout, output_layout)
+        || !pool_index_arithmetic_is_valid(
+            input_layout,
+            output_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            2,
+        )
+        || !layout_fits_cuda_storage(input_layout, input.len(), false)
+        || !layout_fits_cuda_storage(output_layout, output.len(), true)
     {
         return false;
     }
@@ -199,14 +219,34 @@ pub fn dispatch_max_pool2d_backward<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[grad_out_layout, input_layout, grad_input_layout], 4)
         || !pool_prefix_matches(grad_out_layout, grad_input_layout)
         || !pool_shapes_match(input_layout, grad_input_layout)
+        || !pool_index_arithmetic_is_valid(
+            input_layout,
+            grad_out_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            2,
+        )
+        || !layout_fits_cuda_storage(grad_out_layout, grad_out.len(), false)
+        || !layout_fits_cuda_storage(input_layout, input.len(), false)
+        || !layout_fits_cuda_storage(grad_input_layout, grad_input.len(), true)
     {
         return false;
     }

--- a/crates/coeus-cuda/src/kernels/pool/max3d.rs
+++ b/crates/coeus-cuda/src/kernels/pool/max3d.rs
@@ -1,15 +1,16 @@
 #![allow(clippy::too_many_arguments)]
 
-use super::validation::{
-    checked_pool_parameters, checked_pool_work, pool_layouts_are_valid, pool_prefix_matches,
-    pool_shapes_match, POOL_BLOCK_SIZE,
-};
 use super::POOL_COMMON_SRC;
+use super::validation::{
+    POOL_BLOCK_SIZE, checked_pool_parameters, checked_pool_work, pool_index_arithmetic_is_valid,
+    pool_layouts_are_valid, pool_prefix_matches, pool_shapes_match,
+};
 use crate::backend::CudaScalar;
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::kernels::fuse::get_or_create_kernel;
+use crate::kernels::validation::layout_fits_cuda_storage;
 use crate::storage::CudaStorage;
-use coeus_core::Layout;
+use coeus_core::{Layout, Storage};
 
 /// Dispatch the 3-D max pooling forward kernel on the GPU.
 ///
@@ -31,13 +32,32 @@ pub fn dispatch_max_pool3d<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[input_layout, output_layout], 5)
         || !pool_prefix_matches(input_layout, output_layout)
+        || !pool_index_arithmetic_is_valid(
+            input_layout,
+            output_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            3,
+        )
+        || !layout_fits_cuda_storage(input_layout, input.len(), false)
+        || !layout_fits_cuda_storage(output_layout, output.len(), true)
     {
         return false;
     }
@@ -208,14 +228,34 @@ pub fn dispatch_max_pool3d_backward<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return false;
     };
     if !pool_layouts_are_valid(&[grad_out_layout, input_layout, grad_input_layout], 5)
         || !pool_prefix_matches(grad_out_layout, grad_input_layout)
         || !pool_shapes_match(input_layout, grad_input_layout)
+        || !pool_index_arithmetic_is_valid(
+            input_layout,
+            grad_out_layout,
+            [
+                kernel_size_value,
+                stride_value,
+                padding_value,
+                dilation_value,
+            ],
+            3,
+        )
+        || !layout_fits_cuda_storage(grad_out_layout, grad_out.len(), false)
+        || !layout_fits_cuda_storage(input_layout, input.len(), false)
+        || !layout_fits_cuda_storage(grad_input_layout, grad_input.len(), true)
     {
         return false;
     }

--- a/crates/coeus-cuda/src/kernels/pool/pool1d.rs
+++ b/crates/coeus-cuda/src/kernels/pool/pool1d.rs
@@ -1,17 +1,19 @@
 #![allow(clippy::too_many_arguments)]
 
-use super::validation::{
-    checked_pool_parameters, pool_layouts_are_valid, pool_prefix_matches, pool_shapes_match,
-    POOL_BLOCK_SIZE,
-};
 use super::POOL_COMMON_SRC;
-use crate::backend::CudaScalar;
-use crate::driver::{get_cuda_context, CUdeviceptr, CudaDriver};
-use crate::kernels::fuse::get_or_create_kernel;
-use crate::kernels::validation::{checked_numel, cuda_u32, launch_grid_size};
-use crate::storage::CudaStorage;
+use super::validation::{
+    POOL_BLOCK_SIZE, checked_pool_parameters, pool_index_arithmetic_is_valid,
+    pool_layouts_are_valid, pool_prefix_matches, pool_shapes_match,
+};
 use crate::CudaBackendError;
-use coeus_core::Layout;
+use crate::backend::CudaScalar;
+use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
+use crate::kernels::fuse::get_or_create_kernel;
+use crate::kernels::validation::{
+    checked_numel, cuda_u32, launch_grid_size, layout_fits_cuda_storage,
+};
+use crate::storage::CudaStorage;
+use coeus_core::{Layout, Storage};
 
 fn source<T: CudaScalar>() -> String {
     let scalar = T::CUDA_TYPE;
@@ -151,6 +153,25 @@ extern "C" __global__ void avg_pool_backward(
     )
 }
 
+fn pool1d_contract_is_valid(
+    input_layout: &Layout,
+    input_len: usize,
+    input_writable: bool,
+    output_layout: &Layout,
+    output_len: usize,
+    output_writable: bool,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> bool {
+    checked_pool_parameters(kernel_size, stride, padding, dilation).is_some_and(|parameters| {
+        pool_index_arithmetic_is_valid(input_layout, output_layout, parameters, 1)
+            && layout_fits_cuda_storage(input_layout, input_len, input_writable)
+            && layout_fits_cuda_storage(output_layout, output_len, output_writable)
+    })
+}
+
 fn launch<T: CudaScalar>(
     operation: &'static str,
     buffers: &mut [CUdeviceptr],
@@ -173,8 +194,14 @@ fn launch<T: CudaScalar>(
             "CUDA context unavailable",
         ));
     };
-    let Some([kernel_size_value, stride_value, padding_value, dilation_value]) =
-        checked_pool_parameters(kernel_size, stride, padding, dilation)
+    let Some(
+        [
+            kernel_size_value,
+            stride_value,
+            padding_value,
+            dilation_value,
+        ],
+    ) = checked_pool_parameters(kernel_size, stride, padding, dilation)
     else {
         return Err(CudaBackendError::kernel(
             operation,
@@ -287,10 +314,23 @@ pub fn dispatch_max_pool1d<T: CudaScalar>(
     output: &mut CudaStorage<T>,
     output_layout: &Layout,
 ) -> Result<(), CudaBackendError> {
-    if !pool_prefix_matches(input_layout, output_layout) {
+    if !pool_prefix_matches(input_layout, output_layout)
+        || !pool1d_contract_is_valid(
+            input_layout,
+            input.len(),
+            false,
+            output_layout,
+            output.len(),
+            true,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+    {
         return Err(CudaBackendError::kernel(
             "max_pool_forward",
-            "input and output layouts do not share the batch/channel prefix",
+            "input, output, or signed index range violates the pool contract",
         ));
     }
     let Some(thread_count) = checked_numel(output_layout) else {
@@ -326,10 +366,23 @@ pub fn dispatch_max_pool1d_backward<T: CudaScalar>(
 ) -> Result<(), CudaBackendError> {
     if !pool_prefix_matches(grad_out_layout, grad_input_layout)
         || !pool_shapes_match(input_layout, grad_input_layout)
+        || !pool1d_contract_is_valid(
+            input_layout,
+            input.len(),
+            false,
+            grad_out_layout,
+            grad_out.len(),
+            false,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+        || !layout_fits_cuda_storage(grad_input_layout, grad_input.len(), true)
     {
         return Err(CudaBackendError::kernel(
             "max_pool_backward",
-            "pool layouts do not satisfy the shape contract",
+            "pool layouts, storage, or signed index range violate the backward contract",
         ));
     }
     let Some(thread_count) = checked_numel(grad_input_layout) else {
@@ -365,10 +418,23 @@ pub fn dispatch_avg_pool1d<T: CudaScalar>(
     output: &mut CudaStorage<T>,
     output_layout: &Layout,
 ) -> Result<(), CudaBackendError> {
-    if !pool_prefix_matches(input_layout, output_layout) {
+    if !pool_prefix_matches(input_layout, output_layout)
+        || !pool1d_contract_is_valid(
+            input_layout,
+            input.len(),
+            false,
+            output_layout,
+            output.len(),
+            true,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+    {
         return Err(CudaBackendError::kernel(
             "avg_pool_forward",
-            "input and output layouts do not share the batch/channel prefix",
+            "input, output, or signed index range violates the pool contract",
         ));
     }
     let Some(thread_count) = checked_numel(output_layout) else {
@@ -400,10 +466,23 @@ pub fn dispatch_avg_pool1d_backward<T: CudaScalar>(
     grad_input: &mut CudaStorage<T>,
     grad_input_layout: &Layout,
 ) -> Result<(), CudaBackendError> {
-    if !pool_prefix_matches(grad_out_layout, grad_input_layout) {
+    if !pool_prefix_matches(grad_out_layout, grad_input_layout)
+        || !pool1d_contract_is_valid(
+            grad_input_layout,
+            grad_input.len(),
+            true,
+            grad_out_layout,
+            grad_out.len(),
+            false,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+    {
         return Err(CudaBackendError::kernel(
             "avg_pool_backward",
-            "gradient layouts do not share the batch/channel prefix",
+            "gradient layouts, storage, or signed index range violate the pool contract",
         ));
     }
     let Some(thread_count) = checked_numel(grad_input_layout) else {

--- a/crates/coeus-cuda/src/kernels/pool/validation.rs
+++ b/crates/coeus-cuda/src/kernels/pool/validation.rs
@@ -1,5 +1,5 @@
 use crate::kernels::validation::{
-    checked_numel, cuda_u32, launch_grid_size, layouts_fit_cuda, CUDA_BLOCK_SIZE,
+    CUDA_BLOCK_SIZE, checked_numel, cuda_u32, launch_grid_size, layouts_fit_cuda,
 };
 use coeus_core::Layout;
 
@@ -35,9 +35,119 @@ pub(crate) fn checked_pool_parameters(
     ])
 }
 
+pub(crate) fn pool_index_arithmetic_is_valid(
+    input_layout: &Layout,
+    output_layout: &Layout,
+    parameters: [u32; 4],
+    spatial_rank: usize,
+) -> bool {
+    let [kernel_size, stride, padding, dilation] = parameters;
+    let signed_max = i32::MAX.unsigned_abs();
+    if [kernel_size, stride, padding, dilation]
+        .into_iter()
+        .any(|value| value > signed_max)
+    {
+        return false;
+    }
+    let Some(input_spatial) = input_layout
+        .shape()
+        .get(input_layout.ndim().saturating_sub(spatial_rank)..)
+    else {
+        return false;
+    };
+    let Some(output_spatial) = output_layout
+        .shape()
+        .get(output_layout.ndim().saturating_sub(spatial_rank)..)
+    else {
+        return false;
+    };
+    if input_spatial.len() != spatial_rank || output_spatial.len() != spatial_rank {
+        return false;
+    }
+    let Some(window_extent) = kernel_size
+        .checked_sub(1)
+        .and_then(|windows| windows.checked_mul(dilation))
+    else {
+        return false;
+    };
+    input_spatial
+        .iter()
+        .zip(output_spatial)
+        .all(|(&input, &output)| {
+            let (Some(input), Some(output)) = (cuda_u32(input), cuda_u32(output)) else {
+                return false;
+            };
+            input != 0
+                && output != 0
+                && input <= signed_max
+                && output <= signed_max
+                && output
+                    .checked_sub(1)
+                    .and_then(|last| last.checked_mul(stride))
+                    .and_then(|base| base.checked_add(window_extent))
+                    .is_some_and(|coordinate| coordinate <= signed_max)
+                && input
+                    .checked_sub(1)
+                    .and_then(|last| last.checked_add(padding))
+                    .is_some_and(|coordinate| coordinate <= signed_max)
+        })
+}
+
 pub(crate) fn checked_pool_work(layout: &Layout) -> Option<(u32, u32)> {
     let numel = checked_numel(layout)?;
     Some((cuda_u32(numel)?, launch_grid_size(numel)?))
 }
 
 pub(crate) const POOL_BLOCK_SIZE: u32 = CUDA_BLOCK_SIZE;
+
+#[cfg(test)]
+mod tests {
+    use super::pool_index_arithmetic_is_valid;
+    use crate::kernels::validation::layout_fits_cuda_storage;
+    use coeus_core::Layout;
+
+    #[test]
+    fn pool_storage_validation_rejects_undersized_and_overflowed_layouts() {
+        let max_unsigned = usize::try_from(u32::MAX)
+            .expect("invariant: CUDA host usize represents every u32 value");
+        let strided =
+            Layout::from_shape_strides(vec![1, 1, 2, 2].into(), vec![16, 16, 4, 2].into(), 3);
+        let overflowed = Layout::from_shape_strides(
+            vec![1, 1, 2, 2].into(),
+            vec![1, 1, max_unsigned, 1].into(),
+            0,
+        );
+
+        assert!(layout_fits_cuda_storage(&strided, 10, false));
+        assert!(!layout_fits_cuda_storage(&strided, 9, false));
+        assert!(!layout_fits_cuda_storage(&overflowed, usize::MAX, false));
+    }
+
+    #[test]
+    fn pool_signed_index_validation_covers_forward_and_backward_extrema() {
+        let signed_max = usize::try_from(i32::MAX.unsigned_abs())
+            .expect("invariant: CUDA host usize represents every positive i32 value");
+        let input = Layout::new(vec![1, 1, 8, 8].into());
+        let output = Layout::new(vec![1, 1, 4, 4].into());
+        let excessive_output = Layout::new(vec![1, 1, signed_max, 1].into());
+
+        assert!(pool_index_arithmetic_is_valid(
+            &input,
+            &output,
+            [3, 2, 1, 1],
+            2
+        ));
+        assert!(!pool_index_arithmetic_is_valid(
+            &input,
+            &excessive_output,
+            [3, 2, 1, 1],
+            2
+        ));
+        assert!(!pool_index_arithmetic_is_valid(
+            &input,
+            &output,
+            [3, 2, i32::MAX.unsigned_abs(), 1],
+            2
+        ));
+    }
+}

--- a/crates/coeus-cuda/src/kernels/unfold_fold/validation.rs
+++ b/crates/coeus-cuda/src/kernels/unfold_fold/validation.rs
@@ -1,8 +1,5 @@
 use crate::backend::CudaScalar;
-use crate::kernels::validation::{
-    checked_layout_storage_len, checked_numel, cuda_u32, layout_supports_cuda_output_indexing,
-    layouts_fit_cuda,
-};
+use crate::kernels::validation::{checked_numel, cuda_u32, layout_fits_cuda_storage};
 use crate::storage::CudaStorage;
 use coeus_core::{Layout, Storage};
 
@@ -44,11 +41,7 @@ fn layout_storage_is_valid<T: coeus_core::Scalar>(
     layout: &Layout,
     output: bool,
 ) -> bool {
-    layouts_fit_cuda(&[layout])
-        && (!output || layout_supports_cuda_output_indexing(layout))
-        && checked_layout_storage_len(layout).is_some_and(|required| {
-            required.checked_sub(1).and_then(cuda_u32).is_some() && storage.len() >= required
-        })
+    layout_fits_cuda_storage(layout, storage.len(), output)
 }
 
 pub(super) fn checked_output_dim(
@@ -132,8 +125,17 @@ pub(super) fn checked_2d_launch<T: CudaScalar>(
     {
         return None;
     }
-    let [kernel_h, kernel_w, stride_h, stride_w, _, _, dilation_h, dilation_w, _] =
-        parameters.values;
+    let [
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        _,
+        _,
+        dilation_h,
+        dilation_w,
+        _,
+    ] = parameters.values;
     if [
         kernel_h, kernel_w, stride_h, stride_w, dilation_h, dilation_w,
     ]
@@ -142,8 +144,17 @@ pub(super) fn checked_2d_launch<T: CudaScalar>(
     {
         return None;
     }
-    let [Some(kernel_h), Some(kernel_w), Some(stride_h), Some(stride_w), Some(padding_h), Some(padding_w), Some(dilation_h), Some(dilation_w), Some(width)] =
-        parameters.values.map(cuda_u32)
+    let [
+        Some(kernel_h),
+        Some(kernel_w),
+        Some(stride_h),
+        Some(stride_w),
+        Some(padding_h),
+        Some(padding_w),
+        Some(dilation_h),
+        Some(dilation_w),
+        Some(width),
+    ] = parameters.values.map(cuda_u32)
     else {
         return None;
     };

--- a/crates/coeus-cuda/src/kernels/validation.rs
+++ b/crates/coeus-cuda/src/kernels/validation.rs
@@ -50,6 +50,18 @@ pub(crate) fn layout_supports_cuda_output_indexing(layout: &Layout) -> bool {
     layouts_fit_cuda(&[layout]) && layout.strides().iter().all(|&stride| stride != 0)
 }
 
+pub(crate) fn layout_fits_cuda_storage(
+    layout: &Layout,
+    storage_len: usize,
+    writable: bool,
+) -> bool {
+    layouts_fit_cuda(&[layout])
+        && (!writable || layout_supports_cuda_output_indexing(layout))
+        && checked_layout_storage_len(layout).is_some_and(|required| {
+            required.checked_sub(1).and_then(cuda_u32).is_some() && storage_len >= required
+        })
+}
+
 pub(crate) fn launch_grid_size(total: usize) -> Option<u32> {
     launch_grid_size_for_block(total, usize::try_from(CUDA_BLOCK_SIZE).ok()?)
 }
@@ -65,7 +77,7 @@ pub(crate) fn launch_grid_size_for_block(total: usize, block_size: usize) -> Opt
 mod tests {
     use super::{
         checked_layout_storage_len, checked_numel, launch_grid_size, launch_grid_size_for_block,
-        layout_supports_cuda_output_indexing, layouts_share_shape,
+        layout_fits_cuda_storage, layout_supports_cuda_output_indexing, layouts_share_shape,
     };
     use coeus_core::Layout;
 
@@ -118,5 +130,16 @@ mod tests {
         let layout = Layout::from_shape_strides(vec![2].into(), vec![1].into(), usize::MAX);
 
         assert_eq!(checked_layout_storage_len(&layout), None);
+    }
+
+    #[test]
+    fn cuda_storage_validation_checks_physical_bound_and_writable_aliasing() {
+        let strided = Layout::from_shape_strides(vec![2, 3].into(), vec![4, 1].into(), 2);
+        let aliased = Layout::from_shape_strides(vec![2, 3].into(), vec![0, 1].into(), 0);
+
+        assert!(layout_fits_cuda_storage(&strided, 9, false));
+        assert!(!layout_fits_cuda_storage(&strided, 8, false));
+        assert!(layout_fits_cuda_storage(&aliased, 3, false));
+        assert!(!layout_fits_cuda_storage(&aliased, 3, true));
     }
 }

--- a/docs/adr/0041-cuda-pooling-index-contract.md
+++ b/docs/adr/0041-cuda-pooling-index-contract.md
@@ -51,7 +51,10 @@ Pure validation tests cover exact strided storage capacity, undersized
 allocation rejection, physical-offset overflow, writable alias rejection,
 valid forward/backward extrema, and signed-coordinate overflow. The
 feature-enabled package check and warning-denied package Clippy establish the
-compiled contract. Hosted CUDA provider tests are required for device
-execution because the local Windows GNU linker cannot resolve `-lcuda`.
+compiled contract. Exact-head run `30391721824` passes CUDA
+(`90384681039`), WGPU (`90384681127`), Metal (`90384681124`), and ROCm
+(`90384681137`); required-device ROCm (`90384681768`) is intentionally
+skipped. Hosted CUDA execution supplies the device evidence because the local
+Windows GNU linker cannot resolve `-lcuda`.
 No runtime, bandwidth, or resident-memory improvement is claimed without a
 controlled measurement.

--- a/docs/adr/0041-cuda-pooling-index-contract.md
+++ b/docs/adr/0041-cuda-pooling-index-contract.md
@@ -1,0 +1,57 @@
+# ADR-0041: CUDA pooling index contract
+
+- Status: accepted
+- Date: 2026-07-28
+- Scope: `coeus-cuda` pooling launch validation
+
+## Context
+
+CUDA pooling validated each layout field and launch parameter independently
+against the unsigned 32-bit ABI. The kernels then formed physical offsets as
+`offset + sum(index * stride)` and formed window coordinates with signed
+32-bit arithmetic. Individually representable fields did not prove either
+derived expression representable. A strided layout could therefore address
+beyond its allocation or wrap a physical index, while large pooling
+dimensions or parameters could overflow the kernel's signed coordinate
+expressions.
+
+The physical layout/storage proof also existed separately in fused and
+unfold/fold dispatch. Adding a third operation-local copy would create
+divergent memory-safety contracts.
+
+## Decision
+
+Own physical CUDA layout/storage validation in
+`kernels::validation::layout_fits_cuda_storage`. The helper proves the maximum
+physical offset is representable by the CUDA layout ABI, remains inside the
+device allocation, and rejects writable zero-stride aliasing. Fusion,
+unfold/fold, and pooling consume this single contract.
+
+Pooling additionally validates the complete forward and backward coordinate
+extrema before kernel compilation. For every spatial axis, the last forward
+window coordinate and the largest backward input-plus-padding term must fit
+the signed 32-bit domain used by the CUDA source. The validation is
+allocation-free and executes once at the operation boundary; kernel loops and
+monomorphized scalar dispatch remain unchanged.
+
+## Rejected alternatives
+
+- Widen only the CUDA source to 64-bit integers: physical layout indices still
+  use the published 32-bit ABI, and allocation bounds would remain unchecked.
+- Clamp or wrap oversized coordinates: either changes pooling semantics and
+  can redirect an access to unrelated device memory.
+- Copy nonconforming layouts to contiguous buffers: that hides the selected
+  layout contract and introduces an implicit allocation and transfer path.
+- Keep operation-local storage checks: fusion, unfold/fold, and pooling would
+  maintain parallel definitions of one device-memory invariant.
+
+## Verification
+
+Pure validation tests cover exact strided storage capacity, undersized
+allocation rejection, physical-offset overflow, writable alias rejection,
+valid forward/backward extrema, and signed-coordinate overflow. The
+feature-enabled package check and warning-denied package Clippy establish the
+compiled contract. Hosted CUDA provider tests are required for device
+execution because the local Windows GNU linker cannot resolve `-lcuda`.
+No runtime, bandwidth, or resident-memory improvement is claimed without a
+controlled measurement.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,26 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-CUDA-SAFETY-017 — Bound pooling physical indices [patch] [arch] — in progress
+
+- Owner: Codex; scope: shared CUDA layout/storage validation and the canonical
+  1-D/2-D/3-D pooling dispatch leaves.
+- Outcome: prove complete physical layout offsets, allocation capacity,
+  writable non-aliasing, and signed CUDA window-coordinate extrema before any
+  pooling kernel compilation or launch.
+- Non-goals: pooling algorithm changes, implicit contiguous copies, provider
+  fallback, scalar specialization changes, or unmeasured performance claims.
+- Acceptance: pure tests reject undersized, physical-offset-overflowing,
+  writable-aliased, and signed-coordinate-overflowing contracts; feature
+  check and warning-denied package Clippy pass; hosted CUDA provider CI passes.
+- Risk/change class: `[arch]` validation-ownership consolidation with a
+  backward-compatible rejection of previously unsafe launch contracts.
+- Status: implementation and local static gates complete. Local Nextest is
+  blocked before execution by the missing MinGW `-lcuda` link library; hosted
+  CUDA execution, including all three new boundary regressions, is pending.
+  The live Atlas overlay later switched to a Leto tree missing the
+  `T: UnitScalar` stencil bound, so repeat compilation currently stops
+  upstream before Coeus.
+
 ## ATLAS-COEUS-HEPHAESTUS-ELU-DISPATCH-001 — Own ELU in Hephaestus [arch] — complete
 
 - Owner: Codex; scope: CUDA/WGPU contiguous and strided ELU forward/gradient

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,6 @@
 # Coeus Project Backlog & Historical Archives
 
-## ATLAS-CUDA-SAFETY-017 — Bound pooling physical indices [patch] [arch] — in progress
+## ATLAS-CUDA-SAFETY-017 — Bound pooling physical indices [patch] [arch] — complete
 
 - Owner: Codex; scope: shared CUDA layout/storage validation and the canonical
   1-D/2-D/3-D pooling dispatch leaves.
@@ -14,12 +14,13 @@
   check and warning-denied package Clippy pass; hosted CUDA provider CI passes.
 - Risk/change class: `[arch]` validation-ownership consolidation with a
   backward-compatible rejection of previously unsafe launch contracts.
-- Status: implementation and local static gates complete. Local Nextest is
-  blocked before execution by the missing MinGW `-lcuda` link library; hosted
-  CUDA execution, including all three new boundary regressions, is pending.
-  The live Atlas overlay later switched to a Leto tree missing the
-  `T: UnitScalar` stencil bound, so repeat compilation currently stops
-  upstream before Coeus.
+- Status: implemented at `8fe4da78`. Exact-head run `30391721824` passes CUDA
+  (`90384681039`), WGPU (`90384681127`), Metal (`90384681124`), and ROCm
+  (`90384681137`); required-device ROCm (`90384681768`) is intentionally
+  skipped. Local Nextest remains blocked before execution by the missing
+  MinGW `-lcuda` link library. The live Atlas overlay later switched to a Leto
+  tree missing the `T: UnitScalar` stencil bound, so repeat compilation
+  currently stops upstream before Coeus.
 
 ## ATLAS-COEUS-HEPHAESTUS-ELU-DISPATCH-001 — Own ELU in Hephaestus [arch] — complete
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,30 @@
 # Coeus Gap Audit
 
+## ATLAS-CUDA-SAFETY-017: Pooling physical-index contract
+
+**Location**: `crates/coeus-cuda/src/kernels/validation.rs` and
+`crates/coeus-cuda/src/kernels/pool/`.
+**Gap**: pooling checked layout fields and parameters independently against
+the CUDA unsigned ABI, but did not prove the derived physical offset or the
+signed window-coordinate expressions representable. Storage capacity and
+writable aliasing were also unchecked at the pooling boundary.
+**Resolution**: ADR-0041 centralizes the physical layout/storage proof shared
+by fusion, unfold/fold, and pooling. Every pooling dimension now validates
+allocation bounds, writable non-aliasing, and complete forward/backward signed
+coordinate extrema before compilation.
+**Evidence**: pure boundary regressions cover exact and undersized strided
+storage, physical-offset overflow, writable zero-stride aliasing, and signed
+coordinate overflow. Feature-enabled all-target check and warning-denied
+package Clippy pass. Local native test linking remains blocked by MinGW
+`cannot find -lcuda`; the three regressions are selected in hosted CUDA
+provider execution, which is pending.
+**Residual**: the broader warning-denied graph exposes 143 pre-existing
+ignored `Result` errors in `coeus-autograd`. The live Atlas overlay later
+resolved Leto with missing `T: UnitScalar` bounds in
+`application/stencil.rs`, blocking repeat Coeus compilation before the
+touched crate. No runtime, bandwidth, or resident-memory delta is claimed.
+**Status**: implementation complete; hosted provider evidence pending.
+
 ## ATLAS-COEUS-SAFETY-003: Uninitialized COW replacement allocation
 
 **Location**: `crates/coeus-hephaestus/src/storage.rs`,

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -16,14 +16,16 @@ coordinate extrema before compilation.
 storage, physical-offset overflow, writable zero-stride aliasing, and signed
 coordinate overflow. Feature-enabled all-target check and warning-denied
 package Clippy pass. Local native test linking remains blocked by MinGW
-`cannot find -lcuda`; the three regressions are selected in hosted CUDA
-provider execution, which is pending.
+`cannot find -lcuda`. Exact-head run `30391721824` passes CUDA
+(`90384681039`), WGPU (`90384681127`), Metal (`90384681124`), and ROCm
+(`90384681137`); required-device ROCm (`90384681768`) is intentionally
+skipped.
 **Residual**: the broader warning-denied graph exposes 143 pre-existing
 ignored `Result` errors in `coeus-autograd`. The live Atlas overlay later
 resolved Leto with missing `T: UnitScalar` bounds in
 `application/stencil.rs`, blocking repeat Coeus compilation before the
 touched crate. No runtime, bandwidth, or resident-memory delta is claimed.
-**Status**: implementation complete; hosted provider evidence pending.
+**Status**: complete at `8fe4da78`; merge delivery pending.
 
 ## ATLAS-COEUS-SAFETY-003: Uninitialized COW replacement allocation
 


### PR DESCRIPTION
## Summary
- centralize CUDA layout-to-storage validation for pooling, fuse, unfold, and fold kernels
- reject writable zero-stride layouts and physical indices outside the allocation or CUDA u32 address range
- prove pooling window and padded-coordinate arithmetic remains representable by CUDA's signed int kernel coordinates
- add focused contract regressions and run them in hosted CUDA parity

## Local verification
- ustup run 1.95.0 cargo check --offline --package coeus-cuda --features cuda --all-targets passed against the Git-resolved dependency graph
- package-scoped cargo clippy ... --no-deps -- -D warnings passed against that graph
- targeted ustfmt --check, cargo metadata --offline --no-deps, and staged diff checks passed
- local nextest reached the linker but cannot execute because this host lacks -lcuda
- the current live Atlas overlay is independently blocked in Leto stencil code by missing T: UnitScalar bounds

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR centralizes CUDA layout-to-storage validation and adds comprehensive safety checks for pooling operations. It introduces `layout_fits_cuda_storage` to validate that physical memory offsets remain within bounds and reject writable zero-stride layouts, then applies this validation across pooling, fusion, and unfold/fold kernels. Additionally, it proves that pooling window and padded-coordinate arithmetic stays within CUDA's signed 32-bit integer range by validating forward and backward coordinate extrema before kernel compilation. The changes include focused contract regression tests that run in hosted CUDA parity testing.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0041-cuda-pooling-index-contract.md` |
| 2 | `CHECKLIST.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-cuda/src/kernels/validation.rs` |
| 6 | `crates/coeus-cuda/src/kernels/pool/validation.rs` |
| 7 | `crates/coeus-cuda/src/kernels/fuse.rs` |
| 8 | `crates/coeus-cuda/src/kernels/unfold_fold/validation.rs` |
| 9 | `crates/coeus-cuda/src/kernels/pool/pool1d.rs` |
| 10 | `crates/coeus-cuda/src/kernels/pool/avg.rs` |
| 11 | `crates/coeus-cuda/src/kernels/pool/avg3d.rs` |
| 12 | `crates/coeus-cuda/src/kernels/pool/max.rs` |
| 13 | `crates/coeus-cuda/src/kernels/pool/max3d.rs` |
| 14 | `.github/workflows/backend-parity.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA pooling validation across 1D, 2D, and 3D operations.
  * Prevents launches when tensor layouts exceed allocated storage, contain unsupported physical offsets, risk signed index overflow, or create unsafe writable aliasing.
  * Applied consistent storage and layout checks to pooling forward and backward operations, as well as related fused workflows.

* **Documentation**
  * Added documentation covering CUDA pooling safety requirements and validation behavior.

* **Tests**
  * Expanded CUDA coverage for pooling, storage bounds, index validation, and parity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->