### PR TITLE
fix(coeus-cuda): Validate elementwise layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   physical device allocations at both the backend and public raw-launch
   boundaries. Writable zero-stride layouts and aliased storage with different
   logical mappings now return typed layout failures; nonzero-offset contiguous
-  views use the offset-aware strided path. The validation is host-side and
+  views use the offset-aware strided path, and zero-element operations complete
+  as no-ops without requiring a device launch. The validation is host-side and
   allocation-free. No runtime performance or resident-memory delta is claimed
   without matched measurements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Changed
 
+- [patch] Validate CUDA elementwise input and output layouts against their
+  physical device allocations at both the backend and public raw-launch
+  boundaries. Writable zero-stride layouts and aliased storage with different
+  logical mappings now return typed layout failures; nonzero-offset contiguous
+  views use the offset-aware strided path. The validation is host-side and
+  allocation-free. No runtime performance or resident-memory delta is claimed
+  without matched measurements.
+
 - [major] Make all neural-network `Module::forward` implementations return
   typed module or backend failures. Composite modules stop at the first
   failure; normalization operations no longer suppress backend errors;

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise.rs
@@ -3,65 +3,13 @@ use crate::backend::{CudaBackend, CudaScalar};
 use crate::driver::get_cuda_context;
 use crate::kernels;
 use crate::storage::CudaStorage;
-use coeus_core::Layout;
+use coeus_core::{Layout, Storage};
 use std::sync::Arc;
 
-fn try_hephaestus_contiguous_binary<T>(
-    op: coeus_ops::BinaryOp,
-    a: &CudaStorage<T>,
-    b: &CudaStorage<T>,
-    c: &mut CudaStorage<T>,
-) -> Result<bool, CudaBackendError>
-where
-    T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
-{
-    if Arc::ptr_eq(&a.buffer, &c.buffer) || Arc::ptr_eq(&b.buffer, &c.buffer) {
-        return Ok(false);
-    }
-    let device = crate::backend::get_cuda_device();
-    let run = |result: hephaestus_cuda::Result<hephaestus_cuda::CudaBuffer<T>>,
-               c: &mut CudaStorage<T>| {
-        let buffer =
-            result.map_err(|source| CudaBackendError::dispatch("elementwise binary", source))?;
-        c.buffer = Arc::new(buffer);
-        Ok(true)
-    };
-    match op {
-        coeus_ops::BinaryOp::Add => run(
-            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::AddOp, T>(
-                device,
-                a.buffer.as_ref(),
-                b.buffer.as_ref(),
-            ),
-            c,
-        ),
-        coeus_ops::BinaryOp::Sub => run(
-            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::SubOp, T>(
-                device,
-                a.buffer.as_ref(),
-                b.buffer.as_ref(),
-            ),
-            c,
-        ),
-        coeus_ops::BinaryOp::Mul => run(
-            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::MulOp, T>(
-                device,
-                a.buffer.as_ref(),
-                b.buffer.as_ref(),
-            ),
-            c,
-        ),
-        coeus_ops::BinaryOp::Div => run(
-            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::DivOp, T>(
-                device,
-                a.buffer.as_ref(),
-                b.buffer.as_ref(),
-            ),
-            c,
-        ),
-        _ => Ok(false),
-    }
-}
+mod binary;
+mod validation;
+
+use validation::validate_unary_layouts;
 
 fn try_hephaestus_contiguous_unary<T>(
     op: coeus_ops::UnaryOp,
@@ -225,73 +173,6 @@ fn can_route_dynamic_strided(layouts: &[&Layout], out: &Layout) -> bool {
             .iter()
             .zip(out.strides())
             .any(|(&dim, &stride)| dim > 1 && stride == 0)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn try_hephaestus_strided_binary<T>(
-    op: coeus_ops::BinaryOp,
-    a: &CudaStorage<T>,
-    a_layout: &Layout,
-    b: &CudaStorage<T>,
-    b_layout: &Layout,
-    c: &mut CudaStorage<T>,
-    c_layout: &Layout,
-) -> Result<bool, CudaBackendError>
-where
-    T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
-{
-    if !can_route_dynamic_strided(&[a_layout, b_layout], c_layout) {
-        return Ok(false);
-    }
-    let device = crate::backend::get_cuda_device();
-    let run = |result: hephaestus_cuda::Result<()>| {
-        result
-            .map(|_| true)
-            .map_err(|source| CudaBackendError::dispatch("elementwise binary", source))
-    };
-    match op {
-        coeus_ops::BinaryOp::Add => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
-            hephaestus_cuda::AddOp,
-            T,
-        >(
-            device,
-            hephaestus_operand(a, a_layout),
-            hephaestus_operand(b, b_layout),
-            hephaestus_operand(c, c_layout),
-            hephaestus_cuda::BlockWidth::DEFAULT,
-        )),
-        coeus_ops::BinaryOp::Sub => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
-            hephaestus_cuda::SubOp,
-            T,
-        >(
-            device,
-            hephaestus_operand(a, a_layout),
-            hephaestus_operand(b, b_layout),
-            hephaestus_operand(c, c_layout),
-            hephaestus_cuda::BlockWidth::DEFAULT,
-        )),
-        coeus_ops::BinaryOp::Mul => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
-            hephaestus_cuda::MulOp,
-            T,
-        >(
-            device,
-            hephaestus_operand(a, a_layout),
-            hephaestus_operand(b, b_layout),
-            hephaestus_operand(c, c_layout),
-            hephaestus_cuda::BlockWidth::DEFAULT,
-        )),
-        coeus_ops::BinaryOp::Div => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
-            hephaestus_cuda::DivOp,
-            T,
-        >(
-            device,
-            hephaestus_operand(a, a_layout),
-            hephaestus_operand(b, b_layout),
-            hephaestus_operand(c, c_layout),
-            hephaestus_cuda::BlockWidth::DEFAULT,
-        )),
-        _ => Ok(false),
-    }
 }
 
 fn try_hephaestus_strided_unary<T>(
@@ -467,57 +348,6 @@ where
 }
 
 impl CudaBackend {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn cuda_elementwise_binary<T>(
-        &self,
-        op: coeus_ops::BinaryOp,
-        a: &CudaStorage<T>,
-        a_layout: &Layout,
-        b: &CudaStorage<T>,
-        b_layout: &Layout,
-        c: &mut CudaStorage<T>,
-        c_layout: &Layout,
-    ) -> Result<(), CudaBackendError>
-    where
-        T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
-    {
-        if get_cuda_context().is_some() {
-            let n = kernels::checked_numel(c_layout).ok_or_else(|| {
-                CudaBackendError::kernel(
-                    "elementwise binary",
-                    "output element count exceeds the CUDA dispatch ABI",
-                )
-            })?;
-            // The contiguous kernel computes `c[i] = a[i] op b[i]` with no
-            // broadcasting, so it is only valid when both operands already share
-            // the output shape. A broadcast operand (e.g. `[3,1]` against
-            // `[3,2]`) must go through the strided kernel, which resolves each
-            // output coordinate against per-operand strides.
-            let same_shape =
-                a_layout.shape() == c_layout.shape() && b_layout.shape() == c_layout.shape();
-            if same_shape
-                && a_layout.is_contiguous()
-                && b_layout.is_contiguous()
-                && c_layout.is_contiguous()
-            {
-                if try_hephaestus_contiguous_binary(op, a, b, c)? {
-                    return Ok(());
-                }
-                if kernels::launch_contiguous_binary(op, a, b, c, n) {
-                    return Ok(());
-                }
-            } else if try_hephaestus_strided_binary(op, a, a_layout, b, b_layout, c, c_layout)?
-                || kernels::launch_strided_binary(op, a, a_layout, b, b_layout, c, c_layout, n)
-            {
-                return Ok(());
-            }
-        }
-        Err(CudaBackendError::kernel(
-            "elementwise binary",
-            "native CUDA dispatch requirements are not satisfied",
-        ))
-    }
-
     pub(crate) fn cuda_elementwise_unary<T>(
         &self,
         op: coeus_ops::UnaryOp,
@@ -529,6 +359,13 @@ impl CudaBackend {
     where
         T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
     {
+        validate_unary_layouts(
+            a_layout,
+            a.len(),
+            c_layout,
+            c.len(),
+            Arc::ptr_eq(&a.buffer, &c.buffer),
+        )?;
         if get_cuda_context().is_some() {
             let n = kernels::checked_numel(c_layout).ok_or_else(|| {
                 CudaBackendError::kernel(
@@ -536,7 +373,11 @@ impl CudaBackend {
                     "output element count exceeds the CUDA dispatch ABI",
                 )
             })?;
-            if a_layout.is_contiguous() && c_layout.is_contiguous() {
+            if a_layout.is_contiguous()
+                && a_layout.offset() == 0
+                && c_layout.is_contiguous()
+                && c_layout.offset() == 0
+            {
                 if try_hephaestus_contiguous_unary(op, a, c)? {
                     return Ok(());
                 }

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise.rs
@@ -366,13 +366,16 @@ impl CudaBackend {
             c.len(),
             Arc::ptr_eq(&a.buffer, &c.buffer),
         )?;
+        let n = kernels::checked_numel(c_layout).ok_or_else(|| {
+            CudaBackendError::kernel(
+                "elementwise unary",
+                "output element count exceeds the CUDA dispatch ABI",
+            )
+        })?;
+        if n == 0 {
+            return Ok(());
+        }
         if get_cuda_context().is_some() {
-            let n = kernels::checked_numel(c_layout).ok_or_else(|| {
-                CudaBackendError::kernel(
-                    "elementwise unary",
-                    "output element count exceeds the CUDA dispatch ABI",
-                )
-            })?;
             if a_layout.is_contiguous()
                 && a_layout.offset() == 0
                 && c_layout.is_contiguous()

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise/binary.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise/binary.rs
@@ -160,13 +160,16 @@ impl CudaBackend {
             Arc::ptr_eq(&a.buffer, &c.buffer),
             Arc::ptr_eq(&b.buffer, &c.buffer),
         )?;
+        let n = kernels::checked_numel(c_layout).ok_or_else(|| {
+            CudaBackendError::kernel(
+                "elementwise binary",
+                "output element count exceeds the CUDA dispatch ABI",
+            )
+        })?;
+        if n == 0 {
+            return Ok(());
+        }
         if get_cuda_context().is_some() {
-            let n = kernels::checked_numel(c_layout).ok_or_else(|| {
-                CudaBackendError::kernel(
-                    "elementwise binary",
-                    "output element count exceeds the CUDA dispatch ABI",
-                )
-            })?;
             let same_shape =
                 a_layout.shape() == c_layout.shape() && b_layout.shape() == c_layout.shape();
             if same_shape

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise/binary.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise/binary.rs
@@ -1,0 +1,196 @@
+use super::{can_route_dynamic_strided, hephaestus_operand};
+use crate::CudaBackendError;
+use crate::backend::{CudaBackend, CudaScalar};
+use crate::driver::get_cuda_context;
+use crate::kernels;
+use crate::storage::CudaStorage;
+use coeus_core::{Layout, Storage};
+use std::sync::Arc;
+
+use super::validation::validate_binary_layouts;
+
+fn try_hephaestus_contiguous<T>(
+    op: coeus_ops::BinaryOp,
+    a: &CudaStorage<T>,
+    b: &CudaStorage<T>,
+    c: &mut CudaStorage<T>,
+) -> Result<bool, CudaBackendError>
+where
+    T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
+{
+    if Arc::ptr_eq(&a.buffer, &c.buffer) || Arc::ptr_eq(&b.buffer, &c.buffer) {
+        return Ok(false);
+    }
+    let device = crate::backend::get_cuda_device();
+    let run = |result: hephaestus_cuda::Result<hephaestus_cuda::CudaBuffer<T>>,
+               c: &mut CudaStorage<T>| {
+        let buffer =
+            result.map_err(|source| CudaBackendError::dispatch("elementwise binary", source))?;
+        c.buffer = Arc::new(buffer);
+        Ok(true)
+    };
+    match op {
+        coeus_ops::BinaryOp::Add => run(
+            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::AddOp, T>(
+                device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::BinaryOp::Sub => run(
+            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::SubOp, T>(
+                device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::BinaryOp::Mul => run(
+            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::MulOp, T>(
+                device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        coeus_ops::BinaryOp::Div => run(
+            hephaestus_cuda::binary_elementwise::<hephaestus_cuda::DivOp, T>(
+                device,
+                a.buffer.as_ref(),
+                b.buffer.as_ref(),
+            ),
+            c,
+        ),
+        _ => Ok(false),
+    }
+}
+
+fn try_hephaestus_strided<T>(
+    op: coeus_ops::BinaryOp,
+    a: &CudaStorage<T>,
+    a_layout: &Layout,
+    b: &CudaStorage<T>,
+    b_layout: &Layout,
+    c: &mut CudaStorage<T>,
+    c_layout: &Layout,
+) -> Result<bool, CudaBackendError>
+where
+    T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
+{
+    if !can_route_dynamic_strided(&[a_layout, b_layout], c_layout) {
+        return Ok(false);
+    }
+    let device = crate::backend::get_cuda_device();
+    let run = |result: hephaestus_cuda::Result<()>| {
+        result
+            .map(|_| true)
+            .map_err(|source| CudaBackendError::dispatch("elementwise binary", source))
+    };
+    match op {
+        coeus_ops::BinaryOp::Add => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::AddOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::BinaryOp::Sub => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::SubOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::BinaryOp::Mul => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::MulOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        coeus_ops::BinaryOp::Div => run(hephaestus_cuda::binary_elementwise_strided_dyn_into::<
+            hephaestus_cuda::DivOp,
+            T,
+        >(
+            device,
+            hephaestus_operand(a, a_layout),
+            hephaestus_operand(b, b_layout),
+            hephaestus_operand(c, c_layout),
+            hephaestus_cuda::BlockWidth::DEFAULT,
+        )),
+        _ => Ok(false),
+    }
+}
+
+impl CudaBackend {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "backend dispatch receives three explicit buffer-layout pairs"
+    )]
+    pub(crate) fn cuda_elementwise_binary<T>(
+        &self,
+        op: coeus_ops::BinaryOp,
+        a: &CudaStorage<T>,
+        a_layout: &Layout,
+        b: &CudaStorage<T>,
+        b_layout: &Layout,
+        c: &mut CudaStorage<T>,
+        c_layout: &Layout,
+    ) -> Result<(), CudaBackendError>
+    where
+        T: CudaScalar + hephaestus_cuda::DialectScalar<hephaestus_cuda::CudaC>,
+    {
+        validate_binary_layouts(
+            a_layout,
+            a.len(),
+            b_layout,
+            b.len(),
+            c_layout,
+            c.len(),
+            Arc::ptr_eq(&a.buffer, &c.buffer),
+            Arc::ptr_eq(&b.buffer, &c.buffer),
+        )?;
+        if get_cuda_context().is_some() {
+            let n = kernels::checked_numel(c_layout).ok_or_else(|| {
+                CudaBackendError::kernel(
+                    "elementwise binary",
+                    "output element count exceeds the CUDA dispatch ABI",
+                )
+            })?;
+            let same_shape =
+                a_layout.shape() == c_layout.shape() && b_layout.shape() == c_layout.shape();
+            if same_shape
+                && a_layout.is_contiguous()
+                && a_layout.offset() == 0
+                && b_layout.is_contiguous()
+                && b_layout.offset() == 0
+                && c_layout.is_contiguous()
+                && c_layout.offset() == 0
+            {
+                if try_hephaestus_contiguous(op, a, b, c)?
+                    || kernels::launch_contiguous_binary(op, a, b, c, n)
+                {
+                    return Ok(());
+                }
+            } else if try_hephaestus_strided(op, a, a_layout, b, b_layout, c, c_layout)?
+                || kernels::launch_strided_binary(op, a, a_layout, b, b_layout, c, c_layout, n)
+            {
+                return Ok(());
+            }
+        }
+        Err(CudaBackendError::kernel(
+            "elementwise binary",
+            "native CUDA dispatch requirements are not satisfied",
+        ))
+    }
+}

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise/validation.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise/validation.rs
@@ -188,4 +188,18 @@ mod tests {
             Ok(())
         ));
     }
+
+    #[test]
+    fn empty_layouts_are_valid_without_storage() {
+        let empty = Layout::new(vec![2, 0, 3].into());
+
+        assert!(matches!(
+            validate_binary_layouts(&empty, 0, &empty, 0, &empty, 0, false, false),
+            Ok(())
+        ));
+        assert!(matches!(
+            validate_unary_layouts(&empty, 0, &empty, 0, false),
+            Ok(())
+        ));
+    }
 }

--- a/crates/coeus-cuda/src/backend/ops/math/elementwise/validation.rs
+++ b/crates/coeus-cuda/src/backend/ops/math/elementwise/validation.rs
@@ -1,0 +1,191 @@
+use crate::CudaBackendError;
+use crate::kernels::layout_fits_cuda_storage;
+use coeus_core::Layout;
+
+fn require_storage_fit(
+    operation: &'static str,
+    role: &'static str,
+    layout: &Layout,
+    storage_len: usize,
+    writable: bool,
+) -> Result<(), CudaBackendError> {
+    if layout_fits_cuda_storage(layout, storage_len, writable) {
+        Ok(())
+    } else {
+        Err(CudaBackendError::InvalidLayout {
+            operation,
+            reason: role,
+        })
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "validation receives three buffer-layout contracts and two alias relations"
+)]
+pub(super) fn validate_binary_layouts(
+    a_layout: &Layout,
+    a_len: usize,
+    b_layout: &Layout,
+    b_len: usize,
+    c_layout: &Layout,
+    c_len: usize,
+    left_aliases_output: bool,
+    right_aliases_output: bool,
+) -> Result<(), CudaBackendError> {
+    const OPERATION: &str = "elementwise binary";
+
+    require_storage_fit(
+        OPERATION,
+        "left input layout exceeds its CUDA storage",
+        a_layout,
+        a_len,
+        false,
+    )?;
+    require_storage_fit(
+        OPERATION,
+        "right input layout exceeds its CUDA storage",
+        b_layout,
+        b_len,
+        false,
+    )?;
+    require_storage_fit(
+        OPERATION,
+        "output layout exceeds its CUDA storage or aliases output elements",
+        c_layout,
+        c_len,
+        true,
+    )?;
+
+    if (left_aliases_output && a_layout != c_layout)
+        || (right_aliases_output && b_layout != c_layout)
+    {
+        return Err(CudaBackendError::InvalidLayout {
+            operation: OPERATION,
+            reason: "aliased input and output must use the same layout",
+        });
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_unary_layouts(
+    a_layout: &Layout,
+    a_len: usize,
+    c_layout: &Layout,
+    c_len: usize,
+    input_aliases_output: bool,
+) -> Result<(), CudaBackendError> {
+    const OPERATION: &str = "elementwise unary";
+
+    require_storage_fit(
+        OPERATION,
+        "input layout exceeds its CUDA storage",
+        a_layout,
+        a_len,
+        false,
+    )?;
+    require_storage_fit(
+        OPERATION,
+        "output layout exceeds its CUDA storage or aliases output elements",
+        c_layout,
+        c_len,
+        true,
+    )?;
+
+    if input_aliases_output && a_layout != c_layout {
+        return Err(CudaBackendError::InvalidLayout {
+            operation: OPERATION,
+            reason: "aliased input and output must use the same layout",
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_binary_layouts, validate_unary_layouts};
+    use crate::CudaBackendError;
+    use coeus_core::Layout;
+
+    #[test]
+    fn binary_rejects_each_layout_that_exceeds_storage() {
+        let valid = Layout::new([4].into());
+        let oversized = Layout::new([5].into());
+
+        for result in [
+            validate_binary_layouts(&oversized, 4, &valid, 4, &valid, 4, false, false),
+            validate_binary_layouts(&valid, 4, &oversized, 4, &valid, 4, false, false),
+            validate_binary_layouts(&valid, 4, &valid, 4, &oversized, 4, false, false),
+        ] {
+            assert!(matches!(
+                result,
+                Err(CudaBackendError::InvalidLayout {
+                    operation: "elementwise binary",
+                    ..
+                })
+            ));
+        }
+    }
+
+    #[test]
+    fn unary_accepts_bounded_nonzero_offsets_for_strided_dispatch() {
+        let view = Layout::from_shape_strides([2].into(), vec![1].into(), 2);
+        let output = Layout::new([2].into());
+
+        assert!(matches!(
+            validate_unary_layouts(&view, 4, &output, 2, false),
+            Ok(())
+        ));
+    }
+
+    #[test]
+    fn output_rejects_zero_stride_aliasing() {
+        let input = Layout::new([2, 3].into());
+        let output = Layout::from_shape_strides([2, 3].into(), vec![0, 1].into(), 0);
+
+        assert!(matches!(
+            validate_unary_layouts(&input, 6, &output, 3, false),
+            Err(CudaBackendError::InvalidLayout {
+                operation: "elementwise unary",
+                reason: "output layout exceeds its CUDA storage or aliases output elements",
+            })
+        ));
+    }
+
+    #[test]
+    fn aliased_storage_rejects_layout_remapping() {
+        let source = Layout::new([2, 2].into());
+        let transposed = Layout::from_shape_strides([2, 2].into(), vec![1, 2].into(), 0);
+
+        assert!(matches!(
+            validate_binary_layouts(&source, 4, &source, 4, &transposed, 4, true, false,),
+            Err(CudaBackendError::InvalidLayout {
+                operation: "elementwise binary",
+                reason: "aliased input and output must use the same layout",
+            })
+        ));
+        assert!(matches!(
+            validate_unary_layouts(&source, 4, &transposed, 4, true),
+            Err(CudaBackendError::InvalidLayout {
+                operation: "elementwise unary",
+                reason: "aliased input and output must use the same layout",
+            })
+        ));
+    }
+
+    #[test]
+    fn exact_in_place_layouts_remain_valid() {
+        let layout = Layout::new([4].into());
+
+        assert!(matches!(
+            validate_binary_layouts(&layout, 4, &layout, 4, &layout, 4, true, false),
+            Ok(())
+        ));
+        assert!(matches!(
+            validate_unary_layouts(&layout, 4, &layout, 4, true),
+            Ok(())
+        ));
+    }
+}

--- a/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs
@@ -1,8 +1,7 @@
-#![allow(clippy::too_many_arguments)]
-
 use crate::backend::CudaScalar;
 use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::storage::CudaStorage;
+use coeus_core::Storage;
 
 /// Launch a contiguous binary element-wise kernel on the GPU.
 ///
@@ -15,6 +14,9 @@ pub fn launch_contiguous_binary<T: CudaScalar>(
     c: &mut CudaStorage<T>,
     n: usize,
 ) -> bool {
+    if n > a.len() || n > b.len() || n > c.len() {
+        return false;
+    }
     let Some(drv) = CudaDriver::get() else {
         return false;
     };
@@ -102,6 +104,9 @@ pub fn launch_contiguous_unary<T: CudaScalar>(
     c: &mut CudaStorage<T>,
     n: usize,
 ) -> bool {
+    if n > a.len() || n > c.len() {
+        return false;
+    }
     let Some(drv) = CudaDriver::get() else {
         return false;
     };

--- a/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
+++ b/crates/coeus-cuda/src/kernels/launch_ops/strided.rs
@@ -1,10 +1,13 @@
-#![allow(clippy::too_many_arguments)]
+#![expect(
+    clippy::too_many_arguments,
+    reason = "raw launches pass explicit device buffers and layouts"
+)]
 
 use crate::backend::{CudaBackend, CudaScalar};
 use crate::driver::{CUdeviceptr, CudaDriver, get_cuda_context};
 use crate::kernels::GpuLayoutInfo;
 use crate::storage::CudaStorage;
-use coeus_core::{ComputeBackend, Layout};
+use coeus_core::{ComputeBackend, Layout, Storage};
 
 /// Launch a strided binary element-wise kernel on the GPU.
 ///
@@ -27,8 +30,9 @@ pub fn launch_strided_binary<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    if !crate::kernels::validation::layouts_fit_cuda(&[a_layout, b_layout, c_layout])
-        || !crate::kernels::validation::layout_supports_cuda_output_indexing(c_layout)
+    if !crate::kernels::layout_fits_cuda_storage(a_layout, a.len(), false)
+        || !crate::kernels::layout_fits_cuda_storage(b_layout, b.len(), false)
+        || !crate::kernels::layout_fits_cuda_storage(c_layout, c.len(), true)
         || a_layout.ndim() > c_layout.ndim()
         || b_layout.ndim() > c_layout.ndim()
     {
@@ -179,8 +183,8 @@ pub fn launch_strided_unary<T: CudaScalar>(
     let Some(_ctx) = get_cuda_context() else {
         return false;
     };
-    if !crate::kernels::validation::layouts_fit_cuda(&[a_layout, c_layout])
-        || !crate::kernels::validation::layout_supports_cuda_output_indexing(c_layout)
+    if !crate::kernels::layout_fits_cuda_storage(a_layout, a.len(), false)
+        || !crate::kernels::layout_fits_cuda_storage(c_layout, c.len(), true)
         || a_layout.ndim() > c_layout.ndim()
     {
         return false;

--- a/crates/coeus-cuda/src/kernels/mod.rs
+++ b/crates/coeus-cuda/src/kernels/mod.rs
@@ -22,7 +22,7 @@ pub mod reduce;
 pub mod unfold_fold;
 mod validation;
 
-pub(crate) use validation::checked_numel;
+pub(crate) use validation::{checked_numel, layout_fits_cuda_storage};
 
 pub use attention::{launch_sdp_attention, launch_sdp_attention_backward};
 pub use conv_transpose::{launch_conv_transpose1d, launch_conv_transpose2d};

--- a/crates/coeus-cuda/src/kernels/validation.rs
+++ b/crates/coeus-cuda/src/kernels/validation.rs
@@ -58,7 +58,8 @@ pub(crate) fn layout_fits_cuda_storage(
     layouts_fit_cuda(&[layout])
         && (!writable || layout_supports_cuda_output_indexing(layout))
         && checked_layout_storage_len(layout).is_some_and(|required| {
-            required.checked_sub(1).and_then(cuda_u32).is_some() && storage_len >= required
+            required == 0
+                || (required.checked_sub(1).and_then(cuda_u32).is_some() && storage_len >= required)
         })
 }
 
@@ -141,5 +142,13 @@ mod tests {
         assert!(!layout_fits_cuda_storage(&strided, 8, false));
         assert!(layout_fits_cuda_storage(&aliased, 3, false));
         assert!(!layout_fits_cuda_storage(&aliased, 3, true));
+    }
+
+    #[test]
+    fn cuda_storage_validation_accepts_empty_layouts() {
+        let empty = Layout::new(vec![2, 0, 3].into());
+
+        assert!(layout_fits_cuda_storage(&empty, 0, false));
+        assert!(layout_fits_cuda_storage(&empty, 0, true));
     }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -33,11 +33,12 @@
   convolution/attention/optimizers, WGPU attention/elementwise/matmul, and the
   generic ROCm/Metal acquisition and transfer boundary. The CUDA feature test
   targets compile, warning-denied all-target Clippy passes, and the
-  disabled-provider Nextest lane passes 3/3. Hosted run `30425069856` passed
-  CUDA `90489643824`, Metal `90489643784`, ROCm `90489643831`, and WGPU
-  `90489643864`; review-driven empty-layout coverage is pending an exact-head
-  rerun. Local feature-enabled execution is blocked by the GNU CUDA import
-  library and the shared-cache MSVC host-artifact collision.
+  disabled-provider Nextest lane passes 3/3. Exact implementation-head run
+  `30426667552` passed CUDA `90494509271`, Metal `90494509298`, ROCm
+  `90494509264`, and WGPU `90494509247`; required-device ROCm `90494509665`
+  was skipped because no AMD runner was registered. Local feature-enabled
+  execution is blocked by the GNU CUDA import library and the shared-cache
+  MSVC host-artifact collision.
 
 ## ATLAS-COEUS-NN-SAFETY-019 — Fallible module execution [arch]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,29 @@
 # Coeus Project Backlog & Historical Archives
 
+## ATLAS-COEUS-DISPATCH-SAFETY-020 — Provider routing audit [arch]
+
+- Owner: Codex on `codex/coeus-dispatch-audit`; scope: Coeus CPU and
+  accelerator dispatch boundaries under `coeus-leto`, `coeus-cuda`,
+  `coeus-wgpu`, `coeus-rocm`, and `coeus-metal`, plus the focused contract
+  tests, ADR, and active PM evidence required by an accepted finding.
+- Outcome: every audited operation executes through Leto for CPU selection and
+  Hephaestus for accelerator selection, with unsupported contracts surfaced as
+  typed errors and no consumer-owned mathematical fallback.
+- Non-goals: release/version transitions, speculative provider capabilities,
+  unrelated public API redesign, and runtime or memory claims without matched
+  measurements.
+- Acceptance: source and dependency scans enumerate every backend-routing
+  branch in scope; each finding is fixed or rejected with evidence; accepted
+  fixes carry value-semantic Leto differential coverage; warning-denied
+  package Clippy, focused and applicable full Nextest, doctests, SemVer
+  classification, and exact-head provider CI pass before merge.
+- Risk/change class: `[arch]`; the audit can expose provider-ownership or
+  failure-contract corrections, with SemVer class determined from the actual
+  accepted finding.
+- Status: in progress. The stale merged lane was fast-forwarded to
+  `origin/main`; superseded CUDA/WGPU working files were verified byte-equal to
+  main, while the generated overlay lockfile delta remains excluded.
+
 ## ATLAS-COEUS-NN-SAFETY-019 — Fallible module execution [arch]
 
 - Owner: Codex on `codex/coeus-fallible-module-forward`; scope:
@@ -17,10 +41,11 @@
   doctests, SemVer checks, and exact-head provider CI pass.
 - Risk/change class: `[arch] [major]`; the public `Module::forward` return type
   changes and all in-repository callers migrate in one cutover.
-- Status: in progress. The complete call graph is audited, ADR-0045 is
-  accepted, and the module bounded context now has separate manifest, trait,
-  and typed-error leaves. The atomic implementation and consumer cutover
-  remains.
+- Status: merged by PR #247 as `c5179f47`. All retained module
+  implementations and direct Rust/Python consumers use the fallible contract;
+  538 native tests, package doctests, warning-denied Clippy, benchmark smoke,
+  SemVer classification, and exact-head WGPU/CUDA/ROCm/Metal provider
+  contracts passed.
 
 ## ATLAS-COEUS-WGPU-008 — Provider-owned reductions [arch] — complete
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -27,14 +27,17 @@
   layouts are now checked against every physical allocation before raw pointer
   acquisition, offset-bearing views bypass offset-blind contiguous kernels,
   writable zero-stride outputs are rejected, and remapped input/output aliases
-  return typed layout errors. Static audits also retain unresolved typed-error
+  return typed layout errors. Empty layouts remain valid and complete without a
+  device launch. Static audits also retain unresolved typed-error
   and provider-ownership findings for CPU reductions, CUDA
   convolution/attention/optimizers, WGPU attention/elementwise/matmul, and the
   generic ROCm/Metal acquisition and transfer boundary. The CUDA feature test
   targets compile, warning-denied all-target Clippy passes, and the
-  disabled-provider Nextest lane passes 3/3. Local feature-enabled execution is
-  blocked by the GNU CUDA import library and the shared-cache MSVC host-artifact
-  collision; clean hosted CUDA execution remains the merge gate.
+  disabled-provider Nextest lane passes 3/3. Hosted run `30425069856` passed
+  CUDA `90489643824`, Metal `90489643784`, ROCm `90489643831`, and WGPU
+  `90489643864`; review-driven empty-layout coverage is pending an exact-head
+  rerun. Local feature-enabled execution is blocked by the GNU CUDA import
+  library and the shared-cache MSVC host-artifact collision.
 
 ## ATLAS-COEUS-NN-SAFETY-019 — Fallible module execution [arch]
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,7 +22,19 @@
   accepted finding.
 - Status: in progress. The stale merged lane was fast-forwarded to
   `origin/main`; superseded CUDA/WGPU working files were verified byte-equal to
-  main, while the generated overlay lockfile delta remains excluded.
+  main, while the generated overlay lockfile delta remains excluded. The first
+  accepted finding is a CUDA safe-API storage-boundary defect: elementwise
+  layouts are now checked against every physical allocation before raw pointer
+  acquisition, offset-bearing views bypass offset-blind contiguous kernels,
+  writable zero-stride outputs are rejected, and remapped input/output aliases
+  return typed layout errors. Static audits also retain unresolved typed-error
+  and provider-ownership findings for CPU reductions, CUDA
+  convolution/attention/optimizers, WGPU attention/elementwise/matmul, and the
+  generic ROCm/Metal acquisition and transfer boundary. The CUDA feature test
+  targets compile, warning-denied all-target Clippy passes, and the
+  disabled-provider Nextest lane passes 3/3. Local feature-enabled execution is
+  blocked by the GNU CUDA import library and the shared-cache MSVC host-artifact
+  collision; clean hosted CUDA execution remains the merge gate.
 
 ## ATLAS-COEUS-NN-SAFETY-019 — Fallible module execution [arch]
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -289,7 +289,8 @@ writable zero-stride layouts and remapped aliases; route offset-bearing
 contiguous views through the offset-aware strided kernel.
 **Evidence target**: allocation-free validation unit tests for each operand,
 offset routing, writable aliasing, and exact-layout in-place operation; package
-check, warning-denied Clippy, Nextest, and exact-head CUDA provider CI.
+check, warning-denied Clippy, Nextest, and exact-head CUDA provider CI. Empty
+layouts remain valid and complete without a device launch.
 **Residual**: CUDA convolution, attention, optimizer, matmul, module-loading,
 and device-acquisition boundaries remain separate accepted audit findings. No
 runtime performance or resident-memory delta is claimed without controlled
@@ -297,9 +298,10 @@ measurements.
 **Status**: implementation complete under
 `ATLAS-COEUS-DISPATCH-SAFETY-020`. CUDA feature test targets compile,
 warning-denied all-target Clippy passes, and disabled-provider Nextest passes
-3/3. Local feature-enabled execution is blocked by the GNU CUDA import library
-and shared-cache MSVC host-artifact collision; hosted CUDA execution remains
-the merge gate.
+3/3. Hosted run `30425069856` passed CUDA `90489643824`, Metal `90489643784`,
+ROCm `90489643831`, and WGPU `90489643864`; review-driven empty-layout coverage
+is pending an exact-head rerun. Local feature-enabled execution is blocked by
+the GNU CUDA import library and shared-cache MSVC host-artifact collision.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001: exact GELU forward and gradient
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -298,10 +298,11 @@ measurements.
 **Status**: implementation complete under
 `ATLAS-COEUS-DISPATCH-SAFETY-020`. CUDA feature test targets compile,
 warning-denied all-target Clippy passes, and disabled-provider Nextest passes
-3/3. Hosted run `30425069856` passed CUDA `90489643824`, Metal `90489643784`,
-ROCm `90489643831`, and WGPU `90489643864`; review-driven empty-layout coverage
-is pending an exact-head rerun. Local feature-enabled execution is blocked by
-the GNU CUDA import library and shared-cache MSVC host-artifact collision.
+3/3. Exact implementation-head run `30426667552` passed CUDA `90494509271`,
+Metal `90494509298`, ROCm `90494509264`, and WGPU `90494509247`;
+required-device ROCm `90494509665` was skipped because no AMD runner was
+registered. Local feature-enabled execution is blocked by the GNU CUDA import
+library and shared-cache MSVC host-artifact collision.
 
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001: exact GELU forward and gradient
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -276,6 +276,31 @@ Required-device ROCm `90274889835` was skipped because no hosted AMD runner was
 dispatched. The external `recurseml/analysis` status returned its recurring
 analyzer error and is not repository-owned verification.
 
+## ATLAS-COEUS-CUDA-ELEMENTWISE-STORAGE-BOUNDARY-001
+
+**Location**: `crates/coeus-cuda/src/backend/ops/math/elementwise.rs` and its
+`elementwise/validation.rs` leaf.
+**Gap**: the safe elementwise backend accepted layouts whose maximum physical
+offset exceeded the associated CUDA allocation. The contiguous branch also
+accepted nonzero offsets while its raw kernel always indexed from element zero.
+**Resolution**: validate every input and writable output layout against the
+actual allocation at the backend and public raw-launch boundaries; reject
+writable zero-stride layouts and remapped aliases; route offset-bearing
+contiguous views through the offset-aware strided kernel.
+**Evidence target**: allocation-free validation unit tests for each operand,
+offset routing, writable aliasing, and exact-layout in-place operation; package
+check, warning-denied Clippy, Nextest, and exact-head CUDA provider CI.
+**Residual**: CUDA convolution, attention, optimizer, matmul, module-loading,
+and device-acquisition boundaries remain separate accepted audit findings. No
+runtime performance or resident-memory delta is claimed without controlled
+measurements.
+**Status**: implementation complete under
+`ATLAS-COEUS-DISPATCH-SAFETY-020`. CUDA feature test targets compile,
+warning-denied all-target Clippy passes, and disabled-provider Nextest passes
+3/3. Local feature-enabled execution is blocked by the GNU CUDA import library
+and shared-cache MSVC host-artifact collision; hosted CUDA execution remains
+the merge gate.
+
 ## ATLAS-COEUS-HEPHAESTUS-CUDA-GELU-PARITY-001: exact GELU forward and gradient
 
 **Location**: `crates/coeus-cuda/src/backend/ops/math/elementwise.rs`, the CUDA


### PR DESCRIPTION
## Summary
- reject CUDA elementwise layouts that exceed physical device storage
- route nonzero-offset contiguous views through offset-aware strided kernels
- harden public raw launch helpers and split binary/validation leaves below 500 lines

## Verification
- cargo check -p coeus-cuda --features cuda --tests
- cargo clippy --offline -p coeus-cuda --features cuda --all-targets -- -D warnings
- cargo nextest run --offline -p coeus-cuda --no-default-features (3 passed)
- feature-enabled validation tests compile locally; hosted CUDA execution is required because the local GNU linker lacks the CUDA import library

No runtime or memory improvement is claimed without matched measurements.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a security-critical storage boundary defect in CUDA elementwise operations by validating that input and output layouts do not exceed their physical device allocations. The implementation rejects writable zero-stride layouts and aliased storage with different logical mappings, routes nonzero-offset contiguous views through offset-aware strided kernels, and adds allocation-free host-side validation at both backend and public raw-launch boundaries. The validation logic is extracted into a dedicated module with comprehensive unit tests, and the binary operation implementation is split into a separate file to improve code organization while keeping leaves under 500 lines.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/coeus-cuda/src/kernels/mod.rs` |
| 2 | `crates/coeus-cuda/src/backend/ops/math/elementwise/validation.rs` |
| 3 | `crates/coeus-cuda/src/backend/ops/math/elementwise/binary.rs` |
| 4 | `crates/coeus-cuda/src/backend/ops/math/elementwise.rs` |
| 5 | `crates/coeus-cuda/src/kernels/launch_ops/contiguous.rs` |
| 6 | `crates/coeus-cuda/src/kernels/launch_ops/strided.rs` |
| 7 | `CHANGELOG.md` |
| 8 | `docs/gap_audit.md` |
| 9 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA elementwise operation safety by validating tensor layouts against allocated storage before launching work.
  - Added clear layout failures for unsupported writable zero-stride layouts and incompatible aliased inputs or outputs.
  - Correctly routes contiguous views with nonzero offsets through offset-aware processing.
  - Added additional launch-time bounds checks to prevent operations from exceeding available storage.

- **Documentation**
  - Updated changelog and CUDA documentation with the new validation behavior and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->