### PR TITLE
fix(autograd)!: Propagate backward errors

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,24 @@
 # Coeus Development Roadmap Checklist
 
+## ATLAS-AUTOGRAD-SAFETY-018 Fallible backward contract [major][arch]
+
+- [x] Record the typed failure contract and migration in ADR-0042.
+- [x] Return `Result<(), B::Error>` from the graph seam and every operation
+      node.
+- [x] Update every in-repository caller and public doctest.
+- [x] Add failure propagation and existing-gradient regression evidence.
+- [ ] Pass warning-denied Clippy, Nextest, doctests, provider CI, and SemVer
+      classification.
+
+Acceptance: no backend mutation result is ignored or converted to a fallback.
+Traversal returns the exact backend error at the first failed node. The
+successful path remains statically dispatched and allocation-neutral.
+Local evidence: warning-denied `coeus-autograd` all-target Clippy passes;
+Nextest passes 102 autograd/FFT and 268 NN tests; 24 executable doctests pass
+(two pre-existing NN doctests remain ignored). SemVer checks against
+`origin/main` identify the two public trait-return changes as requiring a
+major release. Hosted provider CI remains pending.
+
 ## ATLAS-CUDA-SAFETY-017 Pooling physical-index contract [arch][patch]
 
 - [x] Promote physical layout/allocation validation into the shared CUDA

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -7,7 +7,7 @@
       node.
 - [x] Update every in-repository caller and public doctest.
 - [x] Add failure propagation and existing-gradient regression evidence.
-- [ ] Pass warning-denied Clippy, Nextest, doctests, provider CI, and SemVer
+- [x] Pass warning-denied Clippy, Nextest, doctests, provider CI, and SemVer
       classification.
 
 Acceptance: no backend mutation result is ignored or converted to a fallback.
@@ -17,7 +17,11 @@ Local evidence: warning-denied `coeus-autograd` all-target Clippy passes;
 Nextest passes 102 autograd/FFT and 268 NN tests; 24 executable doctests pass
 (two pre-existing NN doctests remain ignored). SemVer checks against
 `origin/main` identify the two public trait-return changes as requiring a
-major release. Hosted provider CI remains pending.
+major release. Exact-head provider run `30397554467` attempt 2 passes WGPU
+(`90407664433`), ROCm (`90407664470`), CUDA (`90407664479`), and Metal
+(`90407664482`); required-device ROCm (`90407665417`) is intentionally
+skipped. Attempt 1 exposed and triggered the upstream Leto `UnitScalar`
+contract repair merged as Leto PR #77.
 
 ## ATLAS-CUDA-SAFETY-017 Pooling physical-index contract [arch][patch]
 

--- a/crates/coeus-autograd/src/node.rs
+++ b/crates/coeus-autograd/src/node.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
 ///         &self,
 ///         grad_out: &Tensor<T, B>,
 ///         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
-///     ) {
+///     ) -> Result<(), B::Error> {
 ///         // d/dx (c * x) = c, so grad_x += c * grad_out
 ///         if let Some(Some(ref g)) = input_grads.get(0) {
 ///             let go = grad_out.as_slice();
@@ -59,6 +59,7 @@ use std::sync::Arc;
 ///                 gx_s[i] = acc;
 ///             }
 ///         }
+///         Ok(())
 ///     }
 /// }
 /// ```
@@ -75,5 +76,14 @@ pub trait BackwardNode<T: Scalar, B: ComputeBackend + Default = MoiraiBackend>:
     fn inputs(&self) -> &[Var<T, B>];
 
     /// Backward function: given the output gradient, push gradients to inputs.
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]);
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend error when gradient computation or accumulation
+    /// cannot complete.
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error>;
 }

--- a/crates/coeus-autograd/src/ops/activation/ext.rs
+++ b/crates/coeus-autograd/src/ops/activation/ext.rs
@@ -1,4 +1,4 @@
-﻿// ── Extended activation family (G-037 parity) ──
+// ── Extended activation family (G-037 parity) ──
 //
 // Each function is implemented as a tracked autograd wrapper. Parameter-free
 // variants (Hardsigmoid, Hardswish, Softsign) reuse the generic
@@ -66,19 +66,23 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Har
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let deriv = coeus_ops::elementwise_unary(
                 &self.input_tensor,
                 &backend,
                 coeus_ops::UnaryOp::HardtanhGrad(self.bits),
-            )
-            .expect("elementwise_unary");
+            )?;
             let local = coeus_ops::mul(grad_out, &deriv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &local, &backend);
+            coeus_ops::add_assign(lock, &local, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -133,7 +137,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
 
     #[inline(always)]
     fn forward(x: &Tensor<T, B>, backend: &B) -> Tensor<T, B> {
-        coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::Hardsigmoid).expect("elementwise_unary")
+        coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::Hardsigmoid)
+            .expect("elementwise_unary")
     }
 
     #[inline(always)]
@@ -143,7 +148,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::HardsigmoidGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::HardsigmoidGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }
@@ -166,7 +172,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
 
     #[inline(always)]
     fn forward(x: &Tensor<T, B>, backend: &B) -> Tensor<T, B> {
-        coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::Hardswish).expect("elementwise_unary")
+        coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::Hardswish)
+            .expect("elementwise_unary")
     }
 
     #[inline(always)]
@@ -176,7 +183,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::HardswishGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::HardswishGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }
@@ -214,18 +222,23 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Har
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let deriv = coeus_ops::elementwise_unary(
                 &self.input_tensor,
                 &backend,
                 coeus_ops::UnaryOp::HardshrinkGrad(self.bits),
-            ).expect("elementwise_unary");
+            )?;
             let local = coeus_ops::mul(grad_out, &deriv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &local, &backend);
+            coeus_ops::add_assign(lock, &local, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -243,7 +256,8 @@ pub fn hardshrink<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     let backend = B::default();
     let bits = lambda.to_bits();
     let out_tensor =
-        coeus_ops::elementwise_unary(&a.tensor, &backend, coeus_ops::UnaryOp::Hardshrink(bits)).expect("elementwise_unary");
+        coeus_ops::elementwise_unary(&a.tensor, &backend, coeus_ops::UnaryOp::Hardshrink(bits))
+            .expect("elementwise_unary");
     let requires_grad = crate::grad_mode::should_track_var(a);
     let grad = if requires_grad {
         Some(Arc::new(GradBuffer::new(Tensor::zeros_on(
@@ -294,19 +308,23 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sof
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let deriv = coeus_ops::elementwise_unary(
                 &self.input_tensor,
                 &backend,
                 coeus_ops::UnaryOp::SoftshrinkGrad(self.bits),
-            )
-            .expect("elementwise_unary");
+            )?;
             let local = coeus_ops::mul(grad_out, &deriv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &local, &backend);
+            coeus_ops::add_assign(lock, &local, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -361,7 +379,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
 
     #[inline(always)]
     fn forward(x: &Tensor<T, B>, backend: &B) -> Tensor<T, B> {
-        coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::Softsign).expect("elementwise_unary")
+        coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::Softsign)
+            .expect("elementwise_unary")
     }
 
     #[inline(always)]
@@ -371,7 +390,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::SoftsignGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::SoftsignGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }
@@ -408,19 +428,23 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Thr
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let deriv = coeus_ops::elementwise_unary(
                 &self.input_tensor,
                 &backend,
                 coeus_ops::UnaryOp::ThresholdGrad(self.bits),
-            )
-            .expect("elementwise_unary");
+            )?;
             let local = coeus_ops::mul(grad_out, &deriv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &local, &backend);
+            coeus_ops::add_assign(lock, &local, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -491,18 +515,23 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Cel
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let deriv = coeus_ops::elementwise_unary(
                 &self.input_tensor,
                 &backend,
                 coeus_ops::UnaryOp::CeluGrad(self.bits),
-            ).expect("elementwise_unary");
+            )?;
             let local = coeus_ops::mul(grad_out, &deriv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &local, &backend);
+            coeus_ops::add_assign(lock, &local, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -519,7 +548,8 @@ pub fn celu<T: Float, B: coeus_ops::BackendOps<T> + Default>(
     let backend = B::default();
     let bits = alpha.to_bits();
     let out_tensor =
-        coeus_ops::elementwise_unary(&a.tensor, &backend, coeus_ops::UnaryOp::Celu(bits)).expect("elementwise_unary");
+        coeus_ops::elementwise_unary(&a.tensor, &backend, coeus_ops::UnaryOp::Celu(bits))
+            .expect("elementwise_unary");
     let requires_grad = crate::grad_mode::should_track_var(a);
     let grad = if requires_grad {
         Some(Arc::new(GradBuffer::new(Tensor::zeros_on(

--- a/crates/coeus-autograd/src/ops/activation/gelu.rs
+++ b/crates/coeus-autograd/src/ops/activation/gelu.rs
@@ -21,7 +21,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::GeluGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::GeluGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }
@@ -43,7 +44,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::GeluTanhGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::GeluTanhGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }

--- a/crates/coeus-autograd/src/ops/activation/math.rs
+++ b/crates/coeus-autograd/src/ops/activation/math.rs
@@ -63,7 +63,7 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradO
     fn backward(
         grad_out: &Tensor<T, B>,
         x: &Tensor<T, B>,
-        y: &Tensor<T, B>,
+        _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
         // sign(x) = abs(x) / x; where x = 0 this produces NaN, masked to 0
@@ -77,12 +77,12 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradO
         //   pos_mask = ReluGrad(x)      — 1 where x > 0, 0 elsewhere
         //   neg_mask = ReluGrad(-x_neg) — 1 where x < 0, 0 elsewhere
         // sign = pos_mask - neg_mask
-        let pos_mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
+        let pos_mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::ReluGrad)
+            .expect("elementwise_unary");
         let x_neg = coeus_ops::neg(x, backend);
-        let neg_mask = coeus_ops::elementwise_unary(&x_neg, backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
+        let neg_mask = coeus_ops::elementwise_unary(&x_neg, backend, coeus_ops::UnaryOp::ReluGrad)
+            .expect("elementwise_unary");
         let sign = coeus_ops::sub(&pos_mask, &neg_mask, backend);
-        // Ignore the stored forward output `y` here — sign is cheaper directly from x.
-        let _ = y;
         coeus_ops::mul(grad_out, &sign, backend)
     }
 }
@@ -167,17 +167,21 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let exp = f64::from_bits(self.exp_bits);
         let exp_t = T::from_f64(exp);
         let n = self.input_tensor.numel();
         if n == 0 {
-            return;
+            return Ok(());
         }
 
         // Host-side copy of upstream gradient.
@@ -286,13 +290,14 @@ where
             let local_grad = coeus_ops::mul(&n_tensor, &x_pow_n_m1, &backend);
             let grad_in = coeus_ops::mul(grad_out, &local_grad, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &grad_in, &backend);
-            return;
+            coeus_ops::add_assign(lock, &grad_in, &backend)?;
+            return Ok(());
         }
 
         let grad_t = Tensor::from_slice(self.input_tensor.shape().to_vec(), &grad_in_host);
         let lock = g.write();
-        coeus_ops::add_assign(lock, &grad_t, &backend);
+        coeus_ops::add_assign(lock, &grad_t, &backend)?;
+        Ok(())
     }
 }
 
@@ -486,7 +491,11 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let shape = self.input_tensor.shape();
@@ -499,7 +508,7 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
             let lo_t = Tensor::full_on(shape, self.min_val, &backend);
             let lo_minus_x = coeus_ops::sub(&lo_t, &self.input_tensor, &backend);
             let mask_lt_lo =
-                coeus_ops::elementwise_unary(&lo_minus_x, &backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
+                coeus_ops::elementwise_unary(&lo_minus_x, &backend, coeus_ops::UnaryOp::ReluGrad)?;
             let mask_lo_ge = coeus_ops::sub(&one_scalar, &mask_lt_lo, &backend);
 
             // 1_{x <= hi} = 1 - 1_{x > hi} = 1 - ReluGrad(x - hi).
@@ -509,15 +518,16 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
             let hi_t = Tensor::full_on(shape, self.max_val, &backend);
             let x_minus_hi = coeus_ops::sub(&self.input_tensor, &hi_t, &backend);
             let mask_gt_hi =
-                coeus_ops::elementwise_unary(&x_minus_hi, &backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
+                coeus_ops::elementwise_unary(&x_minus_hi, &backend, coeus_ops::UnaryOp::ReluGrad)?;
             let mask_hi_le = coeus_ops::sub(&one_scalar, &mask_gt_hi, &backend);
 
             // Inside mask = mask_lo_ge AND mask_hi_le (product of indicators)
             let inside = coeus_ops::mul(&mask_lo_ge, &mask_hi_le, &backend);
             let grad_in = coeus_ops::mul(grad_out, &inside, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &grad_in, &backend);
+            coeus_ops::add_assign(lock, &grad_in, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -542,11 +552,13 @@ pub fn clamp<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default>(
     let hi_t = Tensor::full_on(a.tensor.shape(), max_val, &backend);
     // x_clamped_lo = relu(x - lo) + lo = max(x, lo)
     let shifted_lo = coeus_ops::sub(&a.tensor, &lo_t, &backend);
-    let relu_lo = coeus_ops::elementwise_unary(&shifted_lo, &backend, coeus_ops::UnaryOp::Relu).expect("elementwise_unary");
+    let relu_lo = coeus_ops::elementwise_unary(&shifted_lo, &backend, coeus_ops::UnaryOp::Relu)
+        .expect("elementwise_unary");
     let clamped_lo = coeus_ops::add(&relu_lo, &lo_t, &backend);
     // max(x, lo) clamped from above: min(clamped_lo, hi) = hi - relu(hi - clamped_lo)
     let shifted_hi = coeus_ops::sub(&hi_t, &clamped_lo, &backend);
-    let relu_hi = coeus_ops::elementwise_unary(&shifted_hi, &backend, coeus_ops::UnaryOp::Relu).expect("elementwise_unary");
+    let relu_hi = coeus_ops::elementwise_unary(&shifted_hi, &backend, coeus_ops::UnaryOp::Relu)
+        .expect("elementwise_unary");
     let out_tensor = coeus_ops::sub(&hi_t, &relu_hi, &backend);
 
     let requires_grad = crate::grad_mode::should_track_var(a);

--- a/crates/coeus-autograd/src/ops/activation/mod.rs
+++ b/crates/coeus-autograd/src/ops/activation/mod.rs
@@ -58,13 +58,18 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default, Op: UnaryAutogradOp<T, B>
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let mask = Op::backward(grad_out, &self.a_tensor, &self.out_tensor, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &mask, &backend);
+            coeus_ops::add_assign(gl, &mask, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/activation/relu.rs
+++ b/crates/coeus-autograd/src/ops/activation/relu.rs
@@ -25,7 +25,8 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
+        let mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::ReluGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &mask, backend)
     }
 }
@@ -47,7 +48,7 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for
 /// assert!((y.tensor.as_slice()[0] - 2.0).abs() < 1e-5);
 /// assert!((y.tensor.as_slice()[1] - 0.0).abs() < 1e-5);
 /// let loss = coeus_autograd::sum(&y);
-/// loss.backward();
+/// loss.backward().expect("invariant: valid autograd fixture completes backward");
 /// let grad = x.grad().unwrap();
 /// assert!((grad.as_slice()[0] - 1.0).abs() < 1e-5); // x > 0
 /// assert!((grad.as_slice()[1] - 0.0).abs() < 1e-5); // x < 0
@@ -77,19 +78,23 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Lea
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let deriv = coeus_ops::elementwise_unary(
                 &self.input_tensor,
                 &backend,
                 coeus_ops::UnaryOp::LeakyReluGrad(self.negative_slope),
-            )
-            .expect("elementwise_unary");
+            )?;
             let mask = coeus_ops::mul(grad_out, &deriv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &mask, &backend);
+            coeus_ops::add_assign(lock, &mask, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -150,7 +155,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         backend: &B,
     ) -> Tensor<T, B> {
         // EluGrad takes the original input x and returns exp(x) or 1
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::EluGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::EluGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }

--- a/crates/coeus-autograd/src/ops/activation/sigmoid.rs
+++ b/crates/coeus-autograd/src/ops/activation/sigmoid.rs
@@ -21,7 +21,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(y, backend, coeus_ops::UnaryOp::SigmoidGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(y, backend, coeus_ops::UnaryOp::SigmoidGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }
@@ -42,7 +43,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
 /// let y = coeus_autograd::sigmoid(&x);
 /// assert!((y.tensor.as_slice()[0] - 0.5).abs() < 1e-5);
 /// let loss = coeus_autograd::sum(&y);
-/// loss.backward();
+/// loss.backward().expect("invariant: valid autograd fixture completes backward");
 /// let grad = x.grad().unwrap();
 /// assert!((grad.as_slice()[0] - 0.25).abs() < 1e-5); // 0.5 * (1 - 0.5)
 /// assert!((grad.as_slice()[1] - 0.25).abs() < 1e-5);

--- a/crates/coeus-autograd/src/ops/activation/silu.rs
+++ b/crates/coeus-autograd/src/ops/activation/silu.rs
@@ -21,7 +21,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::SiluGrad).expect("elementwise_unary");
+        let mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::SiluGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &mask, backend)
     }
 }
@@ -43,7 +44,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         _y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::MishGrad).expect("elementwise_unary");
+        let mask = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::MishGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &mask, backend)
     }
 }
@@ -66,7 +68,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         backend: &B,
     ) -> Tensor<T, B> {
         // SoftplusGrad = sigmoid(x)
-        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::SoftplusGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(x, backend, coeus_ops::UnaryOp::SoftplusGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }

--- a/crates/coeus-autograd/src/ops/activation/tanh_act.rs
+++ b/crates/coeus-autograd/src/ops/activation/tanh_act.rs
@@ -21,7 +21,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for 
         y: &Tensor<T, B>,
         backend: &B,
     ) -> Tensor<T, B> {
-        let deriv = coeus_ops::elementwise_unary(y, backend, coeus_ops::UnaryOp::TanhGrad).expect("elementwise_unary");
+        let deriv = coeus_ops::elementwise_unary(y, backend, coeus_ops::UnaryOp::TanhGrad)
+            .expect("elementwise_unary");
         coeus_ops::mul(grad_out, &deriv, backend)
     }
 }

--- a/crates/coeus-autograd/src/ops/arithmetic/binary.rs
+++ b/crates/coeus-autograd/src/ops/arithmetic/binary.rs
@@ -1,4 +1,4 @@
-﻿use super::traits::{binary_op, BinaryAutogradOp};
+use super::traits::{binary_op, BinaryAutogradOp};
 use crate::backward::reduce_broadcast;
 use crate::grad_buffer::GradBuffer;
 use crate::var::Var;
@@ -25,25 +25,26 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
         b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    ) {
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref g)) = input_grads.get(0) {
             let gl = g.write();
             if grad_out.shape() == &a_shape[..] {
-                coeus_ops::add_assign(gl, grad_out, backend);
+                coeus_ops::add_assign(gl, grad_out, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_out.clone(), a_shape);
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let gl = g.write();
             if grad_out.shape() == &b_shape[..] {
-                coeus_ops::add_assign(gl, grad_out, backend);
+                coeus_ops::add_assign(gl, grad_out, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_out.clone(), b_shape);
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -66,25 +67,26 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
         b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    ) {
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref g)) = input_grads.get(0) {
             let gl = g.write();
             if grad_out.shape() == &a_shape[..] {
-                coeus_ops::add_assign(gl, grad_out, backend);
+                coeus_ops::add_assign(gl, grad_out, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_out.clone(), a_shape);
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let gl = g.write();
             if grad_out.shape() == &b_shape[..] {
-                coeus_ops::sub_assign(gl, grad_out, backend);
+                coeus_ops::sub_assign(gl, grad_out, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_out.clone(), b_shape);
-                coeus_ops::sub_assign(gl, &reduced, backend);
+                coeus_ops::sub_assign(gl, &reduced, backend)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -107,27 +109,28 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
         _b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    ) {
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref g)) = input_grads.get(0) {
             let prod = coeus_ops::mul(grad_out, b, backend);
             let gl = g.write();
             if prod.shape() == a.shape() {
-                coeus_ops::add_assign(gl, &prod, backend);
+                coeus_ops::add_assign(gl, &prod, backend)?;
             } else {
                 let reduced = reduce_broadcast(prod, a.shape());
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let prod = coeus_ops::mul(grad_out, a, backend);
             let gl = g.write();
             if prod.shape() == b.shape() {
-                coeus_ops::add_assign(gl, &prod, backend);
+                coeus_ops::add_assign(gl, &prod, backend)?;
             } else {
                 let reduced = reduce_broadcast(prod, b.shape());
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -150,15 +153,15 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
         _b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    ) {
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref g)) = input_grads.get(0) {
             let grad_a = coeus_ops::div(grad_out, b, backend);
             let gl = g.write();
             if grad_a.shape() == a.shape() {
-                coeus_ops::add_assign(gl, &grad_a, backend);
+                coeus_ops::add_assign(gl, &grad_a, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_a, a.shape());
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
@@ -166,12 +169,13 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
             let grad_b_pos = coeus_ops::div(&coeus_ops::mul(grad_out, a, backend), &b_sq, backend);
             let gl = g.write();
             if grad_b_pos.shape() == b.shape() {
-                coeus_ops::sub_assign(gl, &grad_b_pos, backend);
+                coeus_ops::sub_assign(gl, &grad_b_pos, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_b_pos, b.shape());
-                coeus_ops::sub_assign(gl, &reduced, backend);
+                coeus_ops::sub_assign(gl, &reduced, backend)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -205,15 +209,15 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
         _b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    ) {
+    ) -> Result<(), B::Error> {
         // ∂/∂a = 1: identity passthrough (broadcast-reduced to a's shape).
         if let Some(Some(ref g)) = input_grads.get(0) {
             let gl = g.write();
             if grad_out.shape() == a.shape() {
-                coeus_ops::add_assign(gl, grad_out, backend);
+                coeus_ops::add_assign(gl, grad_out, backend)?;
             } else {
                 let reduced = reduce_broadcast(grad_out.clone(), a.shape());
-                coeus_ops::add_assign(gl, &reduced, backend);
+                coeus_ops::add_assign(gl, &reduced, backend)?;
             }
         }
         // ∂/∂b = −floor(a / b): subtract grad_out · q (broadcast-reduced to b).
@@ -222,12 +226,13 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
             let prod = coeus_ops::mul(grad_out, &q, backend);
             let gl = g.write();
             if prod.shape() == b.shape() {
-                coeus_ops::sub_assign(gl, &prod, backend);
+                coeus_ops::sub_assign(gl, &prod, backend)?;
             } else {
                 let reduced = reduce_broadcast(prod, b.shape());
-                coeus_ops::sub_assign(gl, &reduced, backend);
+                coeus_ops::sub_assign(gl, &reduced, backend)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -248,7 +253,7 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
 /// let y = coeus_autograd::add(&a, &b);
 /// assert!((y.tensor.as_slice()[0] - 5.0).abs() < 1e-5);
 /// let loss = coeus_autograd::sum(&y);
-/// loss.backward();
+/// loss.backward().expect("invariant: valid autograd fixture completes backward");
 /// let ga = a.grad().unwrap();
 /// assert!((ga.as_slice()[0] - 1.0).abs() < 1e-5);
 /// assert!((ga.as_slice()[1] - 1.0).abs() < 1e-5);
@@ -289,7 +294,7 @@ pub fn sub<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
 /// let y = coeus_autograd::mul(&a, &b);
 /// assert!((y.tensor.as_slice()[0] - 4.0).abs() < 1e-5);
 /// let loss = coeus_autograd::sum(&y);
-/// loss.backward();
+/// loss.backward().expect("invariant: valid autograd fixture completes backward");
 /// let ga = a.grad().unwrap();
 /// assert!((ga.as_slice()[0] - 4.0).abs() < 1e-5); // da = b
 /// assert!((ga.as_slice()[1] - 5.0).abs() < 1e-5);
@@ -401,7 +406,7 @@ pub fn ge<T: Scalar, B: coeus_ops::BackendOps<T> + Default>(
 /// let b = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([1], &[-3.0]), true);
 /// let r = remainder(&a, &b);
 /// assert!((r.tensor.as_slice()[0] - (-2.0)).abs() < 1e-12);
-/// sum(&r).backward();
+/// sum(&r).backward().expect("invariant: valid autograd fixture completes backward");
 /// assert!((a.grad().unwrap().as_slice()[0] - 1.0).abs() < 1e-12);
 /// assert!((b.grad().unwrap().as_slice()[0] - 3.0).abs() < 1e-12);
 /// ```

--- a/crates/coeus-autograd/src/ops/arithmetic/reduction.rs
+++ b/crates/coeus-autograd/src/ops/arithmetic/reduction.rs
@@ -196,7 +196,8 @@ mod nan_reduction_tests {
         let s = nansum(&x);
         let v = s.tensor.as_slice()[0];
         assert!((v - 9.0).abs() < 1e-10, "nansum: expected 9, got {v}");
-        s.backward();
+        s.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert_eq!(
             x.grad().unwrap().as_slice(),
             &[1.0, 0.0, 1.0, 0.0, 1.0],
@@ -219,7 +220,8 @@ mod nan_reduction_tests {
         let m = nanmean(&x);
         let v = m.tensor.as_slice()[0];
         assert!((v - 4.0).abs() < 1e-10, "nanmean: expected 4.0, got {v}");
-        m.backward();
+        m.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         let grad = x.grad().unwrap();
         let expected = [1.0 / 3.0, 0.0, 1.0 / 3.0, 0.0, 1.0 / 3.0];
         for (i, (&actual, &expected)) in grad.as_slice().iter().zip(expected.iter()).enumerate() {

--- a/crates/coeus-autograd/src/ops/arithmetic/traits.rs
+++ b/crates/coeus-autograd/src/ops/arithmetic/traits.rs
@@ -22,7 +22,7 @@ pub trait BinaryAutogradOp<T: Scalar, B: coeus_ops::BackendOps<T> + Default>: Se
         b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    );
+    ) -> Result<(), B::Error>;
 }
 
 /// Autograd node for a generic binary operation.
@@ -63,7 +63,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default, Op: BinaryAutogradOp<T, B
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         Op::backward(
             grad_out,
@@ -73,7 +77,7 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default, Op: BinaryAutogradOp<T, B
             &self.b_shape,
             input_grads,
             &backend,
-        );
+        )
     }
 }
 
@@ -179,7 +183,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default, Op: ReductionAutogradOp<T
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let grad_to_broadcast = if let Some(ref scaler) = self.scaler_tensor {
@@ -189,8 +197,9 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default, Op: ReductionAutogradOp<T
             };
             let broadcasted = grad_to_broadcast.broadcast(self.a_shape.clone());
             let gl = g.write();
-            coeus_ops::add_assign(gl, &broadcasted, &backend);
+            coeus_ops::add_assign(gl, &broadcasted, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/embedding.rs
+++ b/crates/coeus-autograd/src/ops/embedding.rs
@@ -42,7 +42,11 @@ where
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref gw)) = input_grads.get(0) {
             let gw_update = coeus_ops::embedding_backward_with_padding_idx(
@@ -53,8 +57,9 @@ where
                 &backend,
             );
             let gl = gw.write();
-            coeus_ops::add_assign(gl, &gw_update, &backend);
+            coeus_ops::add_assign(gl, &gw_update, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/interpolation.rs
+++ b/crates/coeus-autograd/src/ops/interpolation.rs
@@ -45,21 +45,31 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<f32, B>, input_grads: &[Option<Arc<GradBuffer<f32, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<f32, B>,
+        input_grads: &[Option<Arc<GradBuffer<f32, B>>>],
+    ) -> Result<(), B::Error> {
         let updates = linear_interpolation_backward::<D, _, P>(
             &self.image,
             &self.grid,
             grad_out,
             P::default(),
         )
-        .expect("invariant: forward validation fixes backward shapes");
+        .map_err(|error| {
+            B::Error::from(coeus_core::BackendError::Storage {
+                operation: "linear_interpolation_backward",
+                reason: error.to_string(),
+            })
+        })?;
         let backend = B::default();
         if let Some(Some(gradient)) = input_grads.first() {
-            coeus_ops::add_assign(gradient.write(), &updates.image, &backend);
+            coeus_ops::add_assign(gradient.write(), &updates.image, &backend)?;
         }
         if let Some(Some(gradient)) = input_grads.get(1) {
-            coeus_ops::add_assign(gradient.write(), &updates.grid, &backend);
+            coeus_ops::add_assign(gradient.write(), &updates.grid, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -454,15 +464,20 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<f32, B>, input_grads: &[Option<Arc<GradBuffer<f32, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<f32, B>,
+        input_grads: &[Option<Arc<GradBuffer<f32, B>>>],
+    ) -> Result<(), B::Error> {
         let (input_grad, grid_grad) = grid_sample_3d_backward(&self.input, &self.grid, grad_out);
         let backend = B::default();
         if let Some(Some(gradient)) = input_grads.first() {
-            coeus_ops::add_assign(gradient.write(), &input_grad, &backend);
+            coeus_ops::add_assign(gradient.write(), &input_grad, &backend)?;
         }
         if let Some(Some(gradient)) = input_grads.get(1) {
-            coeus_ops::add_assign(gradient.write(), &grid_grad, &backend);
+            coeus_ops::add_assign(gradient.write(), &grid_grad, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/linalg.rs
+++ b/crates/coeus-autograd/src/ops/linalg.rs
@@ -47,7 +47,7 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
         _b_shape: &Shape,
         input_grads: &[Option<Arc<GradBuffer<T, B>>>],
         backend: &B,
-    ) {
+    ) -> Result<(), B::Error> {
         // Batched B ([…,k,n], bmm): per-batch transposes of the last two axes.
         // The permuted view is materialized contiguous because the batched
         // matmul kernels derive strides from shape (they do not honor view
@@ -63,22 +63,22 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
             if let Some(Some(ref g)) = input_grads.get(0) {
                 let b_t = swap_last_two(b, backend);
                 let gl = g.write();
-                coeus_ops::matmul_accumulate(grad_out, &b_t, gl, backend).expect("matmul_accumulate");
+                coeus_ops::matmul_accumulate(grad_out, &b_t, gl, backend)?;
             }
             // ∂/∂B: A^T @ grad_C — [batch,k,m] × [batch,m,n] → [batch,k,n]
             if let Some(Some(ref g)) = input_grads.get(1) {
                 let a_t = swap_last_two(a, backend);
                 let gl = g.write();
-                coeus_ops::matmul_accumulate(&a_t, grad_out, gl, backend).expect("matmul_accumulate");
+                coeus_ops::matmul_accumulate(&a_t, grad_out, gl, backend)?;
             }
-            return;
+            return Ok(());
         }
 
         // ∂/∂A: grad_C @ B^T — grad_C may be batched ([batch,m,n] × [n,k] → [batch,m,k])
         if let Some(Some(ref g)) = input_grads.get(0) {
             let b_t = b.t(); // B is 2-D on this path; b.t() is a stride view.
             let gl = g.write();
-            coeus_ops::matmul_accumulate(grad_out, &b_t, gl, backend).expect("matmul_accumulate");
+            coeus_ops::matmul_accumulate(grad_out, &b_t, gl, backend)?;
         }
         // ∂/∂B: A^T @ grad_C
         // When A is batched ([…,m,k]), flatten to [batch*m, k] to perform 2D matmul.
@@ -100,8 +100,9 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BinaryAutogradOp<T, B> fo
             };
             let a_flat_t = a_flat.t();
             let gl = g.write();
-            coeus_ops::matmul_accumulate(&a_flat_t, &go_flat, gl, backend).expect("matmul_accumulate");
+            coeus_ops::matmul_accumulate(&a_flat_t, &go_flat, gl, backend)?;
         }
+        Ok(())
     }
 }
 
@@ -159,7 +160,7 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> UnaryAutogradOp<T, B> for
 /// let b = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([2, 1], &[3.0, 4.0]), true);
 /// let c = coeus_autograd::matmul(&a, &b);
 /// assert!((c.tensor.as_slice()[0] - 11.0).abs() < 1e-5); // 1*3 + 2*4
-/// c.backward(); // scalar output, seed = 1
+/// c.backward().expect("invariant: valid autograd fixture completes backward"); // scalar output, seed = 1
 /// let ga = a.grad().unwrap();
 /// assert!((ga.as_slice()[0] - 3.0).abs() < 1e-5); // dA = B^T
 /// assert!((ga.as_slice()[1] - 4.0).abs() < 1e-5);
@@ -243,7 +244,11 @@ where
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         // ∂/∂A_values
         if let Some(Some(ref g)) = input_grads.get(0) {
@@ -256,7 +261,7 @@ where
                 &backend,
             );
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_a_vals, &backend);
+            coeus_ops::add_assign(gl, &grad_a_vals, &backend)?;
         }
         // ∂/∂B
         if let Some(Some(ref g)) = input_grads.get(1) {
@@ -269,8 +274,9 @@ where
                 &backend,
             );
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_b, &backend);
+            coeus_ops::add_assign(gl, &grad_b, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -296,7 +302,11 @@ where
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         // ∂/∂A_values (COO values order)
         if let Some(Some(ref g)) = input_grads.first() {
@@ -319,7 +329,7 @@ where
                 grad_coo_slice[orig] += grad_sorted_slice[i];
             }
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_coo, &backend);
+            coeus_ops::add_assign(gl, &grad_coo, &backend)?;
         }
         // ∂/∂B
         if let Some(Some(ref g)) = input_grads.get(1) {
@@ -332,8 +342,9 @@ where
                 &backend,
             );
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_b, &backend);
+            coeus_ops::add_assign(gl, &grad_b, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/attention.rs
+++ b/crates/coeus-autograd/src/ops/nn/attention.rs
@@ -81,7 +81,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, M: AttentionMask> Backward
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
 
         let need_gq = input_grads.first().and_then(|g| g.as_ref()).is_some();
@@ -89,7 +93,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, M: AttentionMask> Backward
         let need_gv = input_grads.get(2).and_then(|g| g.as_ref()).is_some();
 
         if !need_gq && !need_gk && !need_gv {
-            return;
+            return Ok(());
         }
 
         let mut grad_q = need_gq.then(|| Tensor::zeros_on(self.q_clone.shape_cloned(), &backend));
@@ -112,16 +116,18 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, M: AttentionMask> Backward
 
         if let (Some(acc), Some(gq)) = (input_grads.first().and_then(|g| g.as_ref()), grad_q) {
             let lock = acc.write();
-            coeus_ops::add_assign(lock, &gq, &backend);
+            coeus_ops::add_assign(lock, &gq, &backend)?;
         }
         if let (Some(acc), Some(gk)) = (input_grads.get(1).and_then(|g| g.as_ref()), grad_k) {
             let lock = acc.write();
-            coeus_ops::add_assign(lock, &gk, &backend);
+            coeus_ops::add_assign(lock, &gk, &backend)?;
         }
         if let (Some(acc), Some(gv)) = (input_grads.get(2).and_then(|g| g.as_ref()), grad_v) {
             let lock = acc.write();
-            coeus_ops::add_assign(lock, &gv, &backend);
+            coeus_ops::add_assign(lock, &gv, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/conv/transpose.rs
+++ b/crates/coeus-autograd/src/ops/nn/conv/transpose.rs
@@ -45,14 +45,18 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let needs_grad_input = input_grads.get(0).and_then(|g| g.as_ref()).is_some();
         let needs_grad_weight = input_grads.get(1).and_then(|g| g.as_ref()).is_some();
         let needs_grad_bias =
             self.has_bias && input_grads.get(2).and_then(|g| g.as_ref()).is_some();
 
         if !needs_grad_input && !needs_grad_weight && !needs_grad_bias {
-            return;
+            return Ok(());
         }
 
         let backend = B::default();
@@ -157,6 +161,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
                 &backend,
             );
         }
+
+        Ok(())
     }
 }
 
@@ -275,14 +281,18 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let needs_grad_input = input_grads.get(0).and_then(|g| g.as_ref()).is_some();
         let needs_grad_weight = input_grads.get(1).and_then(|g| g.as_ref()).is_some();
         let needs_grad_bias =
             self.has_bias && input_grads.get(2).and_then(|g| g.as_ref()).is_some();
 
         if !needs_grad_input && !needs_grad_weight && !needs_grad_bias {
-            return;
+            return Ok(());
         }
 
         let backend = B::default();
@@ -393,6 +403,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             scatter_accumulate_into(input_grads[2].as_ref().unwrap().write(), &gb, &backend);
         }
+
+        Ok(())
     }
 }
 
@@ -516,14 +528,18 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + coeus_ops::CpuBackend + Default> Ba
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let needs_grad_input = input_grads.get(0).and_then(|g| g.as_ref()).is_some();
         let needs_grad_weight = input_grads.get(1).and_then(|g| g.as_ref()).is_some();
         let needs_grad_bias =
             self.has_bias && input_grads.get(2).and_then(|g| g.as_ref()).is_some();
 
         if !needs_grad_input && !needs_grad_weight && !needs_grad_bias {
-            return;
+            return Ok(());
         }
 
         let backend = B::default();
@@ -668,6 +684,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + coeus_ops::CpuBackend + Default> Ba
             }
             scatter_accumulate_into(input_grads[2].as_ref().unwrap().write(), &gb, &backend);
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/conv/unfold_fold.rs
+++ b/crates/coeus-autograd/src/ops/nn/conv/unfold_fold.rs
@@ -37,7 +37,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Un
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // col2im: fold the windowed gradient back onto the input positions.
@@ -50,8 +54,10 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Un
                 self.dilation,
                 &backend,
             );
-            coeus_ops::add_assign(g.write(), &d_input, &backend);
+            coeus_ops::add_assign(g.write(), &d_input, &backend)?;
         }
+
+        Ok(())
     }
 }
 
@@ -135,7 +141,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Un
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let d_input = coeus_ops::fold2d(
@@ -152,8 +162,10 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Un
                 self.dilation_w,
                 &backend,
             );
-            coeus_ops::add_assign(g.write(), &d_input, &backend);
+            coeus_ops::add_assign(g.write(), &d_input, &backend)?;
         }
+
+        Ok(())
     }
 }
 
@@ -239,7 +251,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Fo
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // Adjoint of col2im is im2col over the output-shaped gradient.
@@ -251,8 +267,10 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Fo
                 self.dilation,
                 &backend,
             );
-            coeus_ops::add_assign(g.write(), &d_input, &backend);
+            coeus_ops::add_assign(g.write(), &d_input, &backend)?;
         }
+
+        Ok(())
     }
 }
 
@@ -328,7 +346,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Fo
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let d_input = coeus_ops::unfold2d(
@@ -343,8 +365,10 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Fo
                 self.dilation_w,
                 &backend,
             );
-            coeus_ops::add_assign(g.write(), &d_input, &backend);
+            coeus_ops::add_assign(g.write(), &d_input, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/conv/utils.rs
+++ b/crates/coeus-autograd/src/ops/nn/conv/utils.rs
@@ -168,7 +168,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
 
         let mut grad_input = if input_grads.get(0).and_then(|g| g.as_ref()).is_some() {
@@ -230,16 +234,18 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
 
         if let Some(gi) = grad_input {
             let gl = input_grads[0].as_ref().unwrap().write();
-            coeus_ops::add_assign(gl, &gi, &backend);
+            coeus_ops::add_assign(gl, &gi, &backend)?;
         }
         if let Some(gw) = grad_weight {
             let gl = input_grads[1].as_ref().unwrap().write();
-            coeus_ops::add_assign(gl, &gw, &backend);
+            coeus_ops::add_assign(gl, &gw, &backend)?;
         }
         if let Some(gb) = grad_bias {
             let gl = input_grads[2].as_ref().unwrap().write();
-            coeus_ops::add_assign(gl, &gb, &backend);
+            coeus_ops::add_assign(gl, &gb, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/dropout.rs
+++ b/crates/coeus-autograd/src/ops/nn/dropout.rs
@@ -1,4 +1,4 @@
-﻿use crate::grad_buffer::GradBuffer;
+use crate::grad_buffer::GradBuffer;
 use crate::node::BackwardNode;
 use crate::var::Var;
 use coeus_core::{Float, Scalar};
@@ -64,13 +64,19 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Dro
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let prod = coeus_ops::mul(grad_out, &self.mask, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &prod, &backend);
+            coeus_ops::add_assign(gl, &prod, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/log_softmax.rs
+++ b/crates/coeus-autograd/src/ops/nn/log_softmax.rs
@@ -52,21 +52,26 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Log
     //   sum_g  = sum_axis(g, axis)          — shape matches probs after broadcasting
     //   scaled = mul(probs, sum_g)           — element-wise, broadcasts sum_g along axis
     //   dx     = sub(g, scaled)              — element-wise
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let Some(Some(ref acc)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
         let backend = B::default();
         // Σ_j g_j along axis; result shape has axis dimension reduced (broadcast-compatible)
-        let sum_g = coeus_ops::sum_axis(grad_out, self.axis, &backend)
-            .expect("invariant: log_softmax backward axis matches the saved input rank");
+        let sum_g = coeus_ops::sum_axis(grad_out, self.axis, &backend)?;
         // p_i · Σ_j g_j
         let scaled = coeus_ops::mul(&self.probs, &sum_g, &backend);
         // g_i − p_i · Σ_j g_j
         let dx = coeus_ops::sub(grad_out, &scaled, &backend);
 
         let lock = acc.write();
-        coeus_ops::add_assign(lock, &dx, &backend);
+        coeus_ops::add_assign(lock, &dx, &backend)?;
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/bce.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/bce.rs
@@ -32,7 +32,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let mut host_grad = [T::zero()];
@@ -59,8 +63,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on([self.n], &d_pred, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/bce_with_logits.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/bce_with_logits.rs
@@ -46,7 +46,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let mut host_grad = [T::zero()];
         let temp_grad;
@@ -69,7 +73,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_logit, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
 
         // d/d_target = -z / n.
@@ -80,8 +84,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/cosine.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/cosine.rs
@@ -41,12 +41,16 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let need_g1 = input_grads.get(0).and_then(|g| g.as_ref()).is_some();
         let need_g2 = input_grads.get(1).and_then(|g| g.as_ref()).is_some();
         if !need_g1 && !need_g2 {
-            return;
+            return Ok(());
         }
 
         let mut host_grad = [T::zero()];
@@ -118,13 +122,15 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         if let Some(Some(ref g)) = input_grads.get(0) {
             let grad_tensor = Tensor::from_slice_on([self.n, self.d], &dg1, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let grad_tensor = Tensor::from_slice_on([self.n, self.d], &dg2, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/cosine_similarity.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/cosine_similarity.rs
@@ -54,7 +54,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let temp_grad;
         let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
@@ -69,7 +73,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         let want_x1 = matches!(input_grads.first(), Some(Some(_)));
         let want_x2 = matches!(input_grads.get(1), Some(Some(_)));
         if !want_x1 && !want_x2 {
-            return;
+            return Ok(());
         }
 
         // d/d_x1: grad_unit_x1[n,k] (already computed at forward time).
@@ -87,7 +91,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         if let Some(Some(ref g)) = input_grads.first() {
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx1, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let mut dx2 = vec![T::zero(); self.rows * self.feat];
@@ -100,8 +104,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx2, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/cross_entropy.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/cross_entropy.rs
@@ -40,7 +40,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let temp_grad;
@@ -69,8 +73,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on([self.n, self.c], &d_logits, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/ctc.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/ctc.rs
@@ -69,10 +69,14 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Ctc
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.get(0) else {
-            return;
+            return Ok(());
         };
 
         let t = self.t_steps;
@@ -147,7 +151,9 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Ctc
         let dx_t: Vec<T> = dx.iter().map(|&v| T::from_f64(v)).collect();
         let grad_tensor = Tensor::from_slice_on([t, n, c], &dx_t, &backend);
         let gl = g.write();
-        coeus_ops::add_assign(gl, &grad_tensor, &backend);
+        coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/huber.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/huber.rs
@@ -39,7 +39,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Hub
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let mut host_grad = [T::zero()];
@@ -83,8 +87,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Hub
             }
             let grad_tensor = Tensor::from_slice_on([self.n], &d_pred, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/kl_div.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/kl_div.rs
@@ -34,7 +34,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for KlD
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let mut host_grad = [T::zero()];
@@ -57,8 +61,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for KlD
             }
             let grad_tensor = Tensor::from_slice_on(self.input_shape.clone(), &d_input, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/l1.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/l1.rs
@@ -30,7 +30,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for L1L
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let mut host_grad = [T::zero()];
         let temp_grad;
@@ -63,7 +67,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for L1L
         if let Some(Some(ref g)) = input_grads.first() {
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_pred, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
 
         if let Some(Some(ref g)) = input_grads.get(1) {
@@ -73,8 +77,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for L1L
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/margin_ranking.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/margin_ranking.rs
@@ -36,7 +36,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let mut host_grad = [T::zero()];
         let temp_grad;
@@ -60,7 +64,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on([self.n], &d1, &backend);
             let gl = g1.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
         if let Some(Some(ref g2)) = input_grads.get(1) {
             let mut d2 = vec![T::zero(); self.n];
@@ -69,8 +73,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on([self.n], &d2, &backend);
             let gl = g2.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/multi_label_margin.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/multi_label_margin.rs
@@ -39,7 +39,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let mut host_grad = [T::zero()];
         let temp_grad;
@@ -79,8 +83,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on([self.n, self.c], &dx, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/multi_margin.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/multi_margin.rs
@@ -30,7 +30,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Mul
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let mut host_grad = [T::zero()];
@@ -50,8 +54,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Mul
             }
             let grad_tensor = Tensor::from_slice_on([self.n, self.c], &d_x, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/nll.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/nll.rs
@@ -30,7 +30,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Nll
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.get(0) {
             let mut host_grad = [T::zero()];
@@ -53,8 +57,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Nll
             }
             let grad_tensor = Tensor::from_slice_on([self.n, self.c], &d_log, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs
@@ -34,7 +34,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let temp_grad;
         let grad_cont = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
@@ -49,7 +53,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         let want_x1 = matches!(input_grads.first(), Some(Some(_)));
         let want_x2 = matches!(input_grads.get(1), Some(Some(_)));
         if !want_x1 && !want_x2 {
-            return;
+            return Ok(());
         }
 
         let mut dx1 = vec![T::zero(); self.rows * self.feat];
@@ -64,7 +68,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         if let Some(Some(ref g)) = input_grads.first() {
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx1, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let mut dx2 = dx1;
@@ -73,8 +77,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &dx2, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/poisson_nll.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/poisson_nll.rs
@@ -32,7 +32,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Poi
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let mut host_grad = [T::zero()];
         let temp_grad;
@@ -55,7 +59,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Poi
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_input, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
 
         // d/d_target = -input / n.
@@ -66,8 +70,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Poi
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/smooth_l1.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/smooth_l1.rs
@@ -52,7 +52,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let grad_cont;
         let grad_src = if grad_out.is_contiguous() && grad_out.layout().offset() == 0 {
@@ -90,7 +94,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
         if let Some(Some(ref g)) = input_grads.first() {
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_pred, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
         if let Some(Some(ref g)) = input_grads.get(1) {
             let mut d_target = d_pred;
@@ -99,8 +103,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d_target, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/loss/soft_margin.rs
+++ b/crates/coeus-autograd/src/ops/nn/loss/soft_margin.rs
@@ -44,7 +44,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sof
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let mut host_grad = [T::zero()];
         let temp_grad;
@@ -66,7 +70,7 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sof
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
 
         if let Some(Some(ref g)) = input_grads.get(1) {
@@ -76,8 +80,10 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sof
             }
             let grad_tensor = Tensor::from_slice_on(self.shape.clone(), &d, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_tensor, &backend);
+            coeus_ops::add_assign(gl, &grad_tensor, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/masked_softmax.rs
+++ b/crates/coeus-autograd/src/ops/nn/masked_softmax.rs
@@ -44,10 +44,16 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B>
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref g_in)) = input_grads.get(0) {
-            accumulate_softmax_grad(grad_out, &self.y_clone, self.dim_u, g_in);
+            accumulate_softmax_grad(grad_out, &self.y_clone, self.dim_u, g_in)?;
         }
+
+        Ok(())
     }
 }
 
@@ -110,7 +116,8 @@ where
 {
     let dim_u = normalize_dim(dim, input.tensor.ndim(), "masked_softmax");
     let backend = B::default();
-    let y_t = coeus_ops::masked_softmax(&input.tensor, mask, dim_u, &backend).expect("masked_softmax");
+    let y_t =
+        coeus_ops::masked_softmax(&input.tensor, mask, dim_u, &backend).expect("masked_softmax");
     build_var(input, y_t, dim_u, "masked_softmax")
 }
 
@@ -156,7 +163,8 @@ mod tests {
         );
 
         // Seed grad_out=[1,0,0]: dx_k = y_k*(g_k - sum_j y_j g_j), sum = y0.
-        out.backward_with_seed(Tensor::from_slice([1, 3], &[1.0, 0.0, 0.0]));
+        out.backward_with_seed(Tensor::from_slice([1, 3], &[1.0, 0.0, 0.0]))
+            .expect("invariant: valid autograd fixture completes backward");
         let g = input.grad().unwrap();
         let gs = g.as_slice();
         assert!((gs[0] - y0 * (1.0 - y0)).abs() < 1e-12, "dx0: {}", gs[0]);
@@ -178,7 +186,8 @@ mod tests {
         for &v in out.tensor.as_slice() {
             assert_eq!(v, 0.0, "all-masked output must be 0");
         }
-        out.backward();
+        out.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         for &v in input.grad().unwrap().as_slice() {
             assert!(
                 v.is_finite() && v == 0.0,
@@ -200,7 +209,8 @@ mod tests {
         assert!((y[2] - e3 / (e3 + e4)).abs() < 1e-12, "causal row1 col0");
         assert!((y[3] - e4 / (e3 + e4)).abs() < 1e-12, "causal row1 col1");
 
-        out.backward();
+        out.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert!(input
             .grad()
             .unwrap()

--- a/crates/coeus-autograd/src/ops/nn/normalization/batchnorm/bn_nd.rs
+++ b/crates/coeus-autograd/src/ops/nn/normalization/batchnorm/bn_nd.rs
@@ -1,4 +1,4 @@
-﻿use crate::grad_buffer::GradBuffer;
+use crate::grad_buffer::GradBuffer;
 use crate::node::BackwardNode;
 use crate::var::Var;
 use coeus_core::{Float, Scalar};
@@ -119,7 +119,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
 
         let go_nhwc = bn_permute_to_nhwc::<T, B, DIM>(grad_out, &backend); // [N, ..., C]
@@ -127,58 +131,56 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
 
         // ── dL/dbeta = sum(dy, dim=0) [C] ──
         if let Some(Some(ref gb)) = input_grads.get(2) {
-            let db_t = coeus_ops::sum_axis(&go_flat, 0, &backend)
-                .expect("invariant: batchnorm beta gradient axis is valid"); // [1, C]
+            let db_t = coeus_ops::sum_axis(&go_flat, 0, &backend)?; // [1, C]
             let db = db_t.reshape([self.c]);
             let gl = gb.write();
-            coeus_ops::add_assign(gl, &db, &backend);
+            coeus_ops::add_assign(gl, &db, &backend)?;
         }
 
         // ── dL/dgamma = sum(dy * x_hat, dim=0) [C] ──
         if let Some(Some(ref gw_var)) = input_grads.get(1) {
             let dy_xhat = coeus_ops::mul(&go_flat, &self.x_hat_clone, &backend);
-            let dg_t = coeus_ops::sum_axis(&dy_xhat, 0, &backend)
-                .expect("invariant: batchnorm gamma gradient axis is valid"); // [1, C]
+            let dg_t = coeus_ops::sum_axis(&dy_xhat, 0, &backend)?; // [1, C]
             let dg = dg_t.reshape([self.c]);
             let gl = gw_var.write();
-            coeus_ops::add_assign(gl, &dg, &backend);
+            coeus_ops::add_assign(gl, &dg, &backend)?;
         }
 
         // ── dL/dx ──
         if let Some(Some(ref gx)) = input_grads.get(0) {
             let dxhat = coeus_ops::mul(&go_flat, &self.w_reshaped_captured, &backend); // [M, C]
-            let sum_dxhat = coeus_ops::sum_axis(&dxhat, 0, &backend)
-                .expect("invariant: batchnorm backward axis is valid"); // [1, C]
+            let sum_dxhat = coeus_ops::sum_axis(&dxhat, 0, &backend)?; // [1, C]
             let dxhat_xmu = coeus_ops::mul(&dxhat, &self.xmu_clone, &backend);
-            let sum_dxhat_xmu = coeus_ops::sum_axis(&dxhat_xmu, 0, &backend)
-                .expect("invariant: batchnorm backward axis is valid"); // [1, C]
+            let sum_dxhat_xmu = coeus_ops::sum_axis(&dxhat_xmu, 0, &backend)?; // [1, C]
 
             let mut istdev_cube = coeus_ops::mul(&self.istdev_clone, &self.istdev_clone, &backend);
-            coeus_ops::mul_assign(&mut istdev_cube, &self.istdev_clone, &backend);
+            coeus_ops::mul_assign(&mut istdev_cube, &self.istdev_clone, &backend)?;
 
-            coeus_ops::mul_assign(&mut istdev_cube, &self.minus_half, &backend);
+            coeus_ops::mul_assign(&mut istdev_cube, &self.minus_half, &backend)?;
             let dvar_scale = istdev_cube; // [1, C]
 
             let mut term3 = coeus_ops::mul(&self.istdev_clone, &sum_dxhat, &backend); // [1, C]
-            coeus_ops::div_assign(&mut term3, &self.m_const_captured, &backend); // [1, C]
+            coeus_ops::div_assign(&mut term3, &self.m_const_captured, &backend)?; // [1, C]
 
             let mut dvar_part = coeus_ops::mul(&dvar_scale, &sum_dxhat_xmu, &backend); // [1, C]
-            coeus_ops::mul_assign(&mut dvar_part, &self.two_const, &backend);
-            coeus_ops::div_assign(&mut dvar_part, &self.m_const_captured, &backend); // [1, C]
+            coeus_ops::mul_assign(&mut dvar_part, &self.two_const, &backend)?;
+            coeus_ops::div_assign(&mut dvar_part, &self.m_const_captured, &backend)?; // [1, C]
 
             let term2 = coeus_ops::mul(&self.xmu_clone, &dvar_part, &backend); // [M, C]
 
             let mut term1 = coeus_ops::mul(&dxhat, &self.istdev_clone, &backend); // [M, C]
-            coeus_ops::add_assign(&mut term1, &term2, &backend);
-            coeus_ops::sub_assign(&mut term1, &term3, &backend);
+            coeus_ops::add_assign(&mut term1, &term2, &backend)?;
+            coeus_ops::sub_assign(&mut term1, &term3, &backend)?;
             let dx_flat = term1; // [M, C]
 
             let dx_nhwc = bn_reshape_from_flat::<T, B, DIM>(dx_flat, self.n, &self.spatial, self.c);
             let dx_nchw = bn_permute_from_nhwc::<T, B, DIM>(&dx_nhwc, &backend);
 
             let gl = gx.write();
-            coeus_ops::add_assign(gl, &dx_nchw, &backend);
+            coeus_ops::add_assign(gl, &dx_nchw, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/normalization/layernorm.rs
+++ b/crates/coeus-autograd/src/ops/nn/normalization/layernorm.rs
@@ -1,4 +1,4 @@
-﻿use crate::grad_buffer::GradBuffer;
+use crate::grad_buffer::GradBuffer;
 use crate::node::BackwardNode;
 use crate::var::Var;
 use coeus_core::{Float, Scalar};
@@ -40,7 +40,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Lay
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let dy = grad_out; // [N, D]
         let mut dy_w = coeus_ops::mul(dy, &self.w_reshaped_captured, &backend);
@@ -49,49 +53,47 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Lay
                 &coeus_ops::mul(dy, &self.x_hat_clone, &backend),
                 0,
                 &backend,
-            )
-            .expect("invariant: layernorm gamma gradient axis is valid");
+            )?;
             let dg = dg_t.reshape([self.d]);
             let gl = gw.write();
-            coeus_ops::add_assign(gl, &dg, &backend);
+            coeus_ops::add_assign(gl, &dg, &backend)?;
         }
 
         // ── dL/dbeta = sum(dy, dim=0) [D] ──
         if let Some(Some(ref gb)) = input_grads.get(2) {
-            let db_t = coeus_ops::sum_axis(dy, 0, &backend)
-                .expect("invariant: layernorm beta gradient axis is valid");
+            let db_t = coeus_ops::sum_axis(dy, 0, &backend)?;
             let db = db_t.reshape([self.d]);
             let gl = gb.write();
-            coeus_ops::add_assign(gl, &db, &backend);
+            coeus_ops::add_assign(gl, &db, &backend)?;
         }
 
         // ── dL/dx ──
         if let Some(Some(ref gx)) = input_grads.get(0) {
-            let sum_dy_w = coeus_ops::sum_axis(&dy_w, 1, &backend)
-                .expect("invariant: layernorm backward axis is valid"); // [N, 1]
+            let sum_dy_w = coeus_ops::sum_axis(&dy_w, 1, &backend)?; // [N, 1]
             let dy_w_xhat = coeus_ops::mul(&dy_w, &self.x_hat_clone, &backend); // [N, D]
-            let sum_dy_w_xhat = coeus_ops::sum_axis(&dy_w_xhat, 1, &backend)
-                .expect("invariant: layernorm backward axis is valid"); // [N, 1]
+            let sum_dy_w_xhat = coeus_ops::sum_axis(&dy_w_xhat, 1, &backend)?; // [N, 1]
 
             // term2 = x_hat * sum_dy_w_xhat + sum_dy_w
             let mut term2 = coeus_ops::mul(&self.x_hat_clone, &sum_dy_w_xhat, &backend); // [N, D]
-            coeus_ops::add_assign(&mut term2, &sum_dy_w, &backend);
+            coeus_ops::add_assign(&mut term2, &sum_dy_w, &backend)?;
 
             // dy_w = dy_w * d_const
-            coeus_ops::mul_assign(&mut dy_w, &self.d_const, &backend);
+            coeus_ops::mul_assign(&mut dy_w, &self.d_const, &backend)?;
 
             // term = dy_w - term2
-            coeus_ops::sub_assign(&mut dy_w, &term2, &backend);
+            coeus_ops::sub_assign(&mut dy_w, &term2, &backend)?;
             let mut term = dy_w;
 
             // dx = term * istdev_clone / d_const
-            coeus_ops::mul_assign(&mut term, &self.istdev_clone, &backend);
-            coeus_ops::div_assign(&mut term, &self.d_const, &backend);
+            coeus_ops::mul_assign(&mut term, &self.istdev_clone, &backend)?;
+            coeus_ops::div_assign(&mut term, &self.d_const, &backend)?;
             let dx = term;
 
             let gl = gx.write();
-            coeus_ops::add_assign(gl, &dx, &backend);
+            coeus_ops::add_assign(gl, &dx, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/normalization/rmsnorm.rs
+++ b/crates/coeus-autograd/src/ops/nn/normalization/rmsnorm.rs
@@ -1,4 +1,4 @@
-﻿use crate::grad_buffer::GradBuffer;
+use crate::grad_buffer::GradBuffer;
 use crate::node::BackwardNode;
 use crate::var::Var;
 use coeus_core::{Float, Scalar};
@@ -38,7 +38,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for RMS
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let dy = grad_out; // [N, D]
 
@@ -48,29 +52,29 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for RMS
                 &coeus_ops::mul(dy, &self.x_hat_clone, &backend),
                 0,
                 &backend,
-            )
-            .expect("invariant: rmsnorm gamma gradient axis is valid");
+            )?;
             let dg = dg_t.reshape([self.d]);
             let gl = gw.write();
-            coeus_ops::add_assign(gl, &dg, &backend);
+            coeus_ops::add_assign(gl, &dg, &backend)?;
         }
 
         // ── dL/dx ──
         if let Some(Some(ref gx)) = input_grads.get(0) {
             let mut dy_w = coeus_ops::mul(dy, &self.w_reshaped_captured, &backend); // [N, D]
             let dy_w_xhat = coeus_ops::mul(&dy_w, &self.x_hat_clone, &backend); // [N, D]
-            let scaled_sum = coeus_ops::mean_axis(&dy_w_xhat, 1, &backend)
-                .expect("invariant: rmsnorm backward axis is valid"); // [N, 1]
+            let scaled_sum = coeus_ops::mean_axis(&dy_w_xhat, 1, &backend)?; // [N, 1]
 
             let term_prod = coeus_ops::mul(&self.x_hat_clone, &scaled_sum, &backend); // [N, D]
-            coeus_ops::sub_assign(&mut dy_w, &term_prod, &backend); // [N, D]
+            coeus_ops::sub_assign(&mut dy_w, &term_prod, &backend)?; // [N, D]
 
             let mut dx = dy_w;
-            coeus_ops::div_assign(&mut dx, &self.rms_clone, &backend); // [N, D]
+            coeus_ops::div_assign(&mut dx, &self.rms_clone, &backend)?; // [N, D]
 
             let gl = gx.write();
-            coeus_ops::add_assign(gl, &dx, &backend);
+            coeus_ops::add_assign(gl, &dx, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/pool.rs
+++ b/crates/coeus-autograd/src/ops/nn/pool.rs
@@ -24,7 +24,7 @@ fn dispatch_max_pool_backward<T: Float, B: coeus_ops::BackendOps<T> + Default, c
     request: PoolBackwardInputs<'_, T, B>,
     input_storage: &B::DeviceBuffer<T>,
     input_layout: &coeus_core::Layout,
-) {
+) -> Result<(), B::Error> {
     let PoolBackwardInputs {
         backend,
         grad_out_storage,
@@ -38,56 +38,51 @@ fn dispatch_max_pool_backward<T: Float, B: coeus_ops::BackendOps<T> + Default, c
     } = request;
 
     match DIM {
-        1 => backend
-            .max_pool1d_backward(
-                grad_out_storage,
-                grad_out_layout,
-                input_storage,
-                input_layout,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                grad_input,
-                grad_input_layout,
-            )
-            .expect("invariant: validated max_pool1d backward dispatch must succeed"),
-        2 => backend
-            .max_pool2d_backward(
-                grad_out_storage,
-                grad_out_layout,
-                input_storage,
-                input_layout,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                grad_input,
-                grad_input_layout,
-            )
-            .expect("invariant: validated max_pool2d backward dispatch must succeed"),
-        3 => backend
-            .max_pool3d_backward(
-                grad_out_storage,
-                grad_out_layout,
-                input_storage,
-                input_layout,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                grad_input,
-                grad_input_layout,
-            )
-            .expect("invariant: validated max_pool3d backward dispatch must succeed"),
+        1 => backend.max_pool1d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            input_storage,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
+        2 => backend.max_pool2d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            input_storage,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
+        3 => backend.max_pool3d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            input_storage,
+            input_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
         _ => panic!("max_pool_backward: unsupported dimension {DIM}"),
-    }
+    }?;
+    Ok(())
 }
 
 #[inline]
 fn dispatch_avg_pool_backward<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize>(
     request: PoolBackwardInputs<'_, T, B>,
-) {
+) -> Result<(), B::Error> {
     let PoolBackwardInputs {
         backend,
         grad_out_storage,
@@ -101,44 +96,39 @@ fn dispatch_avg_pool_backward<T: Float, B: coeus_ops::BackendOps<T> + Default, c
     } = request;
 
     match DIM {
-        1 => backend
-            .avg_pool1d_backward(
-                grad_out_storage,
-                grad_out_layout,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                grad_input,
-                grad_input_layout,
-            )
-            .expect("invariant: validated avg_pool1d backward dispatch must succeed"),
-        2 => backend
-            .avg_pool2d_backward(
-                grad_out_storage,
-                grad_out_layout,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                grad_input,
-                grad_input_layout,
-            )
-            .expect("invariant: validated avg_pool2d backward dispatch must succeed"),
-        3 => backend
-            .avg_pool3d_backward(
-                grad_out_storage,
-                grad_out_layout,
-                kernel_size,
-                stride,
-                padding,
-                dilation,
-                grad_input,
-                grad_input_layout,
-            )
-            .expect("invariant: validated avg_pool3d backward dispatch must succeed"),
+        1 => backend.avg_pool1d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
+        2 => backend.avg_pool2d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
+        3 => backend.avg_pool3d_backward(
+            grad_out_storage,
+            grad_out_layout,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            grad_input,
+            grad_input_layout,
+        ),
         _ => panic!("avg_pool_backward: unsupported dimension {DIM}"),
-    }
+    }?;
+    Ok(())
 }
 
 // ── Max Pool ──
@@ -185,7 +175,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g_in)) = input_grads.get(0) {
             let mut grad_input = Tensor::zeros_on(self.inp_clone.shape_cloned(), &backend);
@@ -204,10 +198,12 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
                 },
                 self.inp_clone.storage(),
                 self.inp_clone.layout(),
-            );
+            )?;
             let gl = g_in.write();
-            coeus_ops::add_assign(gl, &grad_input, &backend);
+            coeus_ops::add_assign(gl, &grad_input, &backend)?;
         }
+
+        Ok(())
     }
 }
 
@@ -336,7 +332,11 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g_in)) = input_grads.get(0) {
             let mut grad_input = Tensor::zeros_on(self.inp_shape.clone(), &backend);
@@ -351,10 +351,12 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default, const DIM: usize> Backward
                 dilation: self.dilation,
                 grad_input: gi_storage,
                 grad_input_layout: gi_layout,
-            });
+            })?;
             let gl = g_in.write();
-            coeus_ops::add_assign(gl, &grad_input, &backend);
+            coeus_ops::add_assign(gl, &grad_input, &backend)?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/nn/softmax.rs
+++ b/crates/coeus-autograd/src/ops/nn/softmax.rs
@@ -34,10 +34,16 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sof
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref g_in)) = input_grads.get(0) {
-            accumulate_softmax_grad(grad_out, &self.y_clone, self.dim_u, g_in);
+            accumulate_softmax_grad(grad_out, &self.y_clone, self.dim_u, g_in)?;
         }
+
+        Ok(())
     }
 }
 
@@ -54,18 +60,19 @@ pub(crate) fn accumulate_softmax_grad<T, B>(
     y: &Tensor<T, B>,
     dim_u: usize,
     g_in: &Arc<GradBuffer<T, B>>,
-) where
+) -> Result<(), B::Error>
+where
     T: Float,
     B: coeus_ops::BackendOps<T> + Default,
 {
     let backend = B::default();
     let gy = coeus_ops::mul(grad_out, y, &backend);
-    let sum_gy = coeus_ops::sum_axis(&gy, dim_u, &backend)
-        .expect("invariant: softmax backward axis matches the input rank");
+    let sum_gy = coeus_ops::sum_axis(&gy, dim_u, &backend)?;
     let mut dx = coeus_ops::sub(grad_out, &sum_gy, &backend);
-    coeus_ops::mul_assign(&mut dx, y, &backend);
+    coeus_ops::mul_assign(&mut dx, y, &backend)?;
     let gl = g_in.write();
-    coeus_ops::add_assign(gl, &dx, &backend);
+    coeus_ops::add_assign(gl, &dx, &backend)?;
+    Ok(())
 }
 
 /// Tracked Softmax.
@@ -168,7 +175,8 @@ mod tests {
         );
         assert!((y.iter().sum::<f64>() - 1.0).abs() < 1e-12);
 
-        out.backward();
+        out.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert!(x.grad().is_some(), "softmin must be differentiable");
     }
 }

--- a/crates/coeus-autograd/src/ops/reduction/max_min.rs
+++ b/crates/coeus-autograd/src/ops/reduction/max_min.rs
@@ -49,10 +49,14 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let max_broad = self.max_tensor.broadcast(self.input_tensor.shape_cloned());
@@ -62,11 +66,9 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         let abs_diff = coeus_ops::abs(&diff, &backend);
         let shifted = coeus_ops::sub(&eps, &abs_diff, &backend);
         let mask_raw =
-            coeus_ops::elementwise_unary(&shifted, &backend, coeus_ops::UnaryOp::ReluGrad)
-                .expect("elementwise_unary");
+            coeus_ops::elementwise_unary(&shifted, &backend, coeus_ops::UnaryOp::ReluGrad)?;
 
-        let tie_count = coeus_ops::sum_axis(&mask_raw, self.axis, &backend)
-            .expect("invariant: max backward axis matches the saved input rank");
+        let tie_count = coeus_ops::sum_axis(&mask_raw, self.axis, &backend)?;
         let tie_broad = tie_count.broadcast(self.input_tensor.shape_cloned());
         let mask = coeus_ops::div(&mask_raw, &tie_broad, &backend);
 
@@ -74,7 +76,8 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         let grad_in = coeus_ops::mul(&grad_broad, &mask, &backend);
 
         let lock = g.write();
-        coeus_ops::add_assign(lock, &grad_in, &backend);
+        coeus_ops::add_assign(lock, &grad_in, &backend)?;
+        Ok(())
     }
 }
 
@@ -142,10 +145,14 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let min_broad = self.min_tensor.broadcast(self.input_tensor.shape_cloned());
@@ -154,17 +161,16 @@ impl<T: Scalar + FloatOps, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T
         let abs_diff = coeus_ops::abs(&diff, &backend);
         let shifted = coeus_ops::sub(&eps, &abs_diff, &backend);
         let mask_raw =
-            coeus_ops::elementwise_unary(&shifted, &backend, coeus_ops::UnaryOp::ReluGrad)
-                .expect("elementwise_unary");
-        let tie_count = coeus_ops::sum_axis(&mask_raw, self.axis, &backend)
-            .expect("invariant: min backward axis matches the saved input rank");
+            coeus_ops::elementwise_unary(&shifted, &backend, coeus_ops::UnaryOp::ReluGrad)?;
+        let tie_count = coeus_ops::sum_axis(&mask_raw, self.axis, &backend)?;
         let tie_broad = tie_count.broadcast(self.input_tensor.shape_cloned());
         let mask = coeus_ops::div(&mask_raw, &tie_broad, &backend);
         let grad_broad = grad_out.broadcast(self.input_tensor.shape_cloned());
         let grad_in = coeus_ops::mul(&grad_broad, &mask, &backend);
 
         let lock = g.write();
-        coeus_ops::add_assign(lock, &grad_in, &backend);
+        coeus_ops::add_assign(lock, &grad_in, &backend)?;
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/reduction/norm.rs
+++ b/crates/coeus-autograd/src/ops/reduction/norm.rs
@@ -38,10 +38,14 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Nor
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let norm_broad = self.norm_tensor.broadcast(self.input_tensor.shape_cloned());
@@ -49,7 +53,8 @@ impl<T: Float, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Nor
         let grad_in = coeus_ops::mul(&scale, &self.input_tensor, &backend);
 
         let lock = g.write();
-        coeus_ops::add_assign(lock, &grad_in, &backend);
+        coeus_ops::add_assign(lock, &grad_in, &backend)?;
+        Ok(())
     }
 }
 
@@ -121,10 +126,14 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let n = self.input_tensor.numel();
@@ -160,7 +169,8 @@ where
 
         let grad_t = Tensor::from_slice(self.input_tensor.shape().to_vec(), &grad_host);
         let lock = g.write();
-        coeus_ops::add_assign(lock, &grad_t, &backend);
+        coeus_ops::add_assign(lock, &grad_t, &backend)?;
+        Ok(())
     }
 }
 
@@ -239,10 +249,14 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let n = self.input_tensor.numel();
@@ -309,7 +323,8 @@ where
 
         let grad_t = Tensor::from_slice(self.input_tensor.shape().to_vec(), &grad_in_host);
         let lock = g.write();
-        coeus_ops::add_assign(lock, &grad_t, &backend);
+        coeus_ops::add_assign(lock, &grad_t, &backend)?;
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/reduction/prod.rs
+++ b/crates/coeus-autograd/src/ops/reduction/prod.rs
@@ -45,7 +45,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let go = grad_out.to_contiguous();
@@ -70,8 +74,9 @@ where
 
             let gi_increment = Tensor::from_slice(self.input_saved.shape_cloned(), &gi);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &gi_increment, &backend);
+            coeus_ops::add_assign(gl, &gi_increment, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/reduction/sort.rs
+++ b/crates/coeus-autograd/src/ops/reduction/sort.rs
@@ -63,10 +63,14 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         // Scatter grad_out[sorted_pos] -> original_pos using sort_indices.
@@ -79,7 +83,8 @@ where
             coeus_ops::scatter_add(&zeros, self.dim, &self.sort_indices, grad_out, &backend);
 
         let gl = g.write();
-        coeus_ops::add_assign(gl, &grad_in, &backend);
+        coeus_ops::add_assign(gl, &grad_in, &backend)?;
+        Ok(())
     }
 }
 
@@ -159,7 +164,9 @@ mod tests {
         assert!(indices.grad.is_none());
 
         // grad_out = [1, 1, 1, 1, 1]; scatter back via sort_indices
-        sorted.backward();
+        sorted
+            .backward()
+            .expect("invariant: valid autograd fixture completes backward");
         let dx = x.grad().unwrap();
         let dx_sum: f64 = dx.as_slice().iter().sum();
         assert!(
@@ -173,7 +180,9 @@ mod tests {
         let data = vec![3.0f64, 1.0, 4.0, 2.0, 5.0, 0.0];
         let x = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([2, 3], &data), true);
         let (sorted, _) = sort(&x, 1, false);
-        sorted.backward();
+        sorted
+            .backward()
+            .expect("invariant: valid autograd fixture completes backward");
         let dx = x.grad().unwrap();
         // Each element should receive exactly 1 gradient
         for v in dx.as_slice() {

--- a/crates/coeus-autograd/src/ops/reduction/topk.rs
+++ b/crates/coeus-autograd/src/ops/reduction/topk.rs
@@ -53,10 +53,14 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref g)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let zeros = Tensor::zeros_on(self.input_shape.clone(), &backend);
@@ -64,7 +68,8 @@ where
             coeus_ops::scatter_add(&zeros, self.dim, &self.topk_indices, grad_out, &backend);
 
         let gl = g.write();
-        coeus_ops::add_assign(gl, &grad_in, &backend);
+        coeus_ops::add_assign(gl, &grad_in, &backend)?;
+        Ok(())
     }
 }
 
@@ -154,7 +159,8 @@ mod tests {
         sorted.sort_by(|a, b| b.partial_cmp(a).unwrap());
         assert_eq!(sorted, vs, "topk should be descending");
 
-        vals.backward();
+        vals.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         let dx = x.grad().unwrap();
         let ones: usize = dx
             .as_slice()
@@ -171,7 +177,8 @@ mod tests {
         let data = vec![3.0f64, 1.0, 4.0, 1.0, 5.0];
         let x = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([5], &data), true);
         let (vals, _) = topk(&x, 2, 0, false);
-        vals.backward();
+        vals.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         let dx = x.grad().unwrap();
         let grad_sum: f64 = dx.as_slice().iter().sum();
         assert!(

--- a/crates/coeus-autograd/src/ops/scan.rs
+++ b/crates/coeus-autograd/src/ops/scan.rs
@@ -150,15 +150,20 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<f32, B>, input_grads: &[Option<Arc<GradBuffer<f32, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<f32, B>,
+        input_grads: &[Option<Arc<GradBuffer<f32, B>>>],
+    ) -> Result<(), B::Error> {
         let (grad_a, grad_u) = selective_scan_backward(&self.a_bar, &self.h, grad_out);
         let backend = B::default();
         if let Some(Some(gradient)) = input_grads.first() {
-            coeus_ops::add_assign(gradient.write(), &grad_a, &backend);
+            coeus_ops::add_assign(gradient.write(), &grad_a, &backend)?;
         }
         if let Some(Some(gradient)) = input_grads.get(1) {
-            coeus_ops::add_assign(gradient.write(), &grad_u, &backend);
+            coeus_ops::add_assign(gradient.write(), &grad_u, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/cat_split_stack/cat.rs
+++ b/crates/coeus-autograd/src/ops/shape/cat_split_stack/cat.rs
@@ -37,7 +37,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let ndim = self.out_shape.len();
         let dim = self.dim;
@@ -73,9 +77,10 @@ where
                 &sliced_out_layout,
                 g_storage,
                 g_layout,
-            );
+            )?;
             offset += sz;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/cat_split_stack/split.rs
+++ b/crates/coeus-autograd/src/ops/shape/cat_split_stack/split.rs
@@ -38,10 +38,14 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref acc)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let ndim = self.input_shape.len();
@@ -70,7 +74,8 @@ where
             grad_out.layout(),
             parent_storage,
             &sliced_layout,
-        );
+        )?;
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/cat_split_stack/stack.rs
+++ b/crates/coeus-autograd/src/ops/shape/cat_split_stack/stack.rs
@@ -41,7 +41,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         // Split the stacked output-gradient back into `n` slices along `dim`,
         // each of size 1; then squeeze `dim` to recover the original rank.
@@ -53,8 +57,9 @@ where
             // Remove the stacked dimension to match the input rank
             let squeezed = chunk.squeeze(self.dim);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &squeezed, &backend);
+            coeus_ops::add_assign(lock, &squeezed, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/mask/masked_fill.rs
+++ b/crates/coeus-autograd/src/ops/shape/mask/masked_fill.rs
@@ -35,14 +35,19 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let grad_input =
                 coeus_ops::masked_fill(grad_out, &self.mask_tensor, T::zero(), &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &grad_input, &backend);
+            coeus_ops::add_assign(lock, &grad_input, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/select/gather.rs
+++ b/crates/coeus-autograd/src/ops/shape/select/gather.rs
@@ -43,15 +43,20 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         // Gradient flows through `input` only (index is non-differentiable).
         if let Some(Some(ref g)) = input_grads.first() {
             // d_input = scatter_add(zeros_like(input), dim, index, grad_out)
             let zeros = Tensor::zeros_on(self.input_shape.clone(), &backend);
             let d_input = coeus_ops::scatter_add(&zeros, self.dim, &self.index, grad_out, &backend);
-            coeus_ops::add_assign(g.write(), &d_input, &backend);
+            coeus_ops::add_assign(g.write(), &d_input, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/select/index_put.rs
+++ b/crates/coeus-autograd/src/ops/shape/select/index_put.rs
@@ -49,7 +49,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
 
         // ∂/∂x: overwrite zeroes the replaced positions (they no longer depend
@@ -64,7 +68,7 @@ where
                 coeus_ops::index_put(grad_out, &self.index_tensor, &zeros, false, &backend)
             };
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_x, &backend);
+            coeus_ops::add_assign(gl, &grad_x, &backend)?;
         }
 
         // ∂/∂v: each value lands at its `idx` position, so its gradient is the
@@ -72,8 +76,9 @@ where
         if let Some(Some(ref g)) = input_grads.get(1) {
             let grad_v = coeus_ops::index_select(grad_out, 0, &self.index_tensor, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &grad_v, &backend);
+            coeus_ops::add_assign(gl, &grad_v, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/select/index_select.rs
+++ b/crates/coeus-autograd/src/ops/shape/select/index_select.rs
@@ -40,7 +40,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // Scatter-add the output gradient back to input positions.
@@ -94,8 +98,9 @@ where
 
             // Accumulate increment into the gradient buffer.
             let gi_increment = Tensor::from_slice(in_shape.clone(), &gi_data);
-            coeus_ops::add_assign(gl, &gi_increment, &backend);
+            coeus_ops::add_assign(gl, &gi_increment, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/select/scatter_add.rs
+++ b/crates/coeus-autograd/src/ops/shape/select/scatter_add.rs
@@ -49,22 +49,27 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
 
         // ∂/∂input: input is copied into the output unchanged, so its gradient
         // is the output gradient verbatim.
         if let Some(Some(ref g)) = input_grads.first() {
             let grad_input = grad_out.to_contiguous_on(&backend);
-            coeus_ops::add_assign(g.write(), &grad_input, &backend);
+            coeus_ops::add_assign(g.write(), &grad_input, &backend)?;
         }
 
         // ∂/∂src: each source element lands at `index`, so its gradient gathers
         // the output gradient from that position.
         if let Some(Some(ref g)) = input_grads.get(1) {
             let grad_src = coeus_ops::gather(grad_out, self.dim, &self.index, &backend);
-            coeus_ops::add_assign(g.write(), &grad_src, &backend);
+            coeus_ops::add_assign(g.write(), &grad_src, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/broadcast.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/broadcast.rs
@@ -35,7 +35,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let mut grad_input = grad_out.clone();
@@ -44,8 +48,9 @@ where
                     .expect("invariant: broadcast gradient axis is derived from the input shape");
             }
             let lock = g.write();
-            coeus_ops::add_assign(lock, &grad_input, &backend);
+            coeus_ops::add_assign(lock, &grad_input, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/diag.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/diag.rs
@@ -36,14 +36,19 @@ where
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // backward of diag(v, k) is diagonal(grad_out, k).
             let gi = coeus_ops::diagonal(grad_out, self.k, &backend);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &gi, &backend);
+            coeus_ops::add_assign(gl, &gi, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -112,7 +117,11 @@ where
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // backward of diagonal(M, k) is a matrix with grad_out on diagonal k.
@@ -136,8 +145,9 @@ where
                 Tensor::from_slice(vec![rows, cols], &data)
             };
             let gl = g.write();
-            coeus_ops::add_assign(gl, &gi, &backend);
+            coeus_ops::add_assign(gl, &gi, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/flip.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/flip.rs
@@ -35,14 +35,19 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // Gradient of flip is flip (self-inverse).
             let flipped_grad = coeus_ops::flip(grad_out, self.axis, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &flipped_grad, &backend);
+            coeus_ops::add_assign(lock, &flipped_grad, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/pad.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/pad.rs
@@ -35,10 +35,14 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         let Some(Some(ref acc)) = input_grads.first() else {
-            return;
+            return Ok(());
         };
 
         let ndim = grad_out.ndim();
@@ -57,7 +61,8 @@ where
         let sliced_grad = grad_out.slice(&ranges);
 
         let lock = acc.write();
-        coeus_ops::add_assign(lock, &sliced_grad, &backend);
+        coeus_ops::add_assign(lock, &sliced_grad, &backend)?;
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/permute.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/permute.rs
@@ -28,13 +28,18 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Pe
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let permuted_grad = grad_out.permute(&self.inv_dims);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &permuted_grad, &backend);
+            coeus_ops::add_assign(gl, &permuted_grad, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -161,7 +166,9 @@ mod movedim_tests {
                 }
             }
         }
-        moved.backward();
+        moved
+            .backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert_eq!(x.grad().unwrap().shape(), &[2, 3, 4]);
     }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/reshape.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/reshape.rs
@@ -28,13 +28,18 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Re
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let reshaped_grad = grad_out.reshape(self.original_shape.clone());
             let gl = g.write();
-            coeus_ops::add_assign(gl, &reshaped_grad, &backend);
+            coeus_ops::add_assign(gl, &reshaped_grad, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -113,7 +118,8 @@ mod flatten_tests {
         let flat = flatten(&x, 1, 2);
         assert_eq!(flat.tensor.shape(), &[2, 12]);
         assert_eq!(flat.tensor.to_contiguous().as_slice(), data.as_slice());
-        flat.backward();
+        flat.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert_eq!(x.grad().unwrap().shape(), &[2, 3, 4]);
     }
 }

--- a/crates/coeus-autograd/src/ops/shape/transform/roll.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/roll.rs
@@ -35,15 +35,20 @@ where
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // Backward of roll(x, shifts, dims) is roll(grad, -shifts, dims).
             let neg_shifts: Vec<isize> = self.shifts.iter().map(|&s| -s).collect();
             let unrolled = coeus_ops::roll(grad_out, &neg_shifts, &self.dims, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &unrolled, &backend);
+            coeus_ops::add_assign(lock, &unrolled, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/slice.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/slice.rs
@@ -28,7 +28,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sl
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let parent_grad = g.write();
@@ -45,8 +49,9 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sl
                 grad_out.layout(),
                 parent_storage,
                 &sliced_layout,
-            );
+            )?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/squeeze.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/squeeze.rs
@@ -28,7 +28,11 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sq
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let unsqueezed_grad = if let Some(ax) = self.axis {
@@ -38,8 +42,9 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Sq
                 grad_out.reshape(original_shape)
             };
             let gl = g.write();
-            coeus_ops::add_assign(gl, &unsqueezed_grad, &backend);
+            coeus_ops::add_assign(gl, &unsqueezed_grad, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -104,13 +109,18 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Un
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let squeezed_grad = grad_out.squeeze(self.axis);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &squeezed_grad, &backend);
+            coeus_ops::add_assign(gl, &squeezed_grad, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/tile.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/tile.rs
@@ -38,7 +38,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // Reconstruct the effective input shape after padding.
@@ -107,8 +111,9 @@ where
             };
 
             let gl = g.write();
-            coeus_ops::add_assign(gl, &gi_inc, &backend);
+            coeus_ops::add_assign(gl, &gi_inc, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/tril.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/tril.rs
@@ -36,15 +36,20 @@ where
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // Gradient of tril(x, k) is tril(grad_out, k): zeroed positions
             // have zero gradient since they contributed nothing to the output.
             let masked = coeus_ops::tril(grad_out, self.k, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &masked, &backend);
+            coeus_ops::add_assign(lock, &masked, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -120,13 +125,18 @@ where
     fn inputs(&self) -> &[Var<T, B>] {
         &self.inputs
     }
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let masked = coeus_ops::triu(grad_out, self.k, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &masked, &backend);
+            coeus_ops::add_assign(lock, &masked, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/transform/where_cond.rs
+++ b/crates/coeus-autograd/src/ops/shape/transform/where_cond.rs
@@ -1,4 +1,4 @@
-﻿// ── Tracked where_cond ──
+// ── Tracked where_cond ──
 //
 // Backward of where_cond(cond, on_true, on_false):
 //   d on_true  += grad_out * any_mask
@@ -38,7 +38,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         // inputs: [cond=0, on_true=1, on_false=2]
         // grad cond  = 0 (no derivative through boolean mask)
@@ -47,15 +51,16 @@ where
         if let Some(Some(ref g)) = input_grads.get(1) {
             let d_true = coeus_ops::mul(grad_out, &self.any_mask, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &d_true, &backend);
+            coeus_ops::add_assign(lock, &d_true, &backend)?;
         }
         if let Some(Some(ref g)) = input_grads.get(2) {
             let one = Tensor::full_on(self.any_mask.shape(), T::from_f64(1.0), &backend);
             let inv = coeus_ops::sub(&one, &self.any_mask, &backend);
             let d_false = coeus_ops::mul(grad_out, &inv, &backend);
             let lock = g.write();
-            coeus_ops::add_assign(lock, &d_false, &backend);
+            coeus_ops::add_assign(lock, &d_false, &backend)?;
         }
+        Ok(())
     }
 }
 
@@ -81,9 +86,12 @@ where
 
     // Compute mask once; reuse in backward.
     let mask_pos =
-        coeus_ops::elementwise_unary(&cond.tensor, &backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
-    let cond_neg = coeus_ops::elementwise_unary(&cond.tensor, &backend, coeus_ops::UnaryOp::Neg).expect("elementwise_unary");
-    let mask_neg = coeus_ops::elementwise_unary(&cond_neg, &backend, coeus_ops::UnaryOp::ReluGrad).expect("elementwise_unary");
+        coeus_ops::elementwise_unary(&cond.tensor, &backend, coeus_ops::UnaryOp::ReluGrad)
+            .expect("elementwise_unary");
+    let cond_neg = coeus_ops::elementwise_unary(&cond.tensor, &backend, coeus_ops::UnaryOp::Neg)
+        .expect("elementwise_unary");
+    let mask_neg = coeus_ops::elementwise_unary(&cond_neg, &backend, coeus_ops::UnaryOp::ReluGrad)
+        .expect("elementwise_unary");
     let any_mask = coeus_ops::add(&mask_pos, &mask_neg, &backend);
 
     let one = Tensor::full_on(any_mask.shape(), T::from_f64(1.0), &backend);

--- a/crates/coeus-autograd/src/ops/shape/util/contiguous.rs
+++ b/crates/coeus-autograd/src/ops/shape/util/contiguous.rs
@@ -27,12 +27,17 @@ impl<T: Scalar, B: coeus_ops::BackendOps<T> + Default> BackwardNode<T, B> for Co
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let gl = g.write();
-            coeus_ops::add_assign(gl, grad_out, &backend);
+            coeus_ops::add_assign(gl, grad_out, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/util/cumprod.rs
+++ b/crates/coeus-autograd/src/ops/shape/util/cumprod.rs
@@ -52,7 +52,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             // grad_in[i] = suffix_sum( grad_out * out )[i] / x[i]
@@ -142,8 +146,9 @@ where
 
             let gi_increment = Tensor::from_slice(shape.to_vec(), &gi_data);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &gi_increment, &backend);
+            coeus_ops::add_assign(gl, &gi_increment, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/util/cumsum.rs
+++ b/crates/coeus-autograd/src/ops/shape/util/cumsum.rs
@@ -33,13 +33,18 @@ where
     }
 
     #[inline]
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let backend = B::default();
         if let Some(Some(ref g)) = input_grads.first() {
             let suffix_grad = coeus_ops::suffix_sum(grad_out, self.dim);
             let gl = g.write();
-            coeus_ops::add_assign(gl, &suffix_grad, &backend);
+            coeus_ops::add_assign(gl, &suffix_grad, &backend)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-autograd/src/ops/shape/util/diff.rs
+++ b/crates/coeus-autograd/src/ops/shape/util/diff.rs
@@ -72,7 +72,8 @@ mod tests {
         assert_eq!(diff(&x, 0, 0).tensor.as_slice(), x.tensor.as_slice());
 
         // Gradient of sum(diff): dx = [-1, 0, 0, 1] (telescoping cancellation).
-        d1.backward();
+        d1.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert_eq!(x.grad().unwrap().as_slice(), &[-1.0, 0.0, 0.0, 1.0]);
     }
 

--- a/crates/coeus-autograd/src/var.rs
+++ b/crates/coeus-autograd/src/var.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 ///
 /// let x = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([2], &[3.0, 4.0]), true);
 /// let y = coeus_autograd::mul(&x, &x); // y = x * x
-/// y.backward();
+/// y.backward().expect("invariant: valid autograd fixture completes backward");
 /// let grad = x.grad().unwrap();
 /// assert!((grad.as_slice()[0] - 6.0).abs() < 1e-5); // 2 * 3
 /// assert!((grad.as_slice()[1] - 8.0).abs() < 1e-5); // 2 * 4
@@ -57,7 +57,7 @@ impl<T: Scalar, B: ComputeBackend + Default> Var<T, B> {
     /// let x = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([2], &[1.0, 2.0]), true);
     /// let c = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([2], &[10.0, 20.0]), false);
     /// let y = coeus_autograd::add(&x, &c);
-    /// y.backward();
+    /// y.backward().expect("invariant: valid autograd fixture completes backward");
     /// assert!(x.grad().is_some()); // tracked leaf: gradient present
     /// assert!(c.grad().is_none()); // constant leaf: no gradient state
     /// ```
@@ -111,7 +111,7 @@ impl<T: Scalar, B: ComputeBackend + Default> Var<T, B> {
     /// let one = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([3], &[1.0; 3]), false);
     /// let y = coeus_autograd::add(&x, &one);
     /// let loss = coeus_autograd::sum(&y);
-    /// loss.backward();
+    /// loss.backward().expect("invariant: valid autograd fixture completes backward");
     /// let grad = x.grad().unwrap();
     /// assert!((grad.as_slice()[0] - 1.0).abs() < 1e-5);
     /// assert!((grad.as_slice()[1] - 1.0).abs() < 1e-5);
@@ -149,7 +149,7 @@ impl<T: Scalar, B: ComputeBackend + Default> Var<T, B> {
     /// let x = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([2], &[2.0, 3.0]), true);
     /// let y = coeus_autograd::sum(&x);
     ///
-    /// y.backward();
+    /// y.backward().expect("invariant: valid autograd fixture completes backward");
     /// let g1 = x.grad().unwrap();
     /// assert!((g1.as_slice()[0] - 1.0).abs() < 1e-5);
     ///
@@ -181,15 +181,20 @@ impl<T: Scalar, B: ComputeBackend + Default> Var<T, B> {
     /// let x = Var::<f32, MoiraiBackend>::new(Tensor::from_slice([2], &[3.0, 4.0]), true);
     /// let y = coeus_autograd::mul(&x, &x);
     /// let loss = coeus_autograd::sum(&y); // scalar: y_0 + y_1
-    /// loss.backward();
+    /// loss.backward().expect("invariant: valid autograd fixture completes backward");
     /// let grad = x.grad().unwrap();
     /// assert!((grad.as_slice()[0] - 6.0).abs() < 1e-5); // 2 * 3
     /// assert!((grad.as_slice()[1] - 8.0).abs() < 1e-5); // 2 * 4
     /// ```
     #[inline]
-    pub fn backward(&self) {
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend error when gradient computation or accumulation
+    /// cannot complete.
+    pub fn backward(&self) -> Result<(), B::Error> {
         let seed = Tensor::ones_on(self.tensor.shape(), &B::default());
-        self.backward_with_seed(seed);
+        self.backward_with_seed(seed)
     }
 
     /// Run reverse-mode autodiff from this variable, seeding with the given gradient.
@@ -198,10 +203,15 @@ impl<T: Scalar, B: ComputeBackend + Default> Var<T, B> {
     /// This enables testing with non-uniform upstream gradients (e.g. for softmax,
     /// where a uniform seed produces zero input gradient due to Jacobian row-sums).
     ///
+    /// # Errors
+    ///
+    /// Returns the backend error when gradient computation or accumulation
+    /// cannot complete.
+    ///
     /// # Panics
     /// If `seed.shape()` does not match `self.tensor.shape()`.
     #[inline]
-    pub fn backward_with_seed(&self, seed: Tensor<T, B>) {
+    pub fn backward_with_seed(&self, seed: Tensor<T, B>) -> Result<(), B::Error> {
         assert_eq!(
             seed.shape(),
             self.tensor.shape(),
@@ -246,7 +256,66 @@ impl<T: Scalar, B: ComputeBackend + Default> Var<T, B> {
             let out_grad = node.output_grad().read().clone();
             let input_grads: Vec<Option<Arc<GradBuffer<T, B>>>> =
                 node.inputs().iter().map(|v| v.grad.clone()).collect();
-            node.backward(&out_grad, &input_grads);
+            node.backward(&out_grad, &input_grads)?;
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Var;
+    use crate::{BackwardNode, GradBuffer};
+    use coeus_core::{BackendError, MoiraiBackend};
+    use coeus_tensor::Tensor;
+    use std::sync::Arc;
+
+    struct FailingNode {
+        output_grad: Arc<GradBuffer<f32, MoiraiBackend>>,
+        inputs: Vec<Var<f32, MoiraiBackend>>,
+    }
+
+    impl BackwardNode<f32, MoiraiBackend> for FailingNode {
+        fn op_name(&self) -> &'static str {
+            "failing_test_node"
+        }
+
+        fn output_grad(&self) -> &Arc<GradBuffer<f32, MoiraiBackend>> {
+            &self.output_grad
+        }
+
+        fn inputs(&self) -> &[Var<f32, MoiraiBackend>] {
+            &self.inputs
+        }
+
+        fn backward(
+            &self,
+            _grad_out: &Tensor<f32, MoiraiBackend>,
+            _input_grads: &[Option<Arc<GradBuffer<f32, MoiraiBackend>>>],
+        ) -> Result<(), BackendError> {
+            Err(BackendError::Storage {
+                operation: "failing_test_node",
+                reason: "injected gradient accumulation failure".to_owned(),
+            })
+        }
+    }
+
+    #[test]
+    fn backward_returns_the_exact_node_error() {
+        let tensor = Tensor::from_slice([1], &[1.0]);
+        let output_grad = Arc::new(GradBuffer::new(Tensor::zeros([1])));
+        let node = Arc::new(FailingNode {
+            output_grad: Arc::clone(&output_grad),
+            inputs: Vec::new(),
+        });
+        let output = Var::with_creator(tensor, Some(output_grad), node);
+
+        assert_eq!(
+            output.backward(),
+            Err(BackendError::Storage {
+                operation: "failing_test_node",
+                reason: "injected gradient accumulation failure".to_owned(),
+            })
+        );
     }
 }

--- a/crates/coeus-autograd/tests/autograd/embedding.rs
+++ b/crates/coeus-autograd/tests/autograd/embedding.rs
@@ -22,7 +22,8 @@ fn test_embedding_autograd() {
 
     let grad_out_data = vec![1.0f32, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0];
     let grad_out = Tensor::from_slice_on(vec![2, 2, 2], &grad_out_data, &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gw = weight.grad().unwrap();
     let gw_slice = gw.as_slice();

--- a/crates/coeus-autograd/tests/autograd/exp_log.rs
+++ b/crates/coeus-autograd/tests/autograd/exp_log.rs
@@ -15,7 +15,8 @@ fn test_exp_autograd() {
     assert!((y_slice[2] - 7.389056).abs() < 1e-5);
 
     let grad_out = Tensor::from_slice_on(vec![3], &[1.0f32, 2.0f32, 3.0f32], &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
@@ -35,7 +36,8 @@ fn test_exp2_autograd() {
     assert!((y_slice[1] - 2.0).abs() < 1e-12, "exp2(1) = 2");
     assert!((y_slice[2] - 4.0).abs() < 1e-12, "exp2(2) = 4");
     let grad_seed = Tensor::from_slice_on(vec![4], &[1.0f64; 4], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let ln2 = core::f64::consts::LN_2;
     let gx = x.grad().unwrap();
     for (i, &xi) in data.iter().enumerate() {
@@ -65,7 +67,8 @@ fn test_selu_autograd() {
         assert!((y_slice[i] - expected).abs() < 1e-12, "selu[{i}]");
     }
     let grad_seed = Tensor::from_slice_on(vec![5], &[1.0f64; 5], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     for (i, &xi) in data.iter().enumerate() {
         let expected = if xi > 0.0 {
@@ -97,7 +100,8 @@ fn test_erf_autograd() {
     assert!((y_slice[3] - 0.995_322_265_018_952_7).abs() < 1e-12);
 
     let grad_out = Tensor::from_slice_on(vec![4], &[1.0f64, 1.0, 1.0, 1.0], &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Analytic gradient: d/dx erf(x) = (2/√π)·e^(−x²).
     let two_over_sqrt_pi = 2.0 / std::f64::consts::PI.sqrt();
@@ -146,7 +150,8 @@ fn test_erfc_autograd() {
         assert!((y_slice[i] - (1.0 - erf_ref[i])).abs() < 1e-12, "erfc[{i}]");
     }
     let grad_seed = Tensor::from_slice_on(vec![4], &[1.0f64; 4], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let two_over_sqrt_pi = 2.0 / std::f64::consts::PI.sqrt();
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
@@ -169,7 +174,8 @@ fn test_log_autograd() {
     assert!((y_slice[2] - 2.0f32 * std::f32::consts::LN_2).abs() < 1e-5);
 
     let grad_out = Tensor::from_slice_on(vec![3], &[1.0f32, 2.0f32, 3.0f32], &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
@@ -191,7 +197,8 @@ fn test_sinh_autograd() {
     }
 
     let grad_seed = Tensor::from_slice_on(vec![5], &[1.0f64; 5], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
     for (i, &xi) in data.iter().enumerate() {
@@ -212,7 +219,8 @@ fn test_cosh_autograd() {
     }
 
     let grad_seed = Tensor::from_slice_on(vec![5], &[1.0f64; 5], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
     for (i, &xi) in data.iter().enumerate() {
@@ -233,7 +241,8 @@ fn test_log2_autograd() {
     }
 
     let grad_seed = Tensor::from_slice_on(vec![5], &[1.0f64; 5], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
     for (i, &xi) in data.iter().enumerate() {
@@ -255,7 +264,8 @@ fn test_log10_autograd() {
     }
 
     let grad_seed = Tensor::from_slice_on(vec![5], &[1.0f64; 5], &backend);
-    y.backward_with_seed(grad_seed);
+    y.backward_with_seed(grad_seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
     for (i, &xi) in data.iter().enumerate() {

--- a/crates/coeus-autograd/tests/autograd/float16.rs
+++ b/crates/coeus-autograd/tests/autograd/float16.rs
@@ -75,7 +75,8 @@ fn f16_autograd_smoke() {
         true,
     );
     let y = coeus_autograd::sum(&coeus_autograd::mul(&x, &x));
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().expect("F16 sum(x^2) must produce gradient");
     // d/dx(sum(x^2)) = 2x
     let expected_grad = [2.0f32, 4.0, 6.0];

--- a/crates/coeus-autograd/tests/autograd/grad_mode.rs
+++ b/crates/coeus-autograd/tests/autograd/grad_mode.rs
@@ -31,7 +31,9 @@ fn no_grad_blocks_operation_graph_construction() {
         "tracked op output must carry a backward node"
     );
 
-    sum(&tracked).backward();
+    sum(&tracked)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(x.grad().unwrap().as_slice(), &[1.0, 0.0, 1.0]);
 }
 
@@ -57,6 +59,8 @@ fn no_grad_preserves_explicit_leaf_requires_grad() {
         y.grad.is_some(),
         "tracking must resume for later operations"
     );
-    sum(&y).backward();
+    sum(&y)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(x.grad().unwrap().as_slice(), &[2.0, 2.0]);
 }

--- a/crates/coeus-autograd/tests/autograd/index_put.rs
+++ b/crates/coeus-autograd/tests/autograd/index_put.rs
@@ -27,7 +27,8 @@ fn test_index_put_backward_overwrite() {
         &[1.0, 10.0, 3.0, 20.0, 5.0],
         "fwd overwrite"
     );
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         x.grad().unwrap().as_slice(),
         &[1.0, 0.0, 1.0, 0.0, 1.0],
@@ -59,7 +60,8 @@ fn test_index_put_backward_accumulate() {
         &[1.0, 12.0, 3.0, 24.0, 5.0],
         "fwd accumulate"
     );
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         x.grad().unwrap().as_slice(),
         &[1.0, 1.0, 1.0, 1.0, 1.0],

--- a/crates/coeus-autograd/tests/autograd/linalg.rs
+++ b/crates/coeus-autograd/tests/autograd/linalg.rs
@@ -42,7 +42,8 @@ fn test_bmm_backward_accumulates_exact_gradients() {
         assert!((got - want).abs() < 1e-14, "fwd {got} vs {want}");
     }
 
-    c.backward();
+    c.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // grad_A[b] rows = row sums of B[b]: B0 rows sum to [1,1,2]; B1 to [3,3,3].
     let ga = a.grad().unwrap();
@@ -92,7 +93,9 @@ fn rank_four_batched_matmul_preserves_axes_and_exact_gradients() {
         &[4.0, 5.0, 10.0, 11.0, 1.0, 2.0, 4.0, 8.0]
     );
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         a.grad().expect("A gradient must be populated").as_slice(),
         &[1.0, 1.0, 2.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0]
@@ -122,13 +125,17 @@ fn matmul_view_input_matches_contiguous_forward_and_grad() {
     let q1 = Var::new(Tensor::from_slice_on(shape, &qd, &backend), true);
     let k1 = Var::new(Tensor::from_slice_on(shape, &kd, &backend), true);
     let out_view = matmul(&q1, &transpose(&k1, 2, 3));
-    sum(&out_view).backward();
+    sum(&out_view)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Reference path: materialize the transpose contiguous first.
     let q2 = Var::new(Tensor::from_slice_on(shape, &qd, &backend), true);
     let k2 = Var::new(Tensor::from_slice_on(shape, &kd, &backend), true);
     let out_ref = matmul(&q2, &contiguous(&transpose(&k2, 2, 3)));
-    sum(&out_ref).backward();
+    sum(&out_ref)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert_eq!(
         out_view.tensor.as_slice(),

--- a/crates/coeus-autograd/tests/autograd/minmax.rs
+++ b/crates/coeus-autograd/tests/autograd/minmax.rs
@@ -22,7 +22,9 @@ fn test_maximum_forward_and_backward() {
     let b = var(&[4.0, 2.0, 3.0]);
     let out = maximum(&a, &b);
     assert_eq!(out.tensor.as_slice(), &[4.0, 5.0, 3.0], "fwd maximum");
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(a.grad().unwrap().as_slice(), &[0.0, 1.0, 1.0], "grad_a max");
     assert_eq!(b.grad().unwrap().as_slice(), &[1.0, 0.0, 0.0], "grad_b max");
 }
@@ -36,7 +38,9 @@ fn test_minimum_forward_and_backward() {
     let b = var(&[4.0, 2.0, 3.0]);
     let out = minimum(&a, &b);
     assert_eq!(out.tensor.as_slice(), &[1.0, 2.0, 3.0], "fwd minimum");
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(a.grad().unwrap().as_slice(), &[1.0, 0.0, 1.0], "grad_a min");
     assert_eq!(b.grad().unwrap().as_slice(), &[0.0, 1.0, 0.0], "grad_b min");
 }

--- a/crates/coeus-autograd/tests/autograd/nn_conv.rs
+++ b/crates/coeus-autograd/tests/autograd/nn_conv.rs
@@ -29,7 +29,8 @@ fn conv_transpose1d_backward_accumulates_exact_gradients() {
     assert_eq!(out.tensor.as_slice(), &[21.0, 40.0, 32.0]);
 
     let seed = Tensor::from_slice_on(vec![1, 1, 3], &[1.0_f64, 2.0, 3.0], &backend);
-    out.backward_with_seed(seed);
+    out.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert_eq!(input.grad().unwrap().as_slice(), &[19.0, 31.0]);
     assert_eq!(weight.grad().unwrap().as_slice(), &[8.0, 13.0]);
@@ -81,7 +82,8 @@ fn conv_transpose2d_backward_accumulates_exact_gradients() {
     );
 
     let seed = Tensor::from_slice_on(vec![1, 1, 2, 2], &[1.0_f64, 2.0, 3.0, 4.0], &backend);
-    out.backward_with_seed(seed);
+    out.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
 
     // grad_input: each position * weight[0,0,0,0]=1.0 → same as seed
     assert_eq!(
@@ -123,7 +125,9 @@ fn conv_transpose2d_no_bias_backward() {
     assert_eq!(out_tensor.shape(), &[1, 1, 3, 3]);
 
     let out = conv_transpose2d(&input, &weight, &None, out_tensor, 1, 0, 0, 1);
-    coeus_autograd::sum(&out).backward();
+    coeus_autograd::sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients exist and are non-zero
     let gi = input.grad().unwrap();
@@ -185,7 +189,8 @@ fn conv_transpose3d_backward_accumulates_exact_gradients() {
         &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
         &backend,
     );
-    out.backward_with_seed(seed);
+    out.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert_eq!(
         input.grad().unwrap().to_contiguous().as_slice(),

--- a/crates/coeus-autograd/tests/autograd/ops_overloads.rs
+++ b/crates/coeus-autograd/tests/autograd/ops_overloads.rs
@@ -58,7 +58,9 @@ fn test_var_ops_overloads() {
     );
     let prod2 = &a2 * &b2;
     let loss2 = coeus_autograd::sum(&prod2);
-    loss2.backward();
+    loss2
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let ga2 = a2.grad().unwrap();
     let gb2 = b2.grad().unwrap();
     assert!((ga2.as_slice()[0] - 4.0).abs() < 1e-10);

--- a/crates/coeus-autograd/tests/autograd/prelu.rs
+++ b/crates/coeus-autograd/tests/autograd/prelu.rs
@@ -26,7 +26,9 @@ fn test_prelu_scalar_weight_forward_and_backward() {
         &[-0.5, -0.25, 0.0, 0.5, 1.0],
         "fwd prelu"
     );
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // dx = w at x<=0 (INCLUDING the kink x=0), 1 at x>0.
     assert_eq!(
         x.grad().unwrap().as_slice(),
@@ -67,7 +69,9 @@ fn test_prelu_per_channel_weight_broadcasts_on_channel_axis() {
         &[-0.1, -0.2, -2.7, -3.6],
         "channel 0 scaled by 0.1, channel 1 by 0.9"
     );
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // dw[0] = sum over channel 0's elements (both negative): -1 + -2 = -3.
     // dw[1] = sum over channel 1's elements: -3 + -4 = -7.
     assert_eq!(
@@ -100,7 +104,9 @@ fn test_prelu_scalar_weight_broadcasts_over_rank4_input() {
         &[-0.5, -1.0, 3.0, -2.0],
         "scalar weight fwd"
     );
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // dw = sum of x over x<=0 elements: -1 + -2 + -4 = -7.
     assert_eq!(
         w.grad().unwrap().as_slice(),

--- a/crates/coeus-autograd/tests/autograd/reductions.rs
+++ b/crates/coeus-autograd/tests/autograd/reductions.rs
@@ -22,7 +22,8 @@ fn test_sum_axis_autograd() {
     assert_eq!(y_slice[1], 15.0);
 
     let grad_out = Tensor::from_slice_on(vec![2, 1], &[2.0f32, 3.0f32], &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
@@ -46,7 +47,8 @@ fn test_mean_axis_autograd() {
     assert!((y_slice[1] - 5.0).abs() < 1e-5);
 
     let grad_out = Tensor::from_slice_on(vec![2, 1], &[3.0f32, 6.0f32], &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
@@ -75,7 +77,8 @@ fn test_max_axis_autograd() {
     assert_eq!(y.tensor.shape(), &[2, 1]);
 
     let seed = Tensor::from_slice_on(vec![2, 1], &[1.0f64, 1.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - 0.0).abs() < 1e-10, "[0,0]: {}", gx_s[0]);
@@ -93,7 +96,8 @@ fn test_max_axis_tie_normalisation() {
     let x = Var::new(x_val, true);
     let y = max_axis(&x, 0);
     let seed = Tensor::from_slice_on(vec![1], &[1.0f64], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - 0.5).abs() < 1e-8, "tie pos 0: {}", gx_s[0]);
@@ -112,7 +116,8 @@ fn test_min_axis_autograd() {
     assert!((y_slice[1] - 1.0).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![2, 1], &[1.0f64, 1.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - 1.0).abs() < 1e-10, "[0,0]: {}", gx_s[0]);
@@ -135,7 +140,8 @@ fn test_norm_p_autograd() {
     assert!((y.tensor.as_slice()[0] - expected_y).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![1], &[1.5f64], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     let denom = expected_y.powf(2.0);
@@ -159,7 +165,8 @@ fn test_norm_p_axis_autograd() {
     assert_eq!(y.tensor.as_slice(), &[5.0, 13.0]);
 
     let seed = Tensor::from_slice_on(vec![2, 1], &[2.0f64, 3.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     let expected = [6.0 / 5.0, 8.0 / 5.0, 15.0 / 13.0, 36.0 / 13.0];
@@ -192,7 +199,8 @@ fn test_log_sum_exp_autograd() {
     );
 
     let seed = Tensor::from_slice_on(vec![1], &[1.0f64], &backend);
-    lse.backward_with_seed(seed);
+    lse.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     let sum_exp = e1 + e2 + e3;
@@ -239,7 +247,8 @@ fn test_cumsum_autograd() {
     assert!((y_s[3] - 10.0).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![4], &[1.0f64, 2.0, 3.0, 4.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!(
@@ -277,7 +286,8 @@ fn test_var_autograd_matches_analytic() {
 
     // Analytic gradient of the unbiased variance: dv/dx_i = 2(x_i - mean)/(n-1)
     // (the mean-path terms cancel because sum(x_j - mean) = 0).
-    v.backward();
+    v.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx = gx.as_slice();
     for (i, &xi) in data.iter().enumerate() {
@@ -333,7 +343,8 @@ fn test_var_axis_autograd_matches_analytic() {
     assert!((vs[1] - 4.0).abs() < 1e-14, "row1 var: {}", vs[1]);
 
     // Row-local gradient: dv_r/dx_ri = 2(x_ri - mean_r)/(extent-1), extent-1 = 2.
-    v.backward();
+    v.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx = gx.as_slice();
     let means = [2.0, 2.0, 2.0, 6.0, 6.0, 6.0];
@@ -357,7 +368,8 @@ fn test_prod_autograd_matches_analytic() {
     );
     let y = coeus_autograd::prod(&x);
     assert!((y.tensor.as_slice()[0] - 24.0).abs() < 1e-14, "fwd");
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = x.grad().unwrap();
     let g = g.as_slice();
     for (i, want) in [24.0, 12.0, 8.0, 6.0].iter().enumerate() {
@@ -372,7 +384,8 @@ fn test_prod_autograd_matches_analytic() {
     );
     let yz = coeus_autograd::prod(&z);
     assert_eq!(yz.tensor.as_slice()[0], 0.0, "fwd zero");
-    yz.backward();
+    yz.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let gz = z.grad().unwrap();
     let gz = gz.as_slice();
     for (i, want) in [0.0, 6.0, 0.0].iter().enumerate() {
@@ -395,7 +408,8 @@ fn test_cumprod_backward_exact_at_zeros() {
         true,
     );
     let y = cumsum_free_cumprod(&x);
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = x.grad().unwrap();
     for (i, want) in [9.0, 4.0, 2.0].iter().enumerate() {
         assert!(
@@ -413,7 +427,8 @@ fn test_cumprod_backward_exact_at_zeros() {
         true,
     );
     let y = cumsum_free_cumprod(&x);
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = x.grad().unwrap();
     for (i, want) in [1.0, 8.0, 0.0].iter().enumerate() {
         assert!(
@@ -431,7 +446,8 @@ fn test_cumprod_backward_exact_at_zeros() {
         true,
     );
     let y = cumsum_free_cumprod(&x);
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = x.grad().unwrap();
     for (i, want) in [1.0, 8.0, 0.0, 0.0, 0.0].iter().enumerate() {
         assert!(

--- a/crates/coeus-autograd/tests/autograd/remainder.rs
+++ b/crates/coeus-autograd/tests/autograd/remainder.rs
@@ -22,7 +22,9 @@ fn test_remainder_forward_and_backward_positive() {
     );
     let out = remainder(&a, &b);
     assert_eq!(out.tensor.as_slice(), &[2.0, 3.0, 2.0], "fwd remainder");
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(a.grad().unwrap().as_slice(), &[1.0, 1.0, 1.0], "grad_a");
     assert_eq!(b.grad().unwrap().as_slice(), &[-1.0, -1.0, -2.0], "grad_b");
 }
@@ -43,7 +45,9 @@ fn test_remainder_sign_of_divisor() {
     );
     let out = remainder(&a, &b);
     assert_eq!(out.tensor.as_slice(), &[-2.0], "fwd sign-of-divisor");
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(a.grad().unwrap().as_slice(), &[1.0], "grad_a");
     assert_eq!(b.grad().unwrap().as_slice(), &[3.0], "grad_b");
 }
@@ -69,7 +73,9 @@ fn test_remainder_broadcast_scalar_divisor() {
         &[1.0, 2.0, 0.0, 1.0],
         "fwd broadcast"
     );
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         a.grad().unwrap().as_slice(),
         &[1.0, 1.0, 1.0, 1.0],

--- a/crates/coeus-autograd/tests/autograd/scatter_add.rs
+++ b/crates/coeus-autograd/tests/autograd/scatter_add.rs
@@ -27,7 +27,8 @@ fn test_scatter_add_backward_src_and_input() {
         &[0.0, 2.0, 0.0, 3.0, 1.0],
         "fwd scatter_add"
     );
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         input.grad().unwrap().as_slice(),
         &[1.0, 1.0, 1.0, 1.0, 1.0],
@@ -57,7 +58,8 @@ fn test_scatter_add_backward_duplicate_indices() {
     let out = scatter_add(&input, 0, &idx, &src);
     // out[1] = 20 + 1 + 2 = 23, out[2] = 30 + 3 = 33.
     assert_eq!(out.tensor.as_slice(), &[10.0, 23.0, 33.0, 40.0], "fwd dup");
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         input.grad().unwrap().as_slice(),
         &[1.0, 1.0, 1.0, 1.0],

--- a/crates/coeus-autograd/tests/autograd/shape_ops.rs
+++ b/crates/coeus-autograd/tests/autograd/shape_ops.rs
@@ -28,7 +28,8 @@ fn test_pad_autograd() {
     assert_eq!(y_slice[10], 4.0);
 
     let grad_out = Tensor::ones_on(vec![4, 4], &backend);
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx = x.grad().unwrap();
     let gx_slice = gx.as_slice();
@@ -51,7 +52,8 @@ fn test_squeeze_unsqueeze_autograd() {
         &[10.0f32, 20.0, 30.0, 40.0, 50.0, 60.0],
         &backend,
     );
-    y.backward_with_seed(grad_out);
+    y.backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx = x.grad().unwrap();
     assert_eq!(gx.shape(), &[2, 3]);
@@ -69,7 +71,8 @@ fn test_squeeze_unsqueeze_autograd() {
         &[10.0f32, 20.0, 30.0, 40.0, 50.0, 60.0],
         &backend,
     );
-    y2.backward_with_seed(grad_out2);
+    y2.backward_with_seed(grad_out2)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx2 = x2.grad().unwrap();
     assert_eq!(gx2.shape(), &[2, 1, 3]);
@@ -91,7 +94,8 @@ fn test_squeeze_unsqueeze_autograd() {
         &[10.0f32, 20.0, 30.0, 40.0, 50.0, 60.0],
         &backend,
     );
-    y3.backward_with_seed(grad_out3);
+    y3.backward_with_seed(grad_out3)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let gx3 = x3.grad().unwrap();
     assert_eq!(gx3.shape(), &[1, 2, 1, 3]);
@@ -108,7 +112,9 @@ fn test_contiguous_backward_is_identity() {
     let y = coeus_autograd::contiguous(&coeus_autograd::permute(&x, &[1, 0]));
     assert_eq!(y.tensor.shape(), &[3, 2]);
     // sum(contiguous(permute(x))).backward() — grad should be all-ones (same as sum backward).
-    coeus_autograd::sum(&y).backward();
+    coeus_autograd::sum(&y)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     assert_eq!(gx.shape(), &[2, 3]);
     // Every element contributed once to the sum, so all grads = 1.
@@ -140,7 +146,9 @@ fn test_einsum3_matmul_chain_backward() {
     assert_eq!(y.tensor.shape(), &[2, 2]);
     assert_eq!(y.tensor.as_slice(), &[413.0, 454.0, 937.0, 1030.0]);
 
-    coeus_autograd::sum(&y).backward();
+    coeus_autograd::sum(&y)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert_close(
         a.grad().unwrap().as_slice(),

--- a/crates/coeus-autograd/tests/autograd/sparse.rs
+++ b/crates/coeus-autograd/tests/autograd/sparse.rs
@@ -26,7 +26,9 @@ fn test_sparse_matmul_backward() {
     // Seed output gradient
     let grad_out_data = vec![1.0f32, -1.0, 2.0, -2.0, 3.0, -3.0];
     let grad_out = Tensor::from_slice_on(vec![3, 2], &grad_out_data, &backend);
-    c_dense_var.backward_with_seed(grad_out.clone());
+    c_dense_var
+        .backward_with_seed(grad_out.clone())
+        .expect("invariant: valid autograd fixture completes backward");
 
     let expected_grad_a = a_var.grad().unwrap();
     let expected_grad_b = b_var.grad().unwrap();
@@ -53,7 +55,9 @@ fn test_sparse_matmul_backward() {
         c_dense_var.tensor.as_slice()
     );
 
-    c_sparse_var.backward_with_seed(grad_out);
+    c_sparse_var
+        .backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let grad_a_vals = a_values_var.grad().unwrap();
     let grad_b_sparse = b_var_sparse.grad().unwrap();
@@ -117,7 +121,9 @@ fn test_sparse_coo_matmul_backward() {
     // Seed output gradient
     let grad_out_data = vec![1.0f32, -1.0, 2.0, -2.0, 3.0, -3.0];
     let grad_out = Tensor::from_slice_on(vec![3, 2], &grad_out_data, &backend);
-    c_dense_var.backward_with_seed(grad_out.clone());
+    c_dense_var
+        .backward_with_seed(grad_out.clone())
+        .expect("invariant: valid autograd fixture completes backward");
 
     let expected_grad_a = a_var.grad().unwrap();
     let expected_grad_b = b_var.grad().unwrap();
@@ -139,7 +145,9 @@ fn test_sparse_coo_matmul_backward() {
         c_dense_var.tensor.as_slice()
     );
 
-    c_sparse_var.backward_with_seed(grad_out);
+    c_sparse_var
+        .backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let grad_a_vals = a_values_var.grad().unwrap();
     let grad_b_sparse = b_var_sparse.grad().unwrap();

--- a/crates/coeus-autograd/tests/autograd/unary_math.rs
+++ b/crates/coeus-autograd/tests/autograd/unary_math.rs
@@ -15,7 +15,8 @@ fn test_neg_autograd() {
     assert!((y_slice[2] - (-3.0)).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![4], &[1.0f64, 2.0, 3.0, 4.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - (-1.0)).abs() < 1e-10);
@@ -37,7 +38,8 @@ fn test_abs_autograd() {
     assert!((y_slice[2] - 0.5).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![3], &[1.0f64, 1.0, 1.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!(
@@ -70,7 +72,8 @@ fn test_sqrt_autograd() {
     assert!((y_slice[2] - 4.0).abs() < 1e-9);
 
     let seed = Tensor::from_slice_on(vec![3], &[1.0f64, 1.0, 1.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!(
@@ -103,7 +106,8 @@ fn test_pow_autograd() {
     assert!((y_slice[2] - 27.0).abs() < 1e-8);
 
     let seed = Tensor::from_slice_on(vec![3], &[1.0f64, 1.0, 1.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - 3.0).abs() < 1e-6, "pow(1,3) grad: {}", gx_s[0]);
@@ -136,7 +140,8 @@ fn test_pow_integer_exp_sign_preserving() {
     // Backward: d/dx x^3 = 3·x^2 — non-negative everywhere; for x = 0 → 0.
     // PyTorch: 3, 12, 3, 0.75, 12 (and 0 at the x = 0 zero index, which we excluded).
     let seed = Tensor::from_slice_on(vec![5], &[1.0f64; 5], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - 3.0).abs() < 1e-10, "bwd[0] = {}", gx_s[0]);
@@ -161,7 +166,8 @@ fn test_pow_integer_exp_zero() {
     }
 
     let seed = Tensor::from_slice_on(vec![4], &[1.0f64; 4], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     for v in gx.as_slice().iter() {
         assert!(v.abs() < 1e-10, "d/dx x^0 = {} (expected 0)", v);
@@ -220,7 +226,8 @@ fn test_clamp_autograd() {
     );
 
     let seed = Tensor::from_slice_on(vec![4], &[1.0f64, 1.0, 1.0, 1.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!(
@@ -258,7 +265,8 @@ fn test_scalar_mul_autograd() {
     assert!((y_slice[2] - 9.0).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![3], &[1.0f64, 2.0, 3.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     let gx_s = gx.as_slice();
     assert!((gx_s[0] - 3.0).abs() < 1e-10);
@@ -284,7 +292,8 @@ fn test_scalar_sub_autograd() {
     assert!((z.tensor.as_slice()[2] - 9.0).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![3], &[1.0f64, 2.0, 3.0], &backend);
-    y.backward_with_seed(seed.clone());
+    y.backward_with_seed(seed.clone())
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     assert!((gx.as_slice()[0] - 1.0).abs() < 1e-10);
     assert!((gx.as_slice()[1] - 2.0).abs() < 1e-10);
@@ -309,7 +318,8 @@ fn test_scalar_div_autograd() {
     assert!((z.tensor.as_slice()[2] - 6.0).abs() < 1e-10);
 
     let seed = Tensor::from_slice_on(vec![3], &[1.0f64, 2.0, 3.0], &backend);
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let gx = x.grad().unwrap();
     assert!((gx.as_slice()[0] - 1.0 / 3.0).abs() < 1e-10);
     assert!((gx.as_slice()[1] - 2.0 / 3.0).abs() < 1e-10);

--- a/crates/coeus-autograd/tests/autograd_ops/grid_sample/grid_sample_3d.rs
+++ b/crates/coeus-autograd/tests/autograd_ops/grid_sample/grid_sample_3d.rs
@@ -127,7 +127,9 @@ fn input_gradient_matches_central_difference() {
     );
     let grid = Var::new(Tensor::from_slice_on(GRID_SHAPE, &GRID, &backend), true);
     let out = grid_sample_3d(&input, &grid);
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic = input.grad().expect("tracked input gradient");
     let analytic = analytic.as_slice();
 
@@ -156,7 +158,9 @@ fn grid_gradient_matches_central_difference() {
     );
     let grid = Var::new(Tensor::from_slice_on(GRID_SHAPE, &GRID, &backend), true);
     let out = grid_sample_3d(&input, &grid);
-    sum(&out).backward();
+    sum(&out)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic = grid.grad().expect("tracked grid gradient");
     let analytic = analytic.as_slice();
 

--- a/crates/coeus-autograd/tests/autograd_ops/interpolation/linear_interpolation.rs
+++ b/crates/coeus-autograd/tests/autograd_ops/interpolation/linear_interpolation.rs
@@ -21,7 +21,9 @@ fn three_dimensional_backward_matches_analytical_derivatives() {
     let sampled = linear_interpolation::<3, _, _>(&image, &grid, Replicate)
         .expect("valid three-dimensional contract");
     assert_eq!(sampled.tensor.as_slice(), &[3.5]);
-    sum(&sampled).backward();
+    sum(&sampled)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         image.grad().expect("tracked image gradient").as_slice(),
         &[0.125; 8]
@@ -46,7 +48,9 @@ fn two_dimensional_backward_matches_analytical_derivatives() {
     let sampled = linear_interpolation::<2, _, _>(&image, &grid, Replicate)
         .expect("valid two-dimensional contract");
     assert_eq!(sampled.tensor.as_slice(), &[1.25]);
-    sum(&sampled).backward();
+    sum(&sampled)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         image.grad().expect("tracked image gradient").as_slice(),
         &[0.1875, 0.5625, 0.0625, 0.1875]
@@ -70,7 +74,9 @@ fn constant_image_has_zero_coordinate_gradient() {
     );
     let sampled = linear_interpolation::<2, _, _>(&image, &grid, Replicate)
         .expect("valid two-dimensional contract");
-    sum(&sampled).backward();
+    sum(&sampled)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         grid.grad().expect("tracked grid gradient").as_slice(),
         &[0.0, 0.0]

--- a/crates/coeus-autograd/tests/autograd_ops/scan/selective_scan.rs
+++ b/crates/coeus-autograd/tests/autograd_ops/scan/selective_scan.rs
@@ -68,7 +68,9 @@ fn a_bar_gradient_matches_central_difference() {
     let a_bar = Var::new(Tensor::from_slice_on(SHAPE, &A_DATA, &backend), true);
     let u = Var::new(Tensor::from_slice_on(SHAPE, &U_DATA, &backend), true);
     let h = selective_scan(&a_bar, &u);
-    sum(&h).backward();
+    sum(&h)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic = a_bar.grad().expect("tracked a_bar gradient");
     let analytic = analytic.as_slice();
 
@@ -93,7 +95,9 @@ fn u_gradient_matches_central_difference() {
     let a_bar = Var::new(Tensor::from_slice_on(SHAPE, &A_DATA, &backend), true);
     let u = Var::new(Tensor::from_slice_on(SHAPE, &U_DATA, &backend), true);
     let h = selective_scan(&a_bar, &u);
-    sum(&h).backward();
+    sum(&h)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic = u.grad().expect("tracked u gradient");
     let analytic = analytic.as_slice();
 

--- a/crates/coeus-cuda/tests/cuda/parity/convolution_transpose.rs
+++ b/crates/coeus-cuda/tests/cuda/parity/convolution_transpose.rs
@@ -149,10 +149,12 @@ fn test_cuda_parity_conv_transpose1d_backward() {
         coeus_ops::conv_transpose1d(&input_cpu.tensor, &weight_cpu.tensor, None, 1, 0, 0, 1, &s);
     let tracked_cpu =
         coeus_autograd::conv_transpose1d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
-    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
-        [1, 1, 4],
-        &seed,
-    ));
+    tracked_cpu
+        .backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+            [1, 1, 4],
+            &seed,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_gpu = Var::new(
         Tensor::<f32, CudaBackend>::from_slice_on([1, 1, 3], &input, &c),
@@ -166,11 +168,13 @@ fn test_cuda_parity_conv_transpose1d_backward() {
         coeus_ops::conv_transpose1d(&input_gpu.tensor, &weight_gpu.tensor, None, 1, 0, 0, 1, &c);
     let tracked_gpu =
         coeus_autograd::conv_transpose1d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
-    tracked_gpu.backward_with_seed(Tensor::<f32, CudaBackend>::from_slice_on(
-        [1, 1, 4],
-        &seed,
-        &c,
-    ));
+    tracked_gpu
+        .backward_with_seed(Tensor::<f32, CudaBackend>::from_slice_on(
+            [1, 1, 4],
+            &seed,
+            &c,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert_parity_tol(
         "conv_transpose1d_backward_input",
@@ -208,10 +212,12 @@ fn test_cuda_parity_conv_transpose2d_backward() {
         coeus_ops::conv_transpose2d(&input_cpu.tensor, &weight_cpu.tensor, None, 1, 0, 0, 1, &s);
     let tracked_cpu =
         coeus_autograd::conv_transpose2d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
-    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
-        [1, 1, 3, 3],
-        &seed,
-    ));
+    tracked_cpu
+        .backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+            [1, 1, 3, 3],
+            &seed,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_gpu = Var::new(
         Tensor::<f32, CudaBackend>::from_slice_on([1, 1, 2, 2], &input, &c),
@@ -225,11 +231,13 @@ fn test_cuda_parity_conv_transpose2d_backward() {
         coeus_ops::conv_transpose2d(&input_gpu.tensor, &weight_gpu.tensor, None, 1, 0, 0, 1, &c);
     let tracked_gpu =
         coeus_autograd::conv_transpose2d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
-    tracked_gpu.backward_with_seed(Tensor::<f32, CudaBackend>::from_slice_on(
-        [1, 1, 3, 3],
-        &seed,
-        &c,
-    ));
+    tracked_gpu
+        .backward_with_seed(Tensor::<f32, CudaBackend>::from_slice_on(
+            [1, 1, 3, 3],
+            &seed,
+            &c,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert_parity_tol(
         "conv_transpose2d_backward_input",

--- a/crates/coeus-fft/benches/fft_bench.rs
+++ b/crates/coeus-fft/benches/fft_bench.rs
@@ -35,7 +35,8 @@ fn bench_fft_autograd_roundtrip(c: &mut Criterion) {
                 let x = Var::<f64, MoiraiBackend>::new(Tensor::from_slice([d.len()], d), true);
                 let y = fft_1d_var(black_box(&x));
                 let seed = Tensor::from_slice([d.len()], &vec![Complex::new(1.0, 0.0); d.len()]);
-                y.backward_with_seed(seed);
+                y.backward_with_seed(seed)
+                    .expect("invariant: valid autograd fixture completes backward");
                 black_box(x.grad());
             });
         });

--- a/crates/coeus-fft/src/lib.rs
+++ b/crates/coeus-fft/src/lib.rs
@@ -145,7 +145,7 @@ where
         &self,
         grad_out: &Tensor<Complex<T>, B>,
         _input_grads: &[Option<Arc<GradBuffer<Complex<T>, B>>>],
-    ) {
+    ) -> Result<(), B::Error> {
         let n = T::from_usize(grad_out.numel());
         let mut dx = ifft_1d(grad_out);
         let mut host = tensor_to_vec(&dx);
@@ -159,9 +159,10 @@ where
         }
         if self.x.creator.is_some() {
             if let Some(current_grad) = self.x.grad() {
-                self.x.backward_with_seed(current_grad);
+                self.x.backward_with_seed(current_grad)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -193,7 +194,11 @@ where
         &[]
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, _input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        _input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         let n = T::from_usize(grad_out.numel());
         let mut dy = fft_1d(grad_out);
         let mut host = tensor_to_vec(&dy);
@@ -208,9 +213,10 @@ where
         }
         if self.y.creator.is_some() {
             if let Some(current_grad) = self.y.grad() {
-                self.y.backward_with_seed(current_grad);
+                self.y.backward_with_seed(current_grad)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -304,7 +310,11 @@ where
         &self.inputs
     }
 
-    fn backward(&self, grad_out: &Tensor<T, B>, input_grads: &[Option<Arc<GradBuffer<T, B>>>]) {
+    fn backward(
+        &self,
+        grad_out: &Tensor<T, B>,
+        input_grads: &[Option<Arc<GradBuffer<T, B>>>],
+    ) -> Result<(), B::Error> {
         if let Some(Some(ref grad)) = input_grads.first() {
             let go = tensor_to_vec(grad_out)[0];
             let factor = go * T::from_f64(2.0);
@@ -324,6 +334,7 @@ where
             dx = Tensor::from_slice_on(dx.shape_cloned(), &dx_host, &B::default());
             accumulate_grad(grad, &dx);
         }
+        Ok(())
     }
 }
 

--- a/crates/coeus-fft/tests/fft.rs
+++ b/crates/coeus-fft/tests/fft.rs
@@ -83,7 +83,8 @@ fn fft_1d_var_accumulates_input_gradient_from_complex_seed() {
             Complex::new(0.0, -1.0),
         ],
     );
-    y.backward_with_seed(seed);
+    y.backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = x.grad().unwrap();
     let expected = [1.5, -1.5, 1.5, 2.5];
     for (index, (&actual, &want)) in grad.as_slice().iter().zip(expected.iter()).enumerate() {
@@ -150,7 +151,8 @@ fn fft_energy_gradient_matches_parseval_oracle() {
     let expected_energy = data.iter().map(|v| v * v).sum::<f64>() * data.len() as f64;
     assert_close(loss.tensor.as_slice()[0], expected_energy, "fft_energy");
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = x.grad().unwrap();
     for (index, (&actual, &value)) in grad.as_slice().iter().zip(data.iter()).enumerate() {
         let expected = 2.0 * data.len() as f64 * value;

--- a/crates/coeus-nn/benches/nn_bench/provider/arithmetic_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/arithmetic_backward.rs
@@ -29,13 +29,17 @@ pub(crate) fn bench_matmul_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::matmul(black_box(&a_seq), black_box(&b_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::matmul(black_box(&a_moirai), black_box(&b_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -57,13 +61,17 @@ pub(crate) fn bench_pow_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::pow(black_box(&x_seq), 2.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::pow(black_box(&x_moirai), 2.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -85,13 +93,17 @@ pub(crate) fn bench_scalar_mul_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::scalar_mul(black_box(&x_seq), 3.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::scalar_mul(black_box(&x_moirai), 3.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/convolution.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/convolution.rs
@@ -62,7 +62,9 @@ pub(crate) fn bench_conv1d_forward_backward(c: &mut Criterion) {
             conv_seq.zero_grad();
             x_seq.zero_grad();
             let out = conv_seq.forward(black_box(&x_seq));
-            coeus_autograd::sum(&out).backward();
+            coeus_autograd::sum(&out)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward");
         })
     });
     group.bench_function("Coeus Moirai", |b| {
@@ -70,7 +72,9 @@ pub(crate) fn bench_conv1d_forward_backward(c: &mut Criterion) {
             conv_moirai.zero_grad();
             x_moirai.zero_grad();
             let out = conv_moirai.forward(black_box(&x_moirai));
-            coeus_autograd::sum(&out).backward();
+            coeus_autograd::sum(&out)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward");
         })
     });
     group.finish();
@@ -215,7 +219,9 @@ pub(crate) fn bench_conv2d_forward_backward(c: &mut Criterion) {
             conv_seq.zero_grad();
             x_seq.zero_grad();
             let out = conv_seq.forward(black_box(&x_seq));
-            coeus_autograd::sum(&out).backward();
+            coeus_autograd::sum(&out)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward");
         })
     });
     group.bench_function("Coeus Moirai", |b| {
@@ -223,7 +229,9 @@ pub(crate) fn bench_conv2d_forward_backward(c: &mut Criterion) {
             conv_moirai.zero_grad();
             x_moirai.zero_grad();
             let out = conv_moirai.forward(black_box(&x_moirai));
-            coeus_autograd::sum(&out).backward();
+            coeus_autograd::sum(&out)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward");
         })
     });
     group.finish();
@@ -299,13 +307,17 @@ pub(crate) fn bench_conv2d_fwd_bwd(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let out = conv_seq.forward(black_box(&inp_seq));
-            black_box(out).backward()
+            black_box(out)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let out = conv_moirai.forward(black_box(&inp_moirai));
-            black_box(out).backward()
+            black_box(out)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/dense.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/dense.rs
@@ -94,14 +94,18 @@ pub(crate) fn bench_linear_forward_backward(c: &mut Criterion) {
         b.iter(|| {
             lin_seq.zero_grad();
             x_seq.zero_grad();
-            coeus_autograd::sum(&lin_seq.forward(black_box(&x_seq))).backward();
+            coeus_autograd::sum(&lin_seq.forward(black_box(&x_seq)))
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward");
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             lin_moirai.zero_grad();
             x_moirai.zero_grad();
-            coeus_autograd::sum(&lin_moirai.forward(black_box(&x_moirai))).backward();
+            coeus_autograd::sum(&lin_moirai.forward(black_box(&x_moirai)))
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward");
         })
     });
     group.finish();
@@ -156,13 +160,17 @@ pub(crate) fn bench_linear_fwd_bwd(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = lin_seq.forward(black_box(&inp_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = lin_moirai.forward(black_box(&inp_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/exponential_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/exponential_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_exp2_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::exp2(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::exp2(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -46,13 +50,17 @@ pub(crate) fn bench_log2_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::log2(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::log2(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -74,13 +82,17 @@ pub(crate) fn bench_expm1_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::expm1(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::expm1(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -102,13 +114,17 @@ pub(crate) fn bench_log1p_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::log1p(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::log1p(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -130,13 +146,17 @@ pub(crate) fn bench_log10_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::log10(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::log10(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -158,13 +178,17 @@ pub(crate) fn bench_log_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::log(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::log(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -186,13 +210,17 @@ pub(crate) fn bench_exp_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::exp(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::exp(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -214,13 +242,17 @@ pub(crate) fn bench_log_softmax_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::log_softmax(black_box(&x_seq), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::log_softmax(black_box(&x_moirai), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -242,13 +274,17 @@ pub(crate) fn bench_log_sum_exp_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::log_sum_exp(black_box(&x_seq), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::log_sum_exp(black_box(&x_moirai), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/gating_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/gating_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_tanh_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::tanh(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::tanh(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -46,13 +50,17 @@ pub(crate) fn bench_sigmoid_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::sigmoid(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::sigmoid(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -74,13 +82,17 @@ pub(crate) fn bench_silu_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::silu(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::silu(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -102,13 +114,17 @@ pub(crate) fn bench_mish_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::mish(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::mish(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -130,13 +146,17 @@ pub(crate) fn bench_softsign_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::softsign(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::softsign(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -158,13 +178,17 @@ pub(crate) fn bench_atanh_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::atanh(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::atanh(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/indexing.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/indexing.rs
@@ -330,13 +330,17 @@ pub(crate) fn bench_flip_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::flip(black_box(&x_seq), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::flip(black_box(&x_moirai), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -356,13 +360,17 @@ pub(crate) fn bench_permute_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::permute(black_box(&x_seq), &[1, 0]);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::permute(black_box(&x_moirai), &[1, 0]);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -383,13 +391,17 @@ pub(crate) fn bench_tile_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::tile(black_box(&x_seq), &[2, 2]);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::tile(black_box(&x_moirai), &[2, 2]);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -411,13 +423,17 @@ pub(crate) fn bench_clamp_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::clamp(black_box(&x_seq), -1.0, 1.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::clamp(black_box(&x_moirai), -1.0, 1.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -439,13 +455,17 @@ pub(crate) fn bench_sort_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let (o, _) = coeus_autograd::sort(black_box(&x_seq), 1, false);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let (o, _) = coeus_autograd::sort(black_box(&x_moirai), 1, false);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/loss_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/loss_backward.rs
@@ -29,13 +29,17 @@ pub(crate) fn bench_l1_loss_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::l1_loss(black_box(&x_seq), black_box(&t_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::l1_loss(black_box(&x_moirai), black_box(&t_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -68,13 +72,17 @@ pub(crate) fn bench_bce_with_logits_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::bce_with_logits(black_box(&x_seq), black_box(&t_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::bce_with_logits(black_box(&x_moirai), black_box(&t_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -107,13 +115,17 @@ pub(crate) fn bench_huber_loss_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::huber_loss(black_box(&x_seq), black_box(&t_seq), 1.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::huber_loss(black_box(&x_moirai), black_box(&t_moirai), 1.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -147,13 +159,17 @@ pub(crate) fn bench_kl_div_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::kl_divergence(black_box(&x_seq), black_box(&t_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::kl_divergence(black_box(&x_moirai), black_box(&t_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/normalization_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/normalization_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_norm_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::norm(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::norm(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/normalization_forward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/normalization_forward.rs
@@ -296,13 +296,17 @@ pub(crate) fn bench_group_norm_forward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = layer_seq.forward(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = layer_moirai.forward(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/rectifier_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/rectifier_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_gelu_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::gelu(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::gelu(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -46,13 +50,17 @@ pub(crate) fn bench_relu_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::relu(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::relu(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -74,13 +82,17 @@ pub(crate) fn bench_elu_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::elu(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::elu(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -102,13 +114,17 @@ pub(crate) fn bench_celu_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::celu(black_box(&x_seq), 1.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::celu(black_box(&x_moirai), 1.0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -130,13 +146,17 @@ pub(crate) fn bench_selu_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::selu(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::selu(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/reduction_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/reduction_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_cumsum_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::cumsum(black_box(&x_seq), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::cumsum(black_box(&x_moirai), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -46,13 +50,17 @@ pub(crate) fn bench_cumprod_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::cumprod(black_box(&x_seq), 0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::cumprod(black_box(&x_moirai), 0);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -74,13 +82,17 @@ pub(crate) fn bench_prod_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::prod(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::prod(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -102,13 +114,17 @@ pub(crate) fn bench_std_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::std_dev(black_box(&x_seq), true);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::std_dev(black_box(&x_moirai), true);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/reduction_forward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/reduction_forward.rs
@@ -231,13 +231,17 @@ pub(crate) fn bench_var2_forward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::var(black_box(&x_seq), true);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::var(black_box(&x_moirai), true);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/tensor_operation.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/tensor_operation.rs
@@ -154,13 +154,17 @@ pub(crate) fn bench_softmax_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::softmax(black_box(&x_seq), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::softmax(black_box(&x_moirai), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -182,13 +186,17 @@ pub(crate) fn bench_softmin_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::softmin(black_box(&x_seq), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::softmin(black_box(&x_moirai), 1);
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/trigonometric_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/trigonometric_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_atan_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::atan(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::atan(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -46,13 +50,17 @@ pub(crate) fn bench_sinh_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::sinh(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::sinh(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -74,13 +82,17 @@ pub(crate) fn bench_cosh_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::cosh(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::cosh(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -102,13 +114,17 @@ pub(crate) fn bench_asinh_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::asinh(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::asinh(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -130,13 +146,17 @@ pub(crate) fn bench_acosh_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::acosh(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::acosh(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -158,13 +178,17 @@ pub(crate) fn bench_acos_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::acos(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::acos(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -186,13 +210,17 @@ pub(crate) fn bench_asin_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::asin(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::asin(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -214,13 +242,17 @@ pub(crate) fn bench_sin_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::sin(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::sin(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -242,13 +274,17 @@ pub(crate) fn bench_cos_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::cos(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::cos(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -270,13 +306,17 @@ pub(crate) fn bench_tan_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::tan(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::tan(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/benches/nn_bench/provider/unary_backward.rs
+++ b/crates/coeus-nn/benches/nn_bench/provider/unary_backward.rs
@@ -18,13 +18,17 @@ pub(crate) fn bench_erf_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::erf(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::erf(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -46,13 +50,17 @@ pub(crate) fn bench_erfc_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::erfc(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::erfc(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -74,13 +82,17 @@ pub(crate) fn bench_sqrt_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::sqrt(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::sqrt(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -102,13 +114,17 @@ pub(crate) fn bench_sqrt_backward2(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::sqrt(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::sqrt(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -130,13 +146,17 @@ pub(crate) fn bench_abs_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::abs(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::abs(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -158,13 +178,17 @@ pub(crate) fn bench_recip_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::recip(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::recip(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -186,13 +210,17 @@ pub(crate) fn bench_neg_backward(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::neg(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::neg(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -214,13 +242,17 @@ pub(crate) fn bench_neg_backward2(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::neg(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::neg(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();
@@ -242,13 +274,17 @@ pub(crate) fn bench_abs_backward2(c: &mut Criterion) {
     group.bench_function("Coeus Sequential", |b| {
         b.iter(|| {
             let o = coeus_autograd::abs(black_box(&x_seq));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.bench_function("Coeus Moirai", |b| {
         b.iter(|| {
             let o = coeus_autograd::abs(black_box(&x_moirai));
-            black_box(o).backward()
+            black_box(o)
+                .backward()
+                .expect("invariant: valid autograd fixture completes backward")
         })
     });
     group.finish();

--- a/crates/coeus-nn/src/conv/depthwise3d.rs
+++ b/crates/coeus-nn/src/conv/depthwise3d.rs
@@ -160,7 +160,9 @@ mod tests {
 
         assert_eq!(output.tensor.shape(), &[1, 2, 1, 1, 2]);
         assert_eq!(output.tensor.as_slice(), &[9.0, 11.0, 17.0, 20.0]);
-        output.backward();
+        output
+            .backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert_eq!(
             input.grad().expect("input gradient").as_slice(),
             &[2.0, 2.0, 3.0, 3.0]

--- a/crates/coeus-nn/tests/nn/attention.rs
+++ b/crates/coeus-nn/tests/nn/attention.rs
@@ -67,7 +67,9 @@ fn test_mha_backward_gradients_exist() {
         true,
     );
     let output = mha.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(mha.w_q.grad().is_some());
     assert!(mha.w_k.grad().is_some());

--- a/crates/coeus-nn/tests/nn/conv1d.rs
+++ b/crates/coeus-nn/tests/nn/conv1d.rs
@@ -78,7 +78,9 @@ fn test_conv1d_backward_gradients_match_reference() {
     );
 
     let output = conv.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_grad = input.grad().expect("input gradient must be set");
     assert_eq!(input_grad.shape(), &[1, 1, 4]);
@@ -169,7 +171,9 @@ fn test_non_contiguous_cross_entropy() {
     let loss_ce_cont = cross_entropy_loss(&logits_cont, &targets);
     assert!((loss_ce.tensor.as_slice()[0] - loss_ce_cont.tensor.as_slice()[0]).abs() < 1e-7);
 
-    loss_ce.backward();
+    loss_ce
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(logits.grad().is_some());
 }
 
@@ -203,11 +207,15 @@ fn test_sliced_offset_cross_entropy() {
     let loss_ce_cont = cross_entropy_loss(&logits_cont, &targets);
     assert!((loss_ce.tensor.as_slice()[0] - loss_ce_cont.tensor.as_slice()[0]).abs() < 1e-7);
 
-    loss_ce.backward();
+    loss_ce
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(logits.grad().is_some());
     let grad = logits.grad().unwrap();
 
-    loss_ce_cont.backward();
+    loss_ce_cont
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad_cont = logits_cont.grad().unwrap();
     assert_eq!(grad.shape(), &[2, 3]);
     for i in 0..6 {

--- a/crates/coeus-nn/tests/nn/conv2d.rs
+++ b/crates/coeus-nn/tests/nn/conv2d.rs
@@ -65,7 +65,9 @@ fn test_conv2d_backward_gradients_match_reference() {
     );
 
     let output = conv.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_grad = input.grad().expect("input gradient must be set");
     assert_eq!(input_grad.shape(), &[1, 1, 3, 3]);

--- a/crates/coeus-nn/tests/nn/conv3d_pool3d.rs
+++ b/crates/coeus-nn/tests/nn/conv3d_pool3d.rs
@@ -54,7 +54,9 @@ fn test_conv3d_backward_gradients_match_reference() {
     );
 
     let output = conv.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_grad = input.grad().expect("input gradient must be set");
     assert_eq!(input_grad.shape(), &[1, 1, 2, 2, 2]);
@@ -96,7 +98,9 @@ fn test_batchnorm3d_forward_and_backward() {
         assert!(val.abs() < 1e-7);
     }
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(bn.weight.grad().is_some());
     assert!(bn.bias.grad().is_some());
@@ -117,7 +121,9 @@ fn test_max_pool3d_forward_and_backward() {
     assert_eq!(output.tensor.shape(), &[1, 1, 1, 1, 1]);
     assert_eq!(output.tensor.as_slice(), &[8.0]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         input.grad().unwrap().as_slice(),
         &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
@@ -139,7 +145,9 @@ fn test_avg_pool3d_forward_and_backward() {
     assert_eq!(output.tensor.shape(), &[1, 1, 1, 1, 1]);
     assert_eq!(output.tensor.as_slice(), &[4.5]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().unwrap();
     for &g in grad.as_slice() {
         assert!((g - 0.125).abs() < 1e-7);

--- a/crates/coeus-nn/tests/nn/linear_activation_loss.rs
+++ b/crates/coeus-nn/tests/nn/linear_activation_loss.rs
@@ -71,7 +71,9 @@ fn test_linear_layer() {
     assert_eq!(output.tensor.shape(), &[1, 2]);
     assert_eq!(output.tensor.as_slice(), &[6.5, 6.5]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         input
             .grad()
@@ -125,7 +127,9 @@ fn linear_projects_last_axis_for_rank_three_and_preserves_gradients() {
         &[-1.75, 8.5, -1.75, 20.5, -1.75, 0.5, 1.75, -2.75]
     );
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         input
             .grad()
@@ -183,7 +187,9 @@ fn test_load_parameters_applies_optimizer_step_to_the_module() {
 
     let x = Var::new(Tensor::from_slice(vec![1, 2], &[3.0f64, 4.0]), false);
     let output = layer.forward(&x); // w . x + b = 1*3 + 1*4 + 0 = 7
-    output.backward(); // d(output)/d(weight) = x = [3, 4]; d(output)/d(bias) = 1
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward"); // d(output)/d(weight) = x = [3, 4]; d(output)/d(bias) = 1
 
     let lr = 0.1;
     let mut opt = SGD::new(layer.named_parameters(), lr, 0.0);
@@ -229,7 +235,9 @@ fn test_activations() {
     // ReLU
     let out_relu = relu(&input);
     assert_eq!(out_relu.tensor.as_slice(), &[0.0, 0.0, 0.5, 2.0]);
-    out_relu.backward();
+    out_relu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(input.grad().unwrap().as_slice(), &[0.0, 0.0, 1.0, 1.0]);
 
     // Sigmoid
@@ -256,7 +264,9 @@ fn test_losses() {
     // MSE
     let loss_mse = mse_loss(&pred, &target);
     assert_eq!(loss_mse.tensor.as_slice(), &[0.25]);
-    loss_mse.backward();
+    loss_mse
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         pred.grad()
             .expect("mse prediction gradient must be populated")
@@ -270,7 +280,9 @@ fn test_losses() {
     let targets = vec![1, 2];
     let loss_ce = cross_entropy_loss(&logits, &targets);
     assert_eq!(loss_ce.tensor.shape(), &[1]);
-    loss_ce.backward();
+    loss_ce
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let expected_ce_gradients = expected_cross_entropy_gradients(logits_values, 2, 3, &targets);
     assert_slice_close(
         "cross_entropy_logits_grad",

--- a/crates/coeus-nn/tests/nn/log_softmax_cat_split.rs
+++ b/crates/coeus-nn/tests/nn/log_softmax_cat_split.rs
@@ -23,7 +23,8 @@ fn test_log_softmax_backward() {
     let log_probs = coeus_autograd::log_softmax(&input, 1);
     let target: Var<f64> = Var::new(Tensor::from_slice(vec![1, 3], &[0.0f64, 1.0, 0.0]), false);
     let loss = coeus_nn::loss::mse_loss(&log_probs, &target);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let g = input.grad().unwrap();
     assert_eq!(g.shape(), &[1, 3]);
@@ -45,7 +46,8 @@ fn test_cat_backward_gradient_split() {
     let a = Var::<f64>::new(Tensor::from_slice(vec![2, 3], &a_data), true);
     let b = Var::<f64>::new(Tensor::from_slice(vec![2, 4], &b_data), true);
     let out = coeus_autograd::cat(&[&a, &b], 1);
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(a.grad().is_some());
     assert!(b.grad().is_some());
     let ga = a.grad().unwrap();
@@ -61,7 +63,8 @@ fn test_cat_along_dim0() {
     let c = Var::<f64>::new(Tensor::zeros(vec![1, 5]), true);
     let out = coeus_autograd::cat(&[&a, &b, &c], 0);
     assert_eq!(out.tensor.shape(), &[6, 5]);
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(a.grad().unwrap().shape(), &[2, 5]);
     assert_eq!(b.grad().unwrap().shape(), &[3, 5]);
     assert_eq!(c.grad().unwrap().shape(), &[1, 5]);
@@ -96,7 +99,8 @@ fn test_split_backward_accumulation() {
     let chunks = coeus_autograd::split(&input, 2, 1);
     let target = Var::<f64>::new(Tensor::from_slice(vec![1, 2], &[0.0f64, 0.0]), false);
     let loss = coeus_nn::loss::mse_loss(&chunks[0], &target);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = input.grad().unwrap();
     assert_eq!(g.shape(), &[1, 4]);
     assert_eq!(g.as_slice()[2], 0.0);

--- a/crates/coeus-nn/tests/nn/normalization.rs
+++ b/crates/coeus-nn/tests/nn/normalization.rs
@@ -27,7 +27,9 @@ fn test_groupnorm_forward_and_backward() {
     let group0_sum: f64 = out_slice[..6].iter().sum();
     assert!(group0_sum.abs() < 1e-5, "group0_sum={group0_sum}");
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(gn.weight.grad().is_some());
     assert!(gn.bias.grad().is_some());
@@ -45,7 +47,9 @@ fn test_groupnorm_g1_is_layernorm() {
     let output = gn.forward(&input);
     assert_eq!(output.tensor.shape(), &[2, 4]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 }
 
@@ -63,7 +67,9 @@ fn test_instancenorm1d_forward_and_backward() {
         assert!(v.abs() < 1e-5);
     }
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(inst.weight.grad().is_some());
     assert!(inst.bias.grad().is_some());
@@ -91,7 +97,9 @@ fn test_instancenorm1d_non_constant_backward() {
     let mean0: f64 = s[..4].iter().sum::<f64>() / 4.0;
     assert!(mean0.abs() < 1e-5);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 }
 
@@ -111,7 +119,9 @@ fn test_instancenorm2d_forward_and_backward() {
     assert!(mean0.abs() < 1e-5, "mean0={mean0}");
     assert!(mean1.abs() < 1e-5, "mean1={mean1}");
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(inst.weight.grad().is_some());
     assert!(inst.bias.grad().is_some());

--- a/crates/coeus-nn/tests/nn/rope_and_transpose.rs
+++ b/crates/coeus-nn/tests/nn/rope_and_transpose.rs
@@ -21,7 +21,9 @@ fn test_rope_backward() {
         true,
     );
     let output = rope.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let g = input.grad().unwrap();
     assert_eq!(g.shape(), &[1, 2, 1, 4]);
@@ -81,7 +83,8 @@ fn test_general_transpose_autograd() {
     assert_eq!(transposed.tensor.shape(), &[4, 3, 2]);
 
     let sum = coeus_autograd::sum(&transposed);
-    sum.backward();
+    sum.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let g = input.grad().unwrap();
     assert_eq!(g.shape(), &[2, 3, 4]);

--- a/crates/coeus-nn/tests/nn_ops/activations/act_extended/parameterized.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/act_extended/parameterized.rs
@@ -47,7 +47,9 @@ fn prelu_forward_and_backward() {
     );
     let output = prelu(&input, &weight);
     assert_close_slice("prelu_forward", output.tensor.as_slice(), &expected, 1e-12);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("prelu requires grad");
     assert_close_slice("prelu_backward", grad.as_slice(), &expected_grad, 1e-12);
     // grad_weight = sum of x over the x<=0 region: -2 + -1 + 0 = -3.0.
@@ -68,7 +70,9 @@ fn prelu_module_weight_learns_via_optimizer_round_trip() {
         false,
     );
     let output = module.forward(&x); // prelu([-2,3], w=0.25) = [-0.5, 3.0]
-    coeus_autograd::sum(&output).backward();
+    coeus_autograd::sum(&output)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let lr = 0.1;
     let mut opt = SGD::new(module.named_parameters(), lr, 0.0);
@@ -117,7 +121,9 @@ fn leaky_relu_kink_at_zero_returns_slope() {
         &data,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("leaky_relu requires grad");
     let expected_grad = vec![slope];
     assert_close_slice("leaky_relu_kink_dx", grad.as_slice(), &expected_grad, 1e-12);
@@ -140,7 +146,9 @@ fn clamp_kink_at_boundary_returns_one() {
     let output = coeus_autograd::clamp(&input, lo, hi);
     // Forward at the boundary is unchanged (clamp(x, x, x) = x).
     assert_close_slice("clamp_kink_out", output.tensor.as_slice(), &data, 1e-12);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("clamp requires grad");
     // Backward at both kink positions must be 1 per PyTorch convention.
     let expected_grad = vec![1.0_f64, 1.0_f64];

--- a/crates/coeus-nn/tests/nn_ops/activations/act_extended/piecewise.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/act_extended/piecewise.rs
@@ -47,7 +47,9 @@ fn hardswish_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("hardswish requires grad");
     assert_close_slice("hardswish_backward", grad.as_slice(), &expected_grad, 1e-12);
 }
@@ -83,7 +85,9 @@ fn hardsigmoid_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("hardsigmoid requires grad");
     assert_close_slice(
         "hardsigmoid_backward",
@@ -128,7 +132,9 @@ fn hardtanh_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("hardtanh requires grad");
     assert_close_slice("hardtanh_backward", grad.as_slice(), &expected_grad, 1e-12);
     // Validate the bit-packing helper is reversible.
@@ -179,7 +185,9 @@ fn softshrink_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("softshrink requires grad");
     assert_close_slice(
         "softshrink_backward",
@@ -228,7 +236,9 @@ fn hardshrink_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("hardshrink requires grad");
     assert_close_slice(
         "hardshrink_backward",
@@ -265,7 +275,9 @@ fn softsign_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("softsign requires grad");
     assert_close_slice("softsign_backward", grad.as_slice(), &expected_grad, 1e-12);
 }
@@ -312,7 +324,9 @@ fn threshold_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("threshold requires grad");
     assert_close_slice("threshold_backward", grad.as_slice(), &expected_grad, 1e-12);
 }
@@ -348,7 +362,9 @@ fn celu_forward_and_backward() {
     );
     let output = celu(&input, alpha);
     assert_close_slice("celu_forward", output.tensor.as_slice(), &expected, 1e-12);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("celu requires grad");
     assert_close_slice("celu_backward", grad.as_slice(), &expected_grad, 1e-12);
 }

--- a/crates/coeus-nn/tests/nn_ops/activations/act_extended/smooth.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/act_extended/smooth.rs
@@ -24,7 +24,9 @@ fn log_sigmoid_forward_and_backward() {
         &expected,
         1e-10,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("log_sigmoid requires grad");
     assert_close_slice(
         "log_sigmoid_backward",
@@ -54,7 +56,9 @@ fn tanhshrink_forward_and_backward() {
         &expected,
         1e-12,
     );
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("tanhshrink requires grad");
     assert_close_slice(
         "tanhshrink_backward",

--- a/crates/coeus-nn/tests/nn_ops/activations/nn_activation_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/nn_activation_tests.rs
@@ -25,7 +25,9 @@ fn test_elu_activation() {
     }
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let grad_slice = input.grad().unwrap().as_slice().to_vec();
 
@@ -66,7 +68,9 @@ fn test_softplus_activation() {
     }
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let grad_slice = input.grad().unwrap().as_slice().to_vec();
 
@@ -113,7 +117,9 @@ fn test_gelu_tanh_activation() {
     }
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let grad_slice = input.grad().unwrap().as_slice().to_vec();
 
@@ -162,7 +168,9 @@ fn test_leaky_relu_activation() {
     }
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let grad_slice = input.grad().unwrap().as_slice().to_vec();
 
@@ -200,14 +208,18 @@ fn test_non_contiguous_activations() {
     // Test ELU on transposed view
     let output_elu = elu(&input);
     assert_eq!(output_elu.tensor.shape(), &[3, 2]);
-    output_elu.backward();
+    output_elu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 
     // Reset gradient for next test
     let input2 = Var::new(input_raw.transpose(), true);
     let output_leaky = leaky_relu(&input2, 0.2);
     assert_eq!(output_leaky.tensor.shape(), &[3, 2]);
-    output_leaky.backward();
+    output_leaky
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input2.grad().is_some());
 }
 
@@ -229,7 +241,8 @@ fn test_glu_forward_and_gradient() {
     assert!((o[1] - 2.0 * s4).abs() < 1e-12, "glu[1]: {}", o[1]);
 
     // grad of sum(glu): d/da_i = sigma(b_i); d/db_i = a_i * sigma(b_i)(1-sigma(b_i)).
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = input.grad().expect("glu input grad");
     let gs = g.as_slice();
     let expected = [

--- a/crates/coeus-nn/tests/nn_ops/activations/nn_mish_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/nn_mish_tests.rs
@@ -53,7 +53,9 @@ fn test_mish_functional_cpu() {
     assert_mish_values("functional_forward", out_slice, &input_data);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let grad_slice = input.grad().unwrap().as_slice().to_vec();
 
@@ -75,7 +77,9 @@ fn test_mish_module_cpu() {
     assert_mish_values("module_forward", output.tensor.as_slice(), &input_data);
     assert_eq!(Module::<f64, MoiraiBackend>::parameters(&mish_mod).len(), 0);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("invariant: Mish input requires grad");
     assert_mish_grads("module_backward", grad.as_slice(), &input_data);
 }
@@ -96,7 +100,9 @@ fn test_mish_non_contiguous_cpu() {
         &logical_input,
     );
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input
         .grad()
         .expect("invariant: non-contiguous Mish input requires grad");

--- a/crates/coeus-nn/tests/nn_ops/activations/nn_silu_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/nn_silu_tests.rs
@@ -51,7 +51,9 @@ fn test_silu_functional_cpu() {
     assert_silu_values("functional_forward", out_slice, &input_data);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     let grad_slice = input.grad().unwrap().as_slice().to_vec();
 
@@ -73,7 +75,9 @@ fn test_silu_module_cpu() {
     assert_silu_values("module_forward", output.tensor.as_slice(), &input_data);
     assert_eq!(Module::<f64, MoiraiBackend>::parameters(&silu_mod).len(), 0);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("invariant: SiLU input requires grad");
     assert_silu_grads("module_backward", grad.as_slice(), &input_data);
 }
@@ -94,7 +98,9 @@ fn test_silu_non_contiguous_cpu() {
         &logical_input,
     );
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input
         .grad()
         .expect("invariant: non-contiguous SiLU input requires grad");

--- a/crates/coeus-nn/tests/nn_ops/activations/swiglu_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/activations/swiglu_tests.rs
@@ -70,7 +70,9 @@ fn swiglu_backward_populates_parameter_grads() {
     );
 
     let output = swiglu.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     for (i, p) in swiglu.parameters().iter().enumerate() {
         let grad = p

--- a/crates/coeus-nn/tests/nn_ops/attention/nn_attention_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/attention/nn_attention_tests.rs
@@ -127,7 +127,8 @@ mod tests {
 
         // Sum-reduce to scalar loss and backprop
         let loss = coeus_autograd::sum(&out);
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
 
         // All three inputs must have non-None gradients
         for (label, var) in [("q", &q), ("k", &k), ("v", &v)] {
@@ -185,7 +186,8 @@ mod tests {
 
         let out = mha.forward(&x_var);
         let loss = coeus_autograd::sum(&out);
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
 
         let params = mha.parameters();
         assert!(!params.is_empty(), "MHA must have parameters");
@@ -343,7 +345,8 @@ mod tests {
 
         let out = layer.forward(&x_var);
         let loss = coeus_autograd::sum(&out);
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
 
         let params = layer.parameters();
         for (i, p) in params.iter().enumerate() {
@@ -380,7 +383,8 @@ mod tests {
         );
 
         let loss = coeus_autograd::sum(&out);
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
 
         let params = layer.parameters();
         for (i, p) in params.iter().enumerate() {
@@ -469,7 +473,8 @@ mod tests {
         println!("aw_data: {:?}", aw_data);
 
         let loss = coeus_autograd::sum(&out);
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
 
         let k_grad = k_var.grad.as_ref().unwrap().read();
         let k_grad_slice = k_grad.storage().try_as_slice().unwrap();

--- a/crates/coeus-nn/tests/nn_ops/attention/nn_transformer_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/attention/nn_transformer_tests.rs
@@ -150,7 +150,8 @@ fn test_transformer_decoder_layer() {
 
     // Backward pass
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(tgt.grad().is_some());
     assert!(memory.grad().is_some());
@@ -194,7 +195,8 @@ fn test_transformer_decoder() {
     assert_eq!(output.tensor.shape(), &[batch, seq_tgt, d_model]);
 
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(tgt.grad().is_some());
     assert!(memory.grad().is_some());
@@ -262,7 +264,8 @@ fn test_transformer_seq2seq() {
     assert_eq!(output.tensor.shape(), &[batch, seq_tgt, d_model]);
 
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(src.grad().is_some());
     assert!(tgt.grad().is_some());

--- a/crates/coeus-nn/tests/nn_ops/convolution/nn_3d_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/convolution/nn_3d_tests.rs
@@ -44,7 +44,9 @@ fn test_conv3d_comprehensive() {
     assert!((out_slice[0] - 204.5).abs() < 1e-7);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     // dy/dx_i = w_i
@@ -98,7 +100,9 @@ fn test_max_pool3d_comprehensive() {
     assert_eq!(output.tensor.as_slice(), &[8.0]);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     // dy/dx should be 1.0 at index 7 (where element is 8.0) and 0.0 elsewhere
@@ -137,7 +141,9 @@ fn test_avg_pool3d_comprehensive() {
     assert_eq!(output.tensor.as_slice(), &[4.5]);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     // dy/dx_i should be 1/8 = 0.125 for all i
@@ -199,7 +205,9 @@ fn test_batchnorm3d_comprehensive() {
     }
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients exist on inputs, weight, and bias
     assert!(input.grad().is_some());

--- a/crates/coeus-nn/tests/nn_ops/convolution/unfold_fold_parity.rs
+++ b/crates/coeus-nn/tests/nn_ops/convolution/unfold_fold_parity.rs
@@ -168,7 +168,9 @@ fn unfold1d_backward_accumulates_window_overlap() {
         Tensor::<f64, SequentialBackend>::from_slice(vec![1, 1, 5], &data),
         true,
     );
-    m.forward(&x).backward();
+    m.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = x.grad().expect("unfold1d input gradient");
     assert_eq!(grad.as_slice(), &[1.0, 2.0, 3.0, 2.0, 1.0]);
     assert!(
@@ -187,7 +189,9 @@ fn unfold2d_backward_accumulates_window_overlap() {
         Tensor::<f64, SequentialBackend>::from_slice(vec![1, 1, 3, 3], &data),
         true,
     );
-    m.forward(&x).backward();
+    m.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = x.grad().expect("unfold2d input gradient");
     assert_eq!(
         grad.as_slice(),
@@ -208,7 +212,8 @@ fn fold1d_backward_is_im2col_of_ones() {
     );
     let y = m.forward(&x);
     assert_eq!(y.tensor.shape(), &[1, 1, 6]);
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         x.grad().expect("fold1d input gradient").as_slice(),
         &[1.0; 6]
@@ -225,7 +230,8 @@ fn fold2d_backward_is_im2col_of_ones() {
     );
     let y = m.forward(&x);
     assert_eq!(y.tensor.shape(), &[1, 1, 4, 4]);
-    y.backward();
+    y.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert_eq!(
         x.grad().expect("fold2d input gradient").as_slice(),
         &[1.0; 16]

--- a/crates/coeus-nn/tests/nn_ops/embedding/embeddingbag_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/embedding/embeddingbag_tests.rs
@@ -51,7 +51,8 @@ fn embeddingbag_empty_bag_emits_zeros() {
 fn embeddingbag_sum_backward_accumulates_weight_grads() {
     let bag = seeded_embedding_bag(EmbeddingBagMode::Sum);
     let out = bag.forward_with_offsets(&[0, 1, 1, 2], Some(&[0, 2]));
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let grad = bag.weight.grad().expect("weight grad must exist");
     assert_eq!(grad.shape(), &[4, 2]);

--- a/crates/coeus-nn/tests/nn_ops/embedding/nn_embedding_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/embedding/nn_embedding_tests.rs
@@ -51,7 +51,9 @@ fn test_embedding_forward_backward_indices() {
     assert_eq!(&out_slice[9..12], &[2.0, 2.1, 2.2]);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients on weights
     let weight_grad = layer.weight.grad().unwrap();
@@ -126,7 +128,9 @@ fn test_embedding_non_contiguous() {
 
     // Backward pass
     let grad_out = Tensor::from_slice(vec![2, 2, 2], &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0]);
-    output.backward_with_seed(grad_out);
+    output
+        .backward_with_seed(grad_out)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let weight_grad = layer.weight.grad().unwrap();
     assert_eq!(weight_grad.shape(), &[3, 2]);

--- a/crates/coeus-nn/tests/nn_ops/losses/ctc_loss_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/losses/ctc_loss_tests.rs
@@ -107,7 +107,8 @@ fn ctc_loss_backward_runs() {
     let logits = t3(&[1.0, 2.0, 0.5, 0.8, 1.5, 0.3], [2, 1, 3]);
     let log_probs = log_softmax(&logits, 2);
     let loss = ctc_loss(&log_probs, &[1usize], &[2], &[1], 0);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(
         logits.grad().is_some(),
         "gradient must propagate through ctc_loss"

--- a/crates/coeus-nn/tests/nn_ops/losses/nn_loss/binary.rs
+++ b/crates/coeus-nn/tests/nn_ops/losses/nn_loss/binary.rs
@@ -38,7 +38,8 @@ fn test_binary_cross_entropy() {
     assert!((loss_val - expected_loss).abs() < 1e-7);
 
     // Backward
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(pred.grad().is_some());
 }
 
@@ -63,7 +64,8 @@ fn test_binary_cross_entropy_clamping() {
     assert!(!loss_val.is_nan());
     assert!(!loss_val.is_infinite());
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(!pred.grad().unwrap().as_slice()[0].is_nan());
 }
 
@@ -95,7 +97,8 @@ fn test_huber_loss() {
     let expected = (0.125 + 1.5 + 0.5) / 3.0;
     assert!((loss_val - expected).abs() < 1e-7);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(pred.grad().is_some());
 }
 
@@ -122,7 +125,8 @@ fn test_l1_loss() {
         "l1_loss forward: got {loss_val:.17}, expected {expected:.17}"
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = pred.grad().expect("pred must receive a gradient");
     assert_eq!(grad.shape(), &[2, 2], "pred grad preserves input shape");
     let quarter = 1.0 / 4.0;
@@ -182,7 +186,8 @@ fn test_bce_with_logits() {
         "bce_with_logits forward: got {loss_val:.17}, expected {expected:.17}"
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // d/d_logit = (sigmoid(z) - y) / n; d/d_target = -z / n.
     let logit_grad = logits.grad().expect("logits must receive a gradient");
     let target_grad = target.grad().expect("target must receive a gradient");
@@ -272,7 +277,8 @@ fn test_smooth_l1_loss() {
 
     // d loss / d pred_i = (1/N)·(z/β if |z|<β else sign(z)):
     //   z=0.5 -> 0.5/1 / 3;  z=2 -> +1 / 3;  z=-3 -> -1 / 3.
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = pred.grad().expect("smooth_l1 pred grad");
     let expected_grad = [0.5 / 3.0, 1.0 / 3.0, -1.0 / 3.0];
     for (g, e) in grad.as_slice().iter().zip(expected_grad.iter()) {

--- a/crates/coeus-nn/tests/nn_ops/losses/nn_loss/classification.rs
+++ b/crates/coeus-nn/tests/nn_ops/losses/nn_loss/classification.rs
@@ -27,7 +27,8 @@ fn test_nll_loss() {
     let expected = -(-0.1 - 0.25 - 0.4) / 3.0;
     assert!((loss_val - expected).abs() < 1e-7);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(log_probs.grad().is_some());
 
     // Check gradients: -1 / N at target index, 0 elsewhere
@@ -66,7 +67,8 @@ fn test_soft_margin() {
         "soft_margin forward: got {loss_val:.17}, expected {expected:.17}"
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let sigmoid = |z: f64| 1.0 / (1.0 + (-z).exp());
     let input_grad = input.grad().expect("input must receive a gradient");
     let target_grad = target.grad().expect("target must receive a gradient");
@@ -113,7 +115,8 @@ fn test_multi_margin() {
         1.3 / 3.0
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g = x.grad().expect("x must receive a gradient");
     let third = 1.0 / 3.0;
     let expected = [-third, third, 0.0];
@@ -161,7 +164,8 @@ fn test_hinge_embedding_loss() {
         loss.tensor.as_slice()[0]
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // d/dx (seed 1/N from mean, N=4): identity branch (y=+1) -> 1/N; hinge
     // branch (y=-1) -> -1/N when margin > x else 0.
     //   i0: y=+1 -> 0.25            i1: y=-1, 1-2<0 -> 0
@@ -198,7 +202,8 @@ fn test_multi_label_soft_margin_loss() {
     let expected = (2.0f64.ln() + -(1.0 - sig2).ln()) / 2.0;
     assert!((loss.tensor.as_slice()[0] - expected).abs() < 1e-10);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // d BCEWithLogits/dx = (σ(x) - y)/N: i0 (0.5-1)/2=-0.25, i1 (σ(2)-0)/2.
     let grad = x.grad().expect("mlsm x grad");
     let g = grad.as_slice();

--- a/crates/coeus-nn/tests/nn_ops/losses/nn_loss/distance.rs
+++ b/crates/coeus-nn/tests/nn_ops/losses/nn_loss/distance.rs
@@ -38,7 +38,9 @@ fn test_pairwise_distance() {
         assert!((out[i] - exp).abs() <= 1e-12, "pd fwd {}", i);
     }
     let total = coeus_autograd::sum(&dist);
-    total.backward();
+    total
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g1 = x1.grad().expect("x1 grad");
     let g2 = x2.grad().expect("x2 grad");
     for i in 0..2 {
@@ -87,7 +89,8 @@ fn test_triplet_margin_loss() {
         loss.tensor.as_slice()[0]
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let ga = anchor.grad().expect("anchor grad");
     let gp = positive.grad().expect("positive grad");
     let gn = negative.grad().expect("negative grad");
@@ -141,7 +144,8 @@ fn test_margin_ranking_loss() {
     assert_eq!(loss.tensor.shape(), &[1]);
     assert_eq!(loss.tensor.as_slice(), &[0.5_f64]);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let g1 = input1
         .grad()
         .expect("invariant: margin ranking input1 requires grad");
@@ -231,7 +235,9 @@ fn test_cosine_embedding_loss() {
         Tensor::<f64, MoiraiBackend>::from_slice([1, 2], &[0.0_f64, 1.0]),
         true,
     );
-    cosine_embedding_loss(&x1_g, &x2_g, &[1.0_f64], 0.0).backward();
+    cosine_embedding_loss(&x1_g, &x2_g, &[1.0_f64], 0.0)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(x1_g.grad().is_some(), "x1 grad");
     assert!(x2_g.grad().is_some(), "x2 grad");
 }
@@ -258,7 +264,8 @@ fn test_cosine_similarity_forward_and_backward() {
     assert!(s[1].abs() < 1e-9, "row1 cos: got {}", s[1]);
 
     // Backward against a central finite-difference reference on sum(cos).
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic: Vec<f64> = x1.grad().expect("cosine x1 grad").as_slice().to_vec();
     let h = 1e-6;
     let forward_sum = |d: &[f64]| -> f64 {
@@ -310,6 +317,7 @@ fn test_triplet_margin_with_distance_loss() {
     assert_eq!(loss.tensor.shape(), &[1]);
     assert!((loss.tensor.as_slice()[0] - 1.5).abs() < 1e-12);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(anchor.grad().is_some(), "triplet anchor grad");
 }

--- a/crates/coeus-nn/tests/nn_ops/losses/nn_loss/distribution.rs
+++ b/crates/coeus-nn/tests/nn_ops/losses/nn_loss/distribution.rs
@@ -31,7 +31,8 @@ fn test_poisson_nll() {
         "poisson_nll forward: got {loss_val:.17}, expected {expected:.17}"
     );
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let input_grad = input.grad().expect("input must receive a gradient");
     let target_grad = target.grad().expect("target must receive a gradient");
     for (i, ((&z, &y), (&gz, &gt))) in zs
@@ -75,7 +76,8 @@ fn test_kl_divergence_loss() {
     assert_eq!(loss.tensor.shape(), &[1]);
     assert!(loss.tensor.as_slice()[0].abs() <= 2.0 * f64::EPSILON);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().expect("invariant: KL input requires grad");
     let grad_slice = grad.as_slice();
     assert!((grad_slice[0] + 0.125).abs() < 1e-12);
@@ -106,7 +108,8 @@ fn test_gaussian_nll_loss() {
     assert_eq!(loss.tensor.shape(), &[1]);
     assert!((loss.tensor.as_slice()[0] - 0.25).abs() < 1e-12);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     // d loss/d input_i = (in_i - t_i)/(N*var_i): [-0.5/1, 1/4] = [-0.5, 0.25].
     let grad = input.grad().expect("gnll input grad");
     let g = grad.as_slice();

--- a/crates/coeus-nn/tests/nn_ops/losses/regularization_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/losses/regularization_tests.rs
@@ -150,7 +150,9 @@ fn lrn_backward_matches_numerical_gradient() {
         Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
         true,
     );
-    lrn.forward(&x).backward();
+    lrn.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic: Vec<f64> = x.grad().expect("lrn input gradient").as_slice().to_vec();
 
     // Numerical: central differences of sum(LRN(x)). f64, h=1e-6 ⇒ error ~1e-10;

--- a/crates/coeus-nn/tests/nn_ops/normalization/nn_norm_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/normalization/nn_norm_tests.rs
@@ -45,7 +45,9 @@ fn test_layernorm() {
     }
 
     // Test backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(ln.weight.grad().is_some());
     assert!(ln.bias.grad().is_some());
@@ -74,7 +76,9 @@ fn test_rmsnorm() {
         );
     }
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(rms.weight.grad().is_some());
 }
@@ -102,7 +106,9 @@ fn test_dropout() {
     assert_eq!(zero_count + scale_count, 100);
 
     // Backward pass should propagate through non-zeroed masks
-    out_train.backward();
+    out_train
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 }
 
@@ -132,7 +138,9 @@ fn test_batchnorm1d_backward_gradients_exist() {
     );
 
     let output = bn.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     assert!(bn.weight.grad().is_some());
@@ -180,7 +188,9 @@ fn test_batchnorm2d_backward_gradients_exist() {
     );
 
     let output = bn.forward(&input);
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     assert!(bn.weight.grad().is_some());
@@ -227,7 +237,9 @@ fn test_batchnorm2d_multi_channel_forward() {
     let ch1_mean: f64 = out_slice[4..8].iter().sum::<f64>() / 4.0;
     assert!(ch1_mean.abs() < 1e-5);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 }
 
@@ -259,7 +271,9 @@ fn test_softmax_backward_uniform_seed() {
     let input: Var<f64> = Var::new(Tensor::from_slice(vec![1, 3], &[1.0, 2.0, 3.0]), true);
     let output = softmax(&input, -1);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 
     let g = input.grad().unwrap();
@@ -275,7 +289,9 @@ fn test_softmax_backward_nonuniform_seed() {
     let output = softmax(&input, -1);
 
     let seed = Tensor::from_slice(vec![1, 3], &[1.0, 0.0, 0.0]);
-    output.backward_with_seed(seed);
+    output
+        .backward_with_seed(seed)
+        .expect("invariant: valid autograd fixture completes backward");
 
     let g = input.grad().unwrap();
     assert_eq!(g.shape(), &[1, 3]);
@@ -363,7 +379,9 @@ fn test_layernorm_various_shapes() {
             assert!(mean.abs() < 1e-5);
         }
 
-        output.backward();
+        output
+            .backward()
+            .expect("invariant: valid autograd fixture completes backward");
         assert!(input.grad().is_some());
         assert!(ln.weight.grad().is_some());
         assert!(ln.bias.grad().is_some());
@@ -385,7 +403,9 @@ fn test_layernorm_single_element() {
     assert!((s[0] - 1.0).abs() < 1e-3);
     assert!((s[1] - 1.0).abs() < 1e-3);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
 }
 
@@ -400,7 +420,9 @@ fn test_avg_pool2d_forward_backward() {
     let out_slice = output.tensor.as_slice();
     assert_eq!(out_slice, &[3.5, 5.5, 11.5, 13.5]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().unwrap();
     assert_eq!(grad.shape(), &[1, 1, 4, 4]);
     for &val in grad.as_slice() {
@@ -419,7 +441,9 @@ fn test_max_pool2d_forward_backward() {
     let out_slice = output.tensor.as_slice();
     assert_eq!(out_slice, &[6.0, 8.0, 14.0, 16.0]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let grad = input.grad().unwrap();
     assert_eq!(grad.shape(), &[1, 1, 4, 4]);
     let grad_slice = grad.as_slice();

--- a/crates/coeus-nn/tests/nn_ops/normalization/nn_normalization_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/normalization/nn_normalization_tests.rs
@@ -24,7 +24,9 @@ fn test_group_norm() {
     assert_eq!(output.tensor.shape(), &[2, 6, 4]);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(gn.weight.grad().is_some());
     assert!(gn.bias.grad().is_some());
@@ -49,7 +51,9 @@ fn test_instance_norm_1d() {
     let output = in1d.forward(&input);
     assert_eq!(output.tensor.shape(), &[2, 4, 5]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(in1d.weight.grad().is_some());
     assert!(in1d.bias.grad().is_some());
@@ -72,7 +76,9 @@ fn test_instance_norm_2d() {
     let output = in2d.forward(&input);
     assert_eq!(output.tensor.shape(), &[2, 3, 4, 4]);
 
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(in2d.weight.grad().is_some());
     assert!(in2d.bias.grad().is_some());

--- a/crates/coeus-nn/tests/nn_ops/normalization/norm_parity.rs
+++ b/crates/coeus-nn/tests/nn_ops/normalization/norm_parity.rs
@@ -295,7 +295,8 @@ where
     }
 
     // Verify backward propagates to weight and bias.
-    out.backward();
+    out.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(bn.weight.grad().is_some(), "weight grad must exist");
     assert!(bn.bias.grad().is_some(), "bias grad must exist");
 }

--- a/crates/coeus-nn/tests/nn_ops/pooling/adaptive_pool_parity.rs
+++ b/crates/coeus-nn/tests/nn_ops/pooling/adaptive_pool_parity.rs
@@ -207,7 +207,9 @@ fn adaptive_avg_pool1d_backward_matches_numerical_gradient() {
         Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
         true,
     );
-    m.forward(&x).backward();
+    m.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic: Vec<f64> = x
         .grad()
         .expect("adaptive avg pool 1d gradient")
@@ -237,7 +239,9 @@ fn adaptive_avg_pool2d_backward_matches_numerical_gradient() {
         Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
         true,
     );
-    m.forward(&x).backward();
+    m.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic: Vec<f64> = x
         .grad()
         .expect("adaptive avg pool 2d gradient")
@@ -268,7 +272,9 @@ fn adaptive_max_pool1d_backward_matches_numerical_gradient() {
         Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
         true,
     );
-    m.forward(&x).backward();
+    m.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic: Vec<f64> = x
         .grad()
         .expect("adaptive max pool 1d gradient")
@@ -300,7 +306,9 @@ fn adaptive_max_pool2d_backward_matches_numerical_gradient() {
         Tensor::<f64, SequentialBackend>::from_slice(shape, &data),
         true,
     );
-    m.forward(&x).backward();
+    m.forward(&x)
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     let analytic: Vec<f64> = x
         .grad()
         .expect("adaptive max pool 2d gradient")

--- a/crates/coeus-nn/tests/nn_ops/recurrent/nn_sequential_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/recurrent/nn_sequential_tests.rs
@@ -34,7 +34,9 @@ fn test_sequential_container() {
     assert_eq!(output.tensor.shape(), &[2, 2]);
 
     // Backward pass
-    output.backward();
+    output
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(input.grad().is_some());
     assert!(params[0].grad().is_some()); // weight1
     assert!(params[1].grad().is_some()); // bias1

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_new_ops_tests.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_new_ops_tests.rs
@@ -28,7 +28,8 @@ fn test_groupnorm_forward_backward() {
 
     // Backward pass
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     assert!(gn.weight.grad().is_some());
@@ -52,7 +53,8 @@ fn test_instancenorm1d_forward_backward() {
     assert_eq!(output.tensor.shape(), &[2, 3, 4]);
 
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     assert!(in1d.weight.grad().is_some());
@@ -76,7 +78,8 @@ fn test_instancenorm2d_forward_backward() {
     assert_eq!(output.tensor.shape(), &[1, 2, 3, 3]);
 
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     assert!(in2d.weight.grad().is_some());
@@ -96,7 +99,8 @@ fn test_sequential_chaining() {
     assert_eq!(output.tensor.shape(), &[2, 2]);
 
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     let params = seq.parameters();
@@ -118,7 +122,8 @@ fn test_binary_cross_entropy_loss() {
     let loss = binary_cross_entropy(&pred, &target, 1e-7);
     assert_eq!(loss.tensor.shape(), &[1]);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(pred.grad().is_some());
 }
 
@@ -134,7 +139,8 @@ fn test_nll_loss() {
     let loss = nll_loss(&log_probs, &targets);
     assert_eq!(loss.tensor.shape(), &[1]);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(log_probs.grad().is_some());
 }
 
@@ -150,7 +156,8 @@ fn test_huber_loss() {
     let loss = huber_loss(&pred, &target, 1.0);
     assert_eq!(loss.tensor.shape(), &[1]);
 
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
     assert!(pred.grad().is_some());
 }
 
@@ -166,7 +173,8 @@ fn test_static_sequential_chaining() {
     assert_eq!(output.tensor.shape(), &[2, 2]);
 
     let loss = coeus_autograd::sum(&output);
-    loss.backward();
+    loss.backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     assert!(input.grad().is_some());
     let params = model.parameters();

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/attention.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/attention.rs
@@ -132,7 +132,9 @@ fn test_mha_parity() {
 
     // Backward
     let loss_coeus = coeus_autograd::sum(&out_coeus);
-    loss_coeus.backward();
+    loss_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify input gradients
     let dq_coeus = q_coeus.grad().unwrap();

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/convolution.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/convolution.rs
@@ -40,7 +40,9 @@ fn test_conv1d_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &expected_conv1d_out, 1e-4);
 
     // Coeus backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     let dx_coeus = x_coeus.grad().unwrap();
@@ -123,7 +125,9 @@ fn test_conv2d_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &expected_conv2d_out, 1e-4);
 
     // Coeus backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     let dx_coeus = x_coeus.grad().unwrap();
@@ -199,7 +203,9 @@ fn test_conv3d_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &expected_conv3d_out, 1e-4);
 
     // Coeus backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     let dx_coeus = x_coeus.grad().unwrap();

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/embedding.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/embedding.rs
@@ -52,7 +52,9 @@ fn test_embedding_parity() {
 
     // Backward pass
     let loss_coeus = coeus_autograd::sum(&out_coeus);
-    loss_coeus.backward();
+    loss_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let dw_coeus = emb_coeus.weight.grad().unwrap();
     let expected_embedding_dw = vec![

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/linear_norm.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/linear_norm.rs
@@ -28,7 +28,9 @@ fn test_linear_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &expected_linear_out, 1e-4);
 
     // Coeus backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     let dx_coeus = x_coeus.grad().unwrap();
@@ -89,7 +91,9 @@ fn test_layernorm_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &expected_layernorm_out, 1e-3);
 
     // Coeus backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     // Verify gradients
     let dx_coeus = x_coeus.grad().unwrap();

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/losses.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/losses.rs
@@ -27,7 +27,9 @@ fn test_softmax_parity() {
 
     // Backward
     let loss_coeus = coeus_autograd::sum(&out_coeus);
-    loss_coeus.backward();
+    loss_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let dx_coeus = x_coeus.grad().unwrap();
     let expected_softmax_dx = vec![
@@ -63,7 +65,9 @@ fn test_cross_entropy_loss_parity() {
     );
 
     // Backward
-    loss_coeus.backward();
+    loss_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let dlogits_coeus = logits_coeus.grad().unwrap();
     let expected_cross_entropy_dlogits = vec![

--- a/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/regularization.rs
+++ b/crates/coeus-nn/tests/nn_ops/tensor/nn_parity/regularization.rs
@@ -22,7 +22,9 @@ fn test_dropout_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &x_data, 1e-4);
 
     // Backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let dx_coeus = x_coeus.grad().unwrap();
 
@@ -38,7 +40,9 @@ fn test_dropout_parity() {
     let mut dropout_coeus2 = coeus_nn::Dropout::new(0.5);
     dropout_coeus2.is_training = true;
     let out_coeus2 = dropout_coeus2.forward(&x_coeus2);
-    out_coeus2.backward();
+    out_coeus2
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let slice: &[f32] = out_coeus2.tensor.as_slice();
     for &val in slice {
@@ -102,7 +106,9 @@ fn test_batchnorm2d_parity() {
     assert_tensor_eq_data(&out_coeus.tensor, &expected_batchnorm2d_out, 1e-3);
 
     // Backward
-    out_coeus.backward();
+    out_coeus
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let dx_coeus = x_coeus.grad().unwrap();
     let dw_coeus = bn_coeus.weight.grad().unwrap();

--- a/crates/coeus-optim/examples/linear_regression.rs
+++ b/crates/coeus-optim/examples/linear_regression.rs
@@ -66,7 +66,8 @@ fn main() {
         let pred = add(&matmul(&x, &opt.params[0]), &opt.params[1]);
         let diff = sub(&pred, &y);
         let loss = mean(&mul(&diff, &diff)); // MSE
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         opt.step();
 
         last_loss = loss.tensor.as_slice()[0];

--- a/crates/coeus-optim/examples/mlp_classifier.rs
+++ b/crates/coeus-optim/examples/mlp_classifier.rs
@@ -79,7 +79,8 @@ fn main() {
         let h = relu(&add(&matmul(&x, &opt.params[0]), &opt.params[1]));
         let logits = add(&matmul(&h, &opt.params[2]), &opt.params[3]);
         let loss = nll_loss(&log_softmax(&logits, 1), &targets);
-        loss.backward();
+        loss.backward()
+            .expect("invariant: valid autograd fixture completes backward");
         opt.step();
 
         last_loss = loss.tensor.as_slice()[0];

--- a/crates/coeus-python/src/ops/reductions.rs
+++ b/crates/coeus-python/src/ops/reductions.rs
@@ -1,7 +1,7 @@
 use crate::tensor::PyTensor;
 use coeus_core::MoiraiBackend;
 use coeus_tensor::Tensor;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -126,11 +126,11 @@ pub fn amax(input: &PyTensor, py: Python<'_>) -> PyResult<f64> {
     if input.inner.tensor.numel() == 0 {
         return Err(PyValueError::new_err("amax: empty tensor has no maximum"));
     }
-    let v = py.allow_threads(|| {
+    py.allow_threads(|| {
         let backend = MoiraiBackend::new();
         coeus_ops::amax::<f64, MoiraiBackend>(&input.inner.tensor, &backend)
-    });
-    Ok(v)
+    })
+    .map_err(|error| PyRuntimeError::new_err(error.to_string()))
 }
 
 #[pyfunction]
@@ -138,11 +138,11 @@ pub fn amin(input: &PyTensor, py: Python<'_>) -> PyResult<f64> {
     if input.inner.tensor.numel() == 0 {
         return Err(PyValueError::new_err("amin: empty tensor has no minimum"));
     }
-    let v = py.allow_threads(|| {
+    py.allow_threads(|| {
         let backend = MoiraiBackend::new();
         coeus_ops::amin::<f64, MoiraiBackend>(&input.inner.tensor, &backend)
-    });
-    Ok(v)
+    })
+    .map_err(|error| PyRuntimeError::new_err(error.to_string()))
 }
 
 #[pyfunction]

--- a/crates/coeus-python/src/tensor/pyimpl/mod.rs
+++ b/crates/coeus-python/src/tensor/pyimpl/mod.rs
@@ -1,6 +1,7 @@
 // ── PyTensor struct definition and single #[pymethods] block ──
 
 use coeus_autograd::Var;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 /// Closed-set dispatch tag for Python binary operators.
@@ -803,8 +804,8 @@ impl PyTensor {
     // ── Grad utilities ──
 
     fn backward(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.backward());
-        Ok(())
+        py.allow_threads(|| self.inner.backward())
+            .map_err(|error| PyRuntimeError::new_err(error.to_string()))
     }
 
     fn detach(&self) -> Self {

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/activations.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/activations.rs
@@ -25,8 +25,12 @@ fn test_wgpu_silu_parity() {
         assert!((out_cpu_slice[i] - out_gpu_slice[i]).abs() < 1e-5);
     }
 
-    out_cpu.backward();
-    out_gpu.backward();
+    out_cpu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
+    out_gpu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let grad_cpu = var_cpu.grad().unwrap();
     let grad_gpu = var_gpu.grad().unwrap();
@@ -63,8 +67,12 @@ fn test_wgpu_mish_parity() {
         assert!((out_cpu_slice[i] - out_gpu_slice[i]).abs() < 1e-5);
     }
 
-    out_cpu.backward();
-    out_gpu.backward();
+    out_cpu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
+    out_gpu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let grad_cpu = var_cpu.grad().unwrap();
     let grad_gpu = var_gpu.grad().unwrap();
@@ -101,8 +109,12 @@ fn test_wgpu_elu_parity() {
         assert!((out_cpu_slice[i] - out_gpu_slice[i]).abs() < 1e-5);
     }
 
-    out_cpu.backward();
-    out_gpu.backward();
+    out_cpu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
+    out_gpu
+        .backward()
+        .expect("invariant: valid autograd fixture completes backward");
 
     let grad_cpu = var_cpu.grad().unwrap();
     let grad_gpu = var_gpu.grad().unwrap();

--- a/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/conv_transpose.rs
+++ b/crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/conv_transpose.rs
@@ -175,10 +175,12 @@ fn test_wgpu_conv_transpose1d_backward_matches_cpu_autograd() {
     );
     let tracked_cpu =
         coeus_autograd::conv_transpose1d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
-    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
-        [1, 1, 4],
-        &seed,
-    ));
+    tracked_cpu
+        .backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+            [1, 1, 4],
+            &seed,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_gpu = Var::new(
         Tensor::<f32, WgpuBackend>::from_slice_on([1, 1, 3], &input, &wgpu),
@@ -200,11 +202,13 @@ fn test_wgpu_conv_transpose1d_backward_matches_cpu_autograd() {
     );
     let tracked_gpu =
         coeus_autograd::conv_transpose1d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
-    tracked_gpu.backward_with_seed(Tensor::<f32, WgpuBackend>::from_slice_on(
-        [1, 1, 4],
-        &seed,
-        &wgpu,
-    ));
+    tracked_gpu
+        .backward_with_seed(Tensor::<f32, WgpuBackend>::from_slice_on(
+            [1, 1, 4],
+            &seed,
+            &wgpu,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_grad_gpu = input_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
     let weight_grad_gpu = weight_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
@@ -249,10 +253,12 @@ fn test_wgpu_conv_transpose2d_backward_matches_cpu_autograd() {
     );
     let tracked_cpu =
         coeus_autograd::conv_transpose2d(&input_cpu, &weight_cpu, &None, out_cpu, 1, 0, 0, 1);
-    tracked_cpu.backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
-        [1, 1, 3, 3],
-        &seed,
-    ));
+    tracked_cpu
+        .backward_with_seed(Tensor::<f32, SequentialBackend>::from_slice(
+            [1, 1, 3, 3],
+            &seed,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_gpu = Var::new(
         Tensor::<f32, WgpuBackend>::from_slice_on([1, 1, 2, 2], &input, &wgpu),
@@ -274,11 +280,13 @@ fn test_wgpu_conv_transpose2d_backward_matches_cpu_autograd() {
     );
     let tracked_gpu =
         coeus_autograd::conv_transpose2d(&input_gpu, &weight_gpu, &None, out_gpu, 1, 0, 0, 1);
-    tracked_gpu.backward_with_seed(Tensor::<f32, WgpuBackend>::from_slice_on(
-        [1, 1, 3, 3],
-        &seed,
-        &wgpu,
-    ));
+    tracked_gpu
+        .backward_with_seed(Tensor::<f32, WgpuBackend>::from_slice_on(
+            [1, 1, 3, 3],
+            &seed,
+            &wgpu,
+        ))
+        .expect("invariant: valid autograd fixture completes backward");
 
     let input_grad_gpu = input_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);
     let weight_grad_gpu = weight_gpu.grad().unwrap().to_backend_on(&wgpu, &seq);

--- a/docs/adr/0042-fallible-autograd-backward.md
+++ b/docs/adr/0042-fallible-autograd-backward.md
@@ -62,5 +62,8 @@ The local verification result is:
 - SemVer checks against `origin/main` identify the public trait-return changes
   as requiring a major release.
 
-Hosted provider validation remains required because CUDA and WGPU parity
-callers also migrated to the fallible contract.
+Exact-head provider run `30397554467` attempt 2 passes WGPU, ROCm, CUDA, and
+Metal. Attempt 1 exposed an upstream Leto stencil contract missing
+`T: UnitScalar`; Leto PR #77 repaired that provider-owned bound before the
+successful rerun. The required-device ROCm lane is intentionally skipped by
+workflow policy.

--- a/docs/adr/0042-fallible-autograd-backward.md
+++ b/docs/adr/0042-fallible-autograd-backward.md
@@ -1,0 +1,66 @@
+# ADR-0042: Fallible autograd backward contract
+
+- Status: accepted
+- Date: 2026-07-28
+- Scope: `coeus-autograd` graph traversal and operation nodes
+- Change class: `[major] [arch]`
+
+## Context
+
+The backend mutation operations used to accumulate gradients return the
+backend's typed error. `BackwardNode::backward`, `Var::backward`, and
+`Var::backward_with_seed` returned `()`, so operation nodes had no path to
+propagate those failures. After the mutation API became fallible, 143
+accumulation and direct-dispatch calls ignored `Result` values. A failed
+gradient update could therefore leave a partially accumulated graph while
+the caller observed success.
+
+## Decision
+
+`BackwardNode::backward` returns `Result<(), B::Error>`. Graph traversal stops
+at the first failed node and returns that same backend error through
+`Var::backward` or `Var::backward_with_seed`. Every operation node uses `?`
+for fallible backend work and returns `Ok(())` only after all requested input
+gradients have been accumulated.
+
+The existing backend error type remains the single error contract. No boxed
+error, string conversion, compatibility wrapper, fallback, or error-swallowing
+branch is introduced. Static dispatch and scalar monomorphization are
+unchanged; successful traversal adds no allocation or virtual-dispatch work.
+
+## Rejected alternatives
+
+- Ignore results with `let _ =`: this reports success after a failed gradient
+  mutation and can expose a partially accumulated graph.
+- Panic with `expect`: backend execution failures are input- or device-
+  dependent failures, not local programmer invariants.
+- Add a parallel `try_backward` API: retaining the infallible path would
+  preserve the unsafe behavior and split one graph contract into two paths.
+- Erase backend errors behind `Box<dyn Error>`: the backend already owns the
+  precise typed failure and generic propagation is zero-cost.
+
+## Migration
+
+Callers handle or explicitly prove success from `backward()` and
+`backward_with_seed()`. In-repository examples and tests use `expect` only
+where their fixed valid fixtures establish that backend execution must
+succeed.
+
+## Verification
+
+Warning-denied all-target Clippy must report no ignored result. Focused
+regressions must inject a backend accumulation failure and assert that
+`backward` returns that error rather than continuing silently. Existing
+value-semantic gradient tests must pass through Nextest, and public doctests
+must compile with the fallible call contract.
+
+The local verification result is:
+
+- warning-denied all-target `coeus-autograd` Clippy passes;
+- Nextest passes 102 autograd/FFT and 268 NN tests;
+- all 24 executable doctests pass, with two pre-existing NN doctests ignored;
+- SemVer checks against `origin/main` identify the public trait-return changes
+  as requiring a major release.
+
+Hosted provider validation remains required because CUDA and WGPU parity
+callers also migrated to the fallible contract.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,6 @@
 # Coeus Project Backlog & Historical Archives
 
-## ATLAS-AUTOGRAD-SAFETY-018 — Propagate backward failures [major] [arch] — in progress
+## ATLAS-AUTOGRAD-SAFETY-018 — Propagate backward failures [major] [arch] — complete
 
 - Owner: Codex; scope: `coeus-autograd` graph traversal, every
   `BackwardNode` implementation, and in-repository callers.
@@ -17,7 +17,11 @@
   warning-denied `coeus-autograd` Clippy passes; Nextest passes 102
   autograd/FFT and 268 NN tests; 24 executable doctests pass. SemVer checks
   against `origin/main` classify the public trait-return changes as major.
-  Hosted provider CI remains pending.
+  Exact-head run `30397554467` attempt 2 passes WGPU (`90407664433`), ROCm
+  (`90407664470`), CUDA (`90407664479`), and Metal (`90407664482`);
+  required-device ROCm (`90407665417`) is intentionally skipped. Attempt 1
+  exposed the upstream Leto `UnitScalar` contract defect, fixed by Leto PR
+  #77 before the successful rerun.
 
 ## ATLAS-CUDA-SAFETY-017 — Bound pooling physical indices [patch] [arch] — complete
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,24 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-AUTOGRAD-SAFETY-018 — Propagate backward failures [major] [arch] — in progress
+
+- Owner: Codex; scope: `coeus-autograd` graph traversal, every
+  `BackwardNode` implementation, and in-repository callers.
+- Outcome: return the backend's typed error from every failed gradient
+  computation or accumulation without partial-success reporting.
+- Non-goals: gradient formula changes, backend fallback, boxed error erasure,
+  compatibility wrappers, or performance claims.
+- Acceptance: warning-denied all-target Clippy reports no ignored `Result`;
+  a failure-injecting backend regression observes the exact error; existing
+  value-semantic gradients and doctests pass.
+- Risk/change class: `[major] [arch]`; `backward` and `backward_with_seed`
+  change from infallible public methods to typed `Result`.
+- Status: implementation and in-repository caller migration complete. Local
+  warning-denied `coeus-autograd` Clippy passes; Nextest passes 102
+  autograd/FFT and 268 NN tests; 24 executable doctests pass. SemVer checks
+  against `origin/main` classify the public trait-return changes as major.
+  Hosted provider CI remains pending.
+
 ## ATLAS-CUDA-SAFETY-017 — Bound pooling physical indices [patch] [arch] — complete
 
 - Owner: Codex; scope: shared CUDA layout/storage validation and the canonical

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -14,12 +14,17 @@ failure-injection regression observes the exact `BackendError::Storage`.
 Nextest passes 102 autograd/FFT and 268 NN tests. All 24 executable doctests
 pass; two pre-existing NN doctests remain ignored. SemVer checks against
 `origin/main` report the `BackwardNode` and `BinaryAutogradOp` return changes
-as requiring a major release. Hosted provider CI remains pending.
+as requiring a major release. Exact-head run `30397554467` attempt 2 passes
+WGPU (`90407664433`), ROCm
+(`90407664470`), CUDA (`90407664479`), and Metal (`90407664482`);
+required-device ROCm (`90407665417`) is intentionally skipped. Attempt 1
+failed before Coeus in Leto's missing `T: UnitScalar` stencil contract; Leto
+PR #77 repaired that provider-owned bound before the successful rerun.
 **Residual**: compilation exposes 54 ignored fallible normalization mutations
 in `coeus-nn` and one ignored distributed mutation outside this increment;
 they remain separate typed-propagation work. No runtime, allocation, or
 binary-size improvement is claimed.
-**Status**: in progress.
+**Status**: complete at `81eeec09`; merge delivery pending.
 
 ## ATLAS-CUDA-SAFETY-017: Pooling physical-index contract
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -1,5 +1,26 @@
 # Coeus Gap Audit
 
+## ATLAS-AUTOGRAD-SAFETY-018: Infallible backward traversal
+
+**Location**: `crates/coeus-autograd/src/node.rs`, `var.rs`, and operation
+node implementations.
+**Gap**: 143 fallible backend mutation or direct-dispatch calls discarded
+their `Result` because the autograd graph contract returned `()`. A backend
+failure could leave partial gradients while the caller observed success.
+**Resolution**: ADR-0042 makes the graph traversal and every node return the
+backend's typed error, with no compatibility or fallback path.
+**Evidence**: warning-denied `coeus-autograd` all-target Clippy passes. The
+failure-injection regression observes the exact `BackendError::Storage`.
+Nextest passes 102 autograd/FFT and 268 NN tests. All 24 executable doctests
+pass; two pre-existing NN doctests remain ignored. SemVer checks against
+`origin/main` report the `BackwardNode` and `BinaryAutogradOp` return changes
+as requiring a major release. Hosted provider CI remains pending.
+**Residual**: compilation exposes 54 ignored fallible normalization mutations
+in `coeus-nn` and one ignored distributed mutation outside this increment;
+they remain separate typed-propagation work. No runtime, allocation, or
+binary-size improvement is claimed.
+**Status**: in progress.
+
 ## ATLAS-CUDA-SAFETY-017: Pooling physical-index contract
 
 **Location**: `crates/coeus-cuda/src/kernels/validation.rs` and


### PR DESCRIPTION
## Summary
- return typed backend failures from autograd graph traversal and every backward node
- migrate in-repository Rust and PyO3 callers without compatibility or fallback paths
- add exact failure propagation coverage and record the major architectural contract in ADR-0042

## Verification
- cargo fmt --all -- --check
- cargo clippy --offline --package coeus-autograd --all-targets --no-deps -- -D warnings
- cargo check --offline --package coeus-autograd --package coeus-nn --package coeus-fft --package coeus-python --package coeus-wgpu --package coeus-optim --package coeus-cuda --all-targets
- cargo nextest run --offline --package coeus-autograd --package coeus-fft (102 passed)
- cargo nextest run --offline --package coeus-nn (268 passed)
- cargo test --offline --doc --package coeus-autograd --package coeus-fft --package coeus-nn (24 passed, 2 pre-existing ignored)
- cargo semver-checks check-release --package coeus-autograd --baseline-rev origin/main --release-type patch (correctly reports major required)

## Residual audit findings
- coeus-nn has 54 pre-existing ignored fallible normalization mutations
- coeus-dist has one pre-existing ignored fallible mutation

No runtime, allocation, or binary-size improvement is claimed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR propagates backend errors through the entire autograd backward pass by making `BackwardNode::backward`, `Var::backward`, and `Var::backward_with_seed` return `Result<(), B::Error>` instead of `()`. Previously, 143 fallible backend mutation calls ignored their `Result` values, which could leave partial gradients while reporting success. The migration updates every operation node implementation across activations, losses, shape operations, normalization, convolution, pooling, embedding, interpolation, reductions, and scanning to use `?` for error propagation. All in-repository callers (tests, benchmarks, examples, FFT, Python bindings, CUDA, and WGPU) are updated to handle the fallible contract with `expect` calls asserting valid fixtures or proper error handling. The change is documented in ADR-0042 as an architectural breaking change requiring a major version bump, with local verification showing 102 autograd/FFT tests passing, 268 NN tests passing, and 24 doctests passing.

⏱️ Estimated Review Time: 3+ hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr/0042-fallible-autograd-backward.md` |
| 2 | `CHECKLIST.md` |
| 3 | `docs/backlog.md` |
| 4 | `docs/gap_audit.md` |
| 5 | `crates/coeus-autograd/src/node.rs` |
| 6 | `crates/coeus-autograd/src/var.rs` |
| 7 | `crates/coeus-autograd/src/ops/arithmetic/traits.rs` |
| 8 | `crates/coeus-autograd/src/ops/arithmetic/binary.rs` |
| 9 | `crates/coeus-autograd/src/ops/activation/mod.rs` |
| 10 | `crates/coeus-autograd/src/ops/activation/relu.rs` |
| 11 | `crates/coeus-autograd/src/ops/activation/sigmoid.rs` |
| 12 | `crates/coeus-autograd/src/ops/activation/silu.rs` |
| 13 | `crates/coeus-autograd/src/ops/activation/tanh_act.rs` |
| 14 | `crates/coeus-autograd/src/ops/activation/gelu.rs` |
| 15 | `crates/coeus-autograd/src/ops/activation/math.rs` |
| 16 | `crates/coeus-autograd/src/ops/activation/ext.rs` |
| 17 | `crates/coeus-autograd/src/ops/linalg.rs` |
| 18 | `crates/coeus-autograd/src/ops/nn/softmax.rs` |
| 19 | `crates/coeus-autograd/src/ops/nn/log_softmax.rs` |
| 20 | `crates/coeus-autograd/src/ops/nn/masked_softmax.rs` |
| 21 | `crates/coeus-autograd/src/ops/nn/attention.rs` |
| 22 | `crates/coeus-autograd/src/ops/nn/dropout.rs` |
| 23 | `crates/coeus-autograd/src/ops/nn/normalization/layernorm.rs` |
| 24 | `crates/coeus-autograd/src/ops/nn/normalization/rmsnorm.rs` |
| 25 | `crates/coeus-autograd/src/ops/nn/normalization/batchnorm/bn_nd.rs` |
| 26 | `crates/coeus-autograd/src/ops/nn/pool.rs` |
| 27 | `crates/coeus-autograd/src/ops/nn/conv/transpose.rs` |
| 28 | `crates/coeus-autograd/src/ops/nn/conv/unfold_fold.rs` |
| 29 | `crates/coeus-autograd/src/ops/nn/conv/utils.rs` |
| 30 | `crates/coeus-autograd/src/ops/nn/loss/cross_entropy.rs` |
| 31 | `crates/coeus-autograd/src/ops/nn/loss/bce.rs` |
| 32 | `crates/coeus-autograd/src/ops/nn/loss/bce_with_logits.rs` |
| 33 | `crates/coeus-autograd/src/ops/nn/loss/nll.rs` |
| 34 | `crates/coeus-autograd/src/ops/nn/loss/huber.rs` |
| 35 | `crates/coeus-autograd/src/ops/nn/loss/l1.rs` |
| 36 | `crates/coeus-autograd/src/ops/nn/loss/smooth_l1.rs` |
| 37 | `crates/coeus-autograd/src/ops/nn/loss/soft_margin.rs` |
| 38 | `crates/coeus-autograd/src/ops/nn/loss/kl_div.rs` |
| 39 | `crates/coeus-autograd/src/ops/nn/loss/poisson_nll.rs` |
| 40 | `crates/coeus-autograd/src/ops/nn/loss/cosine.rs` |
| 41 | `crates/coeus-autograd/src/ops/nn/loss/cosine_similarity.rs` |
| 42 | `crates/coeus-autograd/src/ops/nn/loss/pairwise_distance.rs` |
| 43 | `crates/coeus-autograd/src/ops/nn/loss/margin_ranking.rs` |
| 44 | `crates/coeus-autograd/src/ops/nn/loss/multi_margin.rs` |
| 45 | `crates/coeus-autograd/src/ops/nn/loss/multi_label_margin.rs` |
| 46 | `crates/coeus-autograd/src/ops/nn/loss/ctc.rs` |
| 47 | `crates/coeus-autograd/src/ops/embedding.rs` |
| 48 | `crates/coeus-autograd/src/ops/interpolation.rs` |
| 49 | `crates/coeus-autograd/src/ops/scan.rs` |
| 50 | `crates/coeus-autograd/src/ops/reduction/max_min.rs` |
| 51 | `crates/coeus-autograd/src/ops/reduction/norm.rs` |
| 52 | `crates/coeus-autograd/src/ops/reduction/prod.rs` |
| 53 | `crates/coeus-autograd/src/ops/reduction/sort.rs` |
| 54 | `crates/coeus-autograd/src/ops/reduction/topk.rs` |
| 55 | `crates/coeus-autograd/src/ops/shape/cat_split_stack/cat.rs` |
| 56 | `crates/coeus-autograd/src/ops/shape/cat_split_stack/split.rs` |
| 57 | `crates/coeus-autograd/src/ops/shape/cat_split_stack/stack.rs` |
| 58 | `crates/coeus-autograd/src/ops/shape/mask/masked_fill.rs` |
| 59 | `crates/coeus-autograd/src/ops/shape/select/gather.rs` |
| 60 | `crates/coeus-autograd/src/ops/shape/select/index_put.rs` |
| 61 | `crates/coeus-autograd/src/ops/shape/select/index_select.rs` |
| 62 | `crates/coeus-autograd/src/ops/shape/select/scatter_add.rs` |
| 63 | `crates/coeus-autograd/src/ops/shape/transform/broadcast.rs` |
| 64 | `crates/coeus-autograd/src/ops/shape/transform/diag.rs` |
| 65 | `crates/coeus-autograd/src/ops/shape/transform/flip.rs` |
| 66 | `crates/coeus-autograd/src/ops/shape/transform/pad.rs` |
| 67 | `crates/coeus-autograd/src/ops/shape/transform/permute.rs` |
| 68 | `crates/coeus-autograd/src/ops/shape/transform/reshape.rs` |
| 69 | `crates/coeus-autograd/src/ops/shape/transform/roll.rs` |
| 70 | `crates/coeus-autograd/src/ops/shape/transform/slice.rs` |
| 71 | `crates/coeus-autograd/src/ops/shape/transform/squeeze.rs` |
| 72 | `crates/coeus-autograd/src/ops/shape/transform/tile.rs` |
| 73 | `crates/coeus-autograd/src/ops/shape/transform/tril.rs` |
| 74 | `crates/coeus-autograd/src/ops/shape/transform/where_cond.rs` |
| 75 | `crates/coeus-autograd/src/ops/shape/util/contiguous.rs` |
| 76 | `crates/coeus-autograd/src/ops/shape/util/cumsum.rs` |
| 77 | `crates/coeus-autograd/src/ops/shape/util/cumprod.rs` |
| 78 | `crates/coeus-autograd/src/ops/shape/util/diff.rs` |
| 79 | `crates/coeus-fft/src/lib.rs` |
| 80 | `crates/coeus-autograd/tests/autograd/embedding.rs` |
| 81 | `crates/coeus-autograd/tests/autograd/exp_log.rs` |
| 82 | `crates/coeus-autograd/tests/autograd/float16.rs` |
| 83 | `crates/coeus-autograd/tests/autograd/grad_mode.rs` |
| 84 | `crates/coeus-autograd/tests/autograd/index_put.rs` |
| 85 | `crates/coeus-autograd/tests/autograd/linalg.rs` |
| 86 | `crates/coeus-autograd/tests/autograd/minmax.rs` |
| 87 | `crates/coeus-autograd/tests/autograd/nn_conv.rs` |
| 88 | `crates/coeus-autograd/tests/autograd/ops_overloads.rs` |
| 89 | `crates/coeus-autograd/tests/autograd/prelu.rs` |
| 90 | `crates/coeus-autograd/tests/autograd/reductions.rs` |
| 91 | `crates/coeus-autograd/tests/autograd/remainder.rs` |
| 92 | `crates/coeus-autograd/tests/autograd/scatter_add.rs` |
| 93 | `crates/coeus-autograd/tests/autograd/shape_ops.rs` |
| 94 | `crates/coeus-autograd/tests/autograd/sparse.rs` |
| 95 | `crates/coeus-autograd/tests/autograd/unary_math.rs` |
| 96 | `crates/coeus-autograd/tests/autograd_ops/grid_sample/grid_sample_3d.rs` |
| 97 | `crates/coeus-autograd/tests/autograd_ops/interpolation/linear_interpolation.rs` |
| 98 | `crates/coeus-autograd/tests/autograd_ops/scan/selective_scan.rs` |
| 99 | `crates/coeus-fft/tests/fft.rs` |
| 100 | `crates/coeus-fft/benches/fft_bench.rs` |
| 101 | `crates/coeus-nn/tests/nn/attention.rs` |
| 102 | `crates/coeus-nn/tests/nn/conv1d.rs` |
| 103 | `crates/coeus-nn/tests/nn/conv2d.rs` |
| 104 | `crates/coeus-nn/tests/nn/conv3d_pool3d.rs` |
| 105 | `crates/coeus-nn/tests/nn/linear_activation_loss.rs` |
| 106 | `crates/coeus-nn/tests/nn/log_softmax_cat_split.rs` |
| 107 | `crates/coeus-nn/tests/nn/normalization.rs` |
| 108 | `crates/coeus-nn/tests/nn/rope_and_transpose.rs` |
| 109 | `crates/coeus-nn/tests/nn_ops/activations/act_extended/parameterized.rs` |
| 110 | `crates/coeus-nn/tests/nn_ops/activations/act_extended/piecewise.rs` |
| 111 | `crates/coeus-nn/tests/nn_ops/activations/act_extended/smooth.rs` |
| 112 | `crates/coeus-nn/tests/nn_ops/activations/nn_activation_tests.rs` |
| 113 | `crates/coeus-nn/tests/nn_ops/activations/nn_mish_tests.rs` |
| 114 | `crates/coeus-nn/tests/nn_ops/activations/nn_silu_tests.rs` |
| 115 | `crates/coeus-nn/tests/nn_ops/activations/swiglu_tests.rs` |
| 116 | `crates/coeus-nn/tests/nn_ops/attention/nn_attention_tests.rs` |
| 117 | `crates/coeus-nn/tests/nn_ops/attention/nn_transformer_tests.rs` |
| 118 | `crates/coeus-nn/tests/nn_ops/convolution/nn_3d_tests.rs` |
| 119 | `crates/coeus-nn/tests/nn_ops/convolution/unfold_fold_parity.rs` |
| 120 | `crates/coeus-nn/tests/nn_ops/embedding/embeddingbag_tests.rs` |
| 121 | `crates/coeus-nn/tests/nn_ops/embedding/nn_embedding_tests.rs` |
| 122 | `crates/coeus-nn/tests/nn_ops/losses/ctc_loss_tests.rs` |
| 123 | `crates/coeus-nn/tests/nn_ops/losses/nn_loss/binary.rs` |
| 124 | `crates/coeus-nn/tests/nn_ops/losses/nn_loss/classification.rs` |
| 125 | `crates/coeus-nn/tests/nn_ops/losses/nn_loss/distance.rs` |
| 126 | `crates/coeus-nn/tests/nn_ops/losses/nn_loss/distribution.rs` |
| 127 | `crates/coeus-nn/tests/nn_ops/losses/regularization_tests.rs` |
| 128 | `crates/coeus-nn/tests/nn_ops/normalization/nn_norm_tests.rs` |
| 129 | `crates/coeus-nn/tests/nn_ops/normalization/nn_normalization_tests.rs` |
| 130 | `crates/coeus-nn/tests/nn_ops/normalization/norm_parity.rs` |
| 131 | `crates/coeus-nn/tests/nn_ops/pooling/adaptive_pool_parity.rs` |
| 132 | `crates/coeus-nn/tests/nn_ops/recurrent/nn_sequential_tests.rs` |
| 133 | `crates/coeus-nn/tests/nn_ops/tensor/nn_new_ops_tests.rs` |
| 134 | `crates/coeus-nn/tests/nn_ops/tensor/nn_parity/attention.rs` |
| 135 | `crates/coeus-nn/tests/nn_ops/tensor/nn_parity/convolution.rs` |
| 136 | `crates/coeus-nn/tests/nn_ops/tensor/nn_parity/embedding.rs` |
| 137 | `crates/coeus-nn/tests/nn_ops/tensor/nn_parity/linear_norm.rs` |
| 138 | `crates/coeus-nn/tests/nn_ops/tensor/nn_parity/losses.rs` |
| 139 | `crates/coeus-nn/tests/nn_ops/tensor/nn_parity/regularization.rs` |
| 140 | `crates/coeus-nn/src/conv/depthwise3d.rs` |
| 141 | `crates/coeus-nn/benches/nn_bench/provider/arithmetic_backward.rs` |
| 142 | `crates/coeus-nn/benches/nn_bench/provider/convolution.rs` |
| 143 | `crates/coeus-nn/benches/nn_bench/provider/dense.rs` |
| 144 | `crates/coeus-nn/benches/nn_bench/provider/exponential_backward.rs` |
| 145 | `crates/coeus-nn/benches/nn_bench/provider/gating_backward.rs` |
| 146 | `crates/coeus-nn/benches/nn_bench/provider/indexing.rs` |
| 147 | `crates/coeus-nn/benches/nn_bench/provider/loss_backward.rs` |
| 148 | `crates/coeus-nn/benches/nn_bench/provider/normalization_backward.rs` |
| 149 | `crates/coeus-nn/benches/nn_bench/provider/normalization_forward.rs` |
| 150 | `crates/coeus-nn/benches/nn_bench/provider/rectifier_backward.rs` |
| 151 | `crates/coeus-nn/benches/nn_bench/provider/reduction_backward.rs` |
| 152 | `crates/coeus-nn/benches/nn_bench/provider/reduction_forward.rs` |
| 153 | `crates/coeus-nn/benches/nn_bench/provider/tensor_operation.rs` |
| 154 | `crates/coeus-nn/benches/nn_bench/provider/trigonometric_backward.rs` |
| 155 | `crates/coeus-nn/benches/nn_bench/provider/unary_backward.rs` |
| 156 | `crates/coeus-optim/examples/linear_regression.rs` |
| 157 | `crates/coeus-optim/examples/mlp_classifier.rs` |
| 158 | `crates/coeus-python/src/ops/reductions.rs` |
| 159 | `crates/coeus-python/src/tensor/pyimpl/mod.rs` |
| 160 | `crates/coeus-cuda/tests/cuda/parity/convolution_transpose.rs` |
| 161 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/activations.rs` |
| 162 | `crates/coeus-wgpu/tests/wgpu_ops/backend/wgpu/conv_transpose.rs` |
| 163 | `crates/coeus-autograd/src/ops/arithmetic/reduction.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->